### PR TITLE
Use low/high naming for priors & add docs

### DIFF
--- a/SymbolicDSGE/bayesian/distributions/half_cauchy.py
+++ b/SymbolicDSGE/bayesian/distributions/half_cauchy.py
@@ -9,25 +9,25 @@ from typing import TypedDict, overload, cast
 
 
 class HalfCauchyParams(TypedDict):
-    loc: float
+    low: float
     scale: float
     random_state: RandomState
 
 
 HALF_CAUCHY_DEFAULTS = HalfCauchyParams(
-    loc=0.0,
+    low=0.0,
     scale=1.0,
     random_state=None,
 )
 
 
 class HalfCauchy(Distribution):
-    def __init__(self, loc: float, scale: float, random_state: RandomState) -> None:
-        self._loc = float64(loc)
+    def __init__(self, low: float, scale: float, random_state: RandomState) -> None:
+        self._low = float64(low)
         self._scale = float64(scale)
         self._random_state = random_state
 
-        self.dist = halfcauchy(loc=self._loc, scale=self._scale)
+        self.dist = halfcauchy(loc=self._low, scale=self._scale)
 
     @overload
     def logpdf(self, x: float64) -> float64: ...
@@ -75,7 +75,7 @@ class HalfCauchy(Distribution):
     @property
     def support(self) -> Support:
         return Support(
-            float64(self._loc),
+            float64(self._low),
             float64(np.inf),
             low_inclusive=True,
             high_inclusive=False,
@@ -91,4 +91,4 @@ class HalfCauchy(Distribution):
 
     @property
     def mode(self) -> float64:
-        return float64(self._loc)
+        return float64(self._low)

--- a/SymbolicDSGE/bayesian/distributions/half_norm.py
+++ b/SymbolicDSGE/bayesian/distributions/half_norm.py
@@ -9,26 +9,26 @@ from scipy.stats import halfnorm
 
 
 class HalfNormalParameters(TypedDict):
-    loc: float  # != mean; used like loc + HN(0, 1) * scale
+    low: float  # lower bound of support
     scale: float  # != std;
     random_state: RandomState
 
 
 HALFNORM_DEFAULTS = HalfNormalParameters(
-    loc=0.0,
+    low=0.0,
     scale=1.0,
     random_state=None,
 )
 
 
 class HalfNormal(Distribution[float64, VecF64]):
-    def __init__(self, loc: float, scale: float, random_state: RandomState = None):
-        self.dist = halfnorm(loc=loc, scale=scale)
+    def __init__(self, low: float, scale: float, random_state: RandomState = None):
+        self.dist = halfnorm(loc=low, scale=scale)
 
         self._mean = float64(self.dist.mean())
         self._var = float64(self.dist.var())
-        self._mode = float64(loc)
-        self._loc = float64(loc)
+        self._mode = float64(low)
+        self._low = float64(low)
         self._scale = float64(scale)
         self._random_state = random_state
 
@@ -48,7 +48,7 @@ class HalfNormal(Distribution[float64, VecF64]):
 
     @bounded
     def grad_logpdf(self, x: float64 | VecF64) -> float64 | VecF64:
-        return float64(-(x - self.loc) / self.scale**2)
+        return float64(-(x - self.low) / self.scale**2)
 
     @overload
     def cdf(self, x: float64) -> float64: ...
@@ -83,7 +83,7 @@ class HalfNormal(Distribution[float64, VecF64]):
     @property
     def support(self) -> Support:
         return Support(
-            float64(0),
+            self._low,
             float64(np.inf),
             low_inclusive=True,
             high_inclusive=False,
@@ -102,8 +102,8 @@ class HalfNormal(Distribution[float64, VecF64]):
         return self._mode
 
     @property
-    def loc(self) -> float64:
-        return self._loc
+    def low(self) -> float64:
+        return self._low
 
     @property
     def scale(self) -> float64:

--- a/SymbolicDSGE/bayesian/distributions/log_norm.py
+++ b/SymbolicDSGE/bayesian/distributions/log_norm.py
@@ -9,27 +9,27 @@ from typing import TypedDict, overload, cast
 
 class LogNormalParams(TypedDict):
     s: float  # Shape parameter (standard deviation of the underlying normal distribution)
-    loc: float  # Location parameter (mean of the underlying normal distribution)
+    low: float  # Lower bound / location shift
     scale: float  # Scale parameter (exp(mean) of the underlying normal distribution)
     random_state: RandomState
 
 
 LOGNORM_DEFAULTS = LogNormalParams(
     s=1.0,
-    loc=0.0,
+    low=0.0,
     scale=1.0,
     random_state=None,
 )
 
 
 class LogNormal(Distribution[float64, VecF64]):
-    def __init__(self, s: float, loc: float, scale: float, random_state: RandomState):
+    def __init__(self, s: float, low: float, scale: float, random_state: RandomState):
         self._s = float64(s)
-        self._loc = float64(loc)
+        self._low = float64(low)
         self._scale = float64(scale)
         self._random_state = random_state
 
-        self.dist = lognorm(s=self._s, loc=self._loc, scale=self._scale)
+        self.dist = lognorm(s=self._s, loc=self._low, scale=self._scale)
 
     @overload
     def logpdf(self, x: float64) -> float64: ...
@@ -78,7 +78,7 @@ class LogNormal(Distribution[float64, VecF64]):
     @property
     def support(self) -> Support:
         return Support(
-            low=float64(0.0),
+            low=self._low,
             high=float64(np.inf),
             low_inclusive=False,
             high_inclusive=False,
@@ -94,4 +94,4 @@ class LogNormal(Distribution[float64, VecF64]):
 
     @property
     def mode(self) -> float64:
-        return float64(np.exp(self._loc - self._s**2))
+        return float64(np.exp(self._low - self._s**2))

--- a/SymbolicDSGE/bayesian/distributions/trunc_norm.py
+++ b/SymbolicDSGE/bayesian/distributions/trunc_norm.py
@@ -9,29 +9,34 @@ from typing import TypedDict, Tuple, overload, cast
 class TruncNormParams(TypedDict):
     loc: float
     scale: float
-    a: float  # Scalar lower bound (scipy expects standard deviations)
-    b: float  # Scalar upper bound (scipy expects standard deviations)
+    low: float  # Scalar lower bound (scipy expects standard deviations)
+    high: float  # Scalar upper bound (scipy expects standard deviations)
     random_state: RandomState
 
 
 TRUNCNORM_DEFAULTS = TruncNormParams(
     loc=0.0,
     scale=1.0,
-    a=-6.0,  # Effectively unbounded
-    b=6.0,
+    low=-6.0,  # Effectively unbounded
+    high=6.0,
     random_state=None,
 )
 
 
 class TruncNormal(Distribution[float64, VecF64]):
     def __init__(
-        self, a: float, b: float, loc: float, scale: float, random_state: RandomState
+        self,
+        low: float,
+        high: float,
+        loc: float,
+        scale: float,
+        random_state: RandomState,
     ):
         self._loc = float64(loc)
         self._scale = float64(scale)
-        self._a_trunc = float64(a)
-        self._b_trunc = float64(b)
-        self._a, self._b = self._scalar_to_std(loc, scale, a, b)
+        self._low_trunc = float64(low)
+        self._high_trunc = float64(high)
+        self._a, self._b = self._scalar_to_std(loc, scale, low, high)
         self._random_state = random_state
 
         self.dist = truncnorm(a=self._a, b=self._b, loc=self._loc, scale=self._scale)
@@ -84,19 +89,19 @@ class TruncNormal(Distribution[float64, VecF64]):
 
     @staticmethod
     def _scalar_to_std(
-        loc: float, scale: float, a: float, b: float
+        loc: float, scale: float, low: float, high: float
     ) -> Tuple[float, float]:
         # Z-transform to get unit std
         return (
-            (a - loc) / scale,
-            (b - loc) / scale,
+            (low - loc) / scale,
+            (high - loc) / scale,
         )
 
     @property
     def support(self) -> Support:
         return Support(
-            float64(self._a_trunc),
-            float64(self._b_trunc),
+            float64(self._low_trunc),
+            float64(self._high_trunc),
             low_inclusive=True,
             high_inclusive=True,
         )

--- a/SymbolicDSGE/bayesian/distributions/uniform.py
+++ b/SymbolicDSGE/bayesian/distributions/uniform.py
@@ -8,23 +8,23 @@ from typing import TypedDict, Tuple, overload, cast
 
 
 class UniformParams(TypedDict):
-    a: float
-    b: float
+    low: float
+    high: float
     random_state: RandomState
 
 
 UNIFORM_DEFAULTS = UniformParams(
-    a=0.0,
-    b=1.0,
+    low=0.0,
+    high=1.0,
     random_state=None,
 )
 
 
 class Uniform(Distribution[float64, VecF64]):
-    def __init__(self, a: float, b: float, random_state: RandomState) -> None:
-        self._a = float64(a)
-        self._b = float64(b)
-        self._loc, self._scale = self._a_b_to_loc_scale(a, b)
+    def __init__(self, low: float, high: float, random_state: RandomState) -> None:
+        self._low = float64(low)
+        self._high = float64(high)
+        self._loc, self._scale = self._low_high_to_loc_scale(low, high)
         self._random_state = random_state
 
         self.dist = uniform(loc=self._loc, scale=self._scale)
@@ -80,8 +80,8 @@ class Uniform(Distribution[float64, VecF64]):
     @property
     def support(self) -> Support:
         return Support(
-            self._a,
-            self._b,
+            self._low,
+            self._high,
             low_inclusive=True,
             high_inclusive=True,
         )
@@ -99,7 +99,7 @@ class Uniform(Distribution[float64, VecF64]):
         raise ValueError("Uniform distribution does not have a unique mode.")
 
     @staticmethod
-    def _a_b_to_loc_scale(a: float, b: float) -> Tuple[float64, float64]:
-        loc = float64(a)
-        scale = float64(b - a)
+    def _low_high_to_loc_scale(low: float, high: float) -> Tuple[float64, float64]:
+        loc = float64(low)
+        scale = float64(high - low)
         return loc, scale

--- a/SymbolicDSGE/bayesian/transforms/affine_logit.py
+++ b/SymbolicDSGE/bayesian/transforms/affine_logit.py
@@ -51,7 +51,7 @@ class AffineLogitTransform(Transform):
     def grad_forward(self, x: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dy/dx = 1 / ((b-a) * z * (1 - z)), with z = (x-a)/(b-a)
+        # dy/dx = 1 / ((high-low) * z * (1 - z)), with z = (x-low)/(high-low)
         if self.support.contains(x):
             z = affine_to_unit(x, self.low, self.high)
             return float64(1.0) / (self._span * z * (1 - z))
@@ -64,7 +64,7 @@ class AffineLogitTransform(Transform):
     def grad_inverse(self, y: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_inverse(self, y: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dx/dy = (b-a) * sigmoid(y) * (1 - sigmoid(y))
+        # dx/dy = (high-low) * sigmoid(y) * (1 - sigmoid(y))
         if self.maps_to.contains(y):
             z = float64(1.0) / (float64(1.0) + np.exp(-y))
             return self._span * z * (1 - z)
@@ -79,7 +79,7 @@ class AffineLogitTransform(Transform):
     def log_det_abs_jacobian_forward(
         self, x: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dy/dx| = -log(b-a) - log(z) - log(1-z)
+        # log|dy/dx| = -log(high-low) - log(z) - log(1-z)
         if self.support.contains(x):
             z = affine_to_unit(x, self.low, self.high)
             return float64(-np.log(self._span) - np.log(z) - np.log(1 - z))
@@ -94,8 +94,8 @@ class AffineLogitTransform(Transform):
     def log_det_abs_jacobian_inverse(
         self, y: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dx/dy| = log(b-a) + log(sigmoid(y)(1-sigmoid(y)))
-        #            = log(b-a) - y - 2*log(1 + exp(-y))
+        # log|dx/dy| = log(high-low) + log(sigmoid(y)(1-sigmoid(y)))
+        #            = log(high-low) - y - 2*log(1 + exp(-y))
         if self.maps_to.contains(y):
             return float64(np.log(self._span) - y - 2.0 * np.log1p(np.exp(-y)))
         else:

--- a/SymbolicDSGE/bayesian/transforms/affine_probit.py
+++ b/SymbolicDSGE/bayesian/transforms/affine_probit.py
@@ -53,7 +53,7 @@ class AffineProbitTransform(Transform):
     def grad_forward(self, x: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dy/dx = 1 / ((b-a) * phi(y)), where y = Phi^{-1}(z) and z = (x-a)/(b-a)
+        # dy/dx = 1 / ((high-low) * phi(y)), where y = Phi^{-1}(z) and z = (x-low)/(high-low)
         if self.support.contains(x):
             z = affine_to_unit(x, self.low, self.high)
             y = float64(norm.ppf(z))
@@ -67,7 +67,7 @@ class AffineProbitTransform(Transform):
     def grad_inverse(self, y: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_inverse(self, y: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dx/dy = (b-a) * phi(y)
+        # dx/dy = (high-low) * phi(y)
         if self.maps_to.contains(y):
             return float64(self._span * norm.pdf(y))
         else:
@@ -81,7 +81,7 @@ class AffineProbitTransform(Transform):
     def log_det_abs_jacobian_forward(
         self, x: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dy/dx| = -log(b-a) - log(phi(y))
+        # log|dy/dx| = -log(high-low) - log(phi(y))
         if self.support.contains(x):
             z = affine_to_unit(x, self.low, self.high)
             y = norm.ppf(z)
@@ -97,7 +97,7 @@ class AffineProbitTransform(Transform):
     def log_det_abs_jacobian_inverse(
         self, y: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dx/dy| = log(b-a) + log(phi(y))
+        # log|dx/dy| = log(high-low) + log(phi(y))
         if self.maps_to.contains(y):
             return float64(np.log(self._span) + float64(norm.logpdf(y)))
         else:

--- a/SymbolicDSGE/bayesian/transforms/lower_bounded.py
+++ b/SymbolicDSGE/bayesian/transforms/lower_bounded.py
@@ -9,14 +9,14 @@ from numpy.typing import NDArray
 
 class LowerBoundedTransform(Transform):
 
-    def __init__(self, lower: float64):
-        self.lower = float64(lower)
+    def __init__(self, low: float64):
+        self.low = float64(low)
 
     def __repr__(self) -> str:
         return self.__class__.__name__
 
-    def _x_minus_a(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        return x - self.lower
+    def _x_minus_low(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
+        return x - self.low
 
     @overload
     def forward(self, x: float64) -> float64: ...
@@ -25,7 +25,7 @@ class LowerBoundedTransform(Transform):
 
     def forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
         if self.support.contains(x):
-            return np.log(self._x_minus_a(x))
+            return np.log(self._x_minus_low(x))
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -36,7 +36,7 @@ class LowerBoundedTransform(Transform):
 
     def inverse(self, y: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
         if self.maps_to.contains(y):
-            return self.lower + np.exp(y)
+            return self.low + np.exp(y)
         else:
             raise OutOfSupportError(y, self.maps_to)
 
@@ -46,9 +46,9 @@ class LowerBoundedTransform(Transform):
     def grad_forward(self, x: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dy/dx = 1 / (x - a)
+        # dy/dx = 1 / (x - low)
         if self.support.contains(x):
-            return float64(1.0) / self._x_minus_a(x)
+            return float64(1.0) / self._x_minus_low(x)
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -72,9 +72,9 @@ class LowerBoundedTransform(Transform):
     def log_det_abs_jacobian_forward(
         self, x: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dy/dx| = -log(x - a)
+        # log|dy/dx| = -log(x - low)
         if self.support.contains(x):
-            return -np.log(self._x_minus_a(x))
+            return -np.log(self._x_minus_low(x))
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -111,7 +111,7 @@ class LowerBoundedTransform(Transform):
     @property
     def support(self) -> Support:
         return Support(
-            self.lower,
+            self.low,
             float64(np.inf),
             low_inclusive=False,
             high_inclusive=False,

--- a/SymbolicDSGE/bayesian/transforms/transform.py
+++ b/SymbolicDSGE/bayesian/transforms/transform.py
@@ -16,11 +16,13 @@ class TransformMethod(StrEnum):
     LOGIT = "logit"  # (0, 1)    via y=log(x/(1-x))
     PROBIT = "probit"  # (0, 1)    via y=Phi^{-1}(x)
 
-    AFFINE_LOGIT = "affine_logit"  # (a, b)    via x=a+(b-a)*sigmoid(y)
-    AFFINE_PROBIT = "affine_probit"  # (a, b)    via x=a+(b-a)*Phi(y)
+    AFFINE_LOGIT = "affine_logit"  # (low, high) via x=low+(high-low)*sigmoid(y)
+    AFFINE_PROBIT = "affine_probit"  # (low, high) via x=low+(high-low)*Phi(y)
 
-    LOWER_BOUNDED = "lower_bounded"  # (a, inf)  via x=a+exp(y)   (or a+softplus(y))
-    UPPER_BOUNDED = "upper_bounded"  # (-inf, b) via x=b-exp(y)   (or b-softplus(y))
+    LOWER_BOUNDED = "lower_bounded"  # (low, inf) via x=low+exp(y) (or low+softplus(y))
+    UPPER_BOUNDED = (
+        "upper_bounded"  # (-inf, high) via x=high-exp(y) (or high-softplus(y))
+    )
 
     SIMPLEX = (
         "simplex"  # weights on simplex (sum=1, each>0) via softmax / stick-breaking

--- a/SymbolicDSGE/bayesian/transforms/upper_bounded.py
+++ b/SymbolicDSGE/bayesian/transforms/upper_bounded.py
@@ -9,15 +9,17 @@ from numpy.typing import NDArray
 
 class UpperBoundedTransform(Transform):
 
-    def __init__(self, upper: float64):
-        self.upper = float64(upper)
+    def __init__(self, high: float64):
+        self.high = float64(high)
 
     def __repr__(self) -> str:
         return self.__class__.__name__
 
     # ---- private helper ----
-    def _b_minus_x(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        return self.upper - x
+    def _high_minus_x(
+        self, x: float64 | NDArray[float64]
+    ) -> float64 | NDArray[float64]:
+        return self.high - x
 
     @overload
     def forward(self, x: float64) -> float64: ...
@@ -26,7 +28,7 @@ class UpperBoundedTransform(Transform):
 
     def forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
         if self.support.contains(x):
-            return np.log(self._b_minus_x(x))
+            return np.log(self._high_minus_x(x))
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -37,7 +39,7 @@ class UpperBoundedTransform(Transform):
 
     def inverse(self, y: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
         if self.maps_to.contains(y):
-            return self.upper - np.exp(y)
+            return self.high - np.exp(y)
         else:
             raise OutOfSupportError(y, self.maps_to)
 
@@ -47,9 +49,9 @@ class UpperBoundedTransform(Transform):
     def grad_forward(self, x: NDArray[float64]) -> NDArray[float64]: ...
 
     def grad_forward(self, x: float64 | NDArray[float64]) -> float64 | NDArray[float64]:
-        # dy/dx = -1 / (b - x)
+        # dy/dx = -1 / (high - x)
         if self.support.contains(x):
-            return -float64(1.0) / self._b_minus_x(x)
+            return -float64(1.0) / self._high_minus_x(x)
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -73,9 +75,9 @@ class UpperBoundedTransform(Transform):
     def log_det_abs_jacobian_forward(
         self, x: float64 | NDArray[float64]
     ) -> float64 | NDArray[float64]:
-        # log|dy/dx| = -log(b - x)
+        # log|dy/dx| = -log(high - x)
         if self.support.contains(x):
-            return -np.log(self._b_minus_x(x))
+            return -np.log(self._high_minus_x(x))
         else:
             raise OutOfSupportError(x, self.support)
 
@@ -113,7 +115,7 @@ class UpperBoundedTransform(Transform):
     def support(self) -> Support:
         return Support(
             float64(-np.inf),
-            self.upper,
+            self.high,
             low_inclusive=False,
             high_inclusive=False,
         )

--- a/docs/documentation/prior_spec/Prior.md
+++ b/docs/documentation/prior_spec/Prior.md
@@ -45,14 +45,14 @@ Accepted `distribution` values in `make_prior(...)`:
 | __Enum Member__ | __String__ | __Parameter Keys__ | __Defaults__ |
 |:----------------|:----------:|-------------------:|-------------:|
 | `NORMAL` | `"normal"` | `mean`, `std`, `random_state` | `0.0`, `1.0`, `None` |
-| `LOGNORMAL` | `"log_normal"` | `s`, `loc`, `scale`, `random_state` | `1.0`, `0.0`, `1.0`, `None` |
-| `HALFNORMAL` | `"half_normal"` | `loc`, `scale`, `random_state` | `0.0`, `1.0`, `None` |
-| `TRUNCNORMAL` | `"trunc_normal"` | `a`, `b`, `loc`, `scale`, `random_state` | `-6.0`, `6.0`, `0.0`, `1.0`, `None` |
-| `HALFCAUCHY` | `"half_cauchy"` | `loc`, `scale`, `random_state` | `0.0`, `1.0`, `None` |
+| `LOGNORMAL` | `"log_normal"` | `s`, `low`, `scale`, `random_state` | `1.0`, `0.0`, `1.0`, `None` |
+| `HALFNORMAL` | `"half_normal"` | `low`, `scale`, `random_state` | `0.0`, `1.0`, `None` |
+| `TRUNCNORMAL` | `"trunc_normal"` | `low`, `high`, `loc`, `scale`, `random_state` | `-6.0`, `6.0`, `0.0`, `1.0`, `None` |
+| `HALFCAUCHY` | `"half_cauchy"` | `low`, `scale`, `random_state` | `0.0`, `1.0`, `None` |
 | `BETA` | `"beta"` | `a`, `b`, `loc`, `scale`, `random_state` | `1.0`, `1.0`, `0.0`, `1.0`, `None` |
 | `GAMMA` | `"gamma"` | `a`, `loc`, `scale`, `random_state` | `1.0`, `0.0`, `1.0`, `None` |
 | `INVGAMMA` | `"inv_gamma"` | `a`, `loc`, `scale`, `random_state` | `1.0`, `0.0`, `1.0`, `None` |
-| `UNIFORM` | `"uniform"` | `a`, `b`, `random_state` | `0.0`, `1.0`, `None` |
+| `UNIFORM` | `"uniform"` | `low`, `high`, `random_state` | `0.0`, `1.0`, `None` |
 | `LKJCHOL` | `"lkj_chol"` | `eta`, `K`, `random_state` | `1.0`, `-1`, `None` |
 
 ???+ note "LKJ Parameter"
@@ -70,8 +70,8 @@ Dispatched `transform` values accepted by `make_prior(...)`:
 | `PROBIT` | `"probit"` | none |
 | `AFFINE_LOGIT` | `"affine_logit"` | `low`, `high` |
 | `AFFINE_PROBIT` | `"affine_probit"` | `low`, `high` |
-| `LOWER_BOUNDED` | `"lower_bounded"` | `lower` |
-| `UPPER_BOUNDED` | `"upper_bounded"` | `upper` |
+| `LOWER_BOUNDED` | `"lower_bounded"` | `low` |
+| `UPPER_BOUNDED` | `"upper_bounded"` | `high` |
 
 Additional `TransformMethod` enum members currently not dispatched by `make_prior(...)`:
 

--- a/docs/documentation/prior_spec/distributions/beta.md
+++ b/docs/documentation/prior_spec/distributions/beta.md
@@ -1,0 +1,31 @@
+---
+tags:
+    - doc
+---
+# Beta
+
+Bounded prior family on the unit interval in its standard form.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `a` | $\alpha$ | First shape parameter | `1.0` |
+| `b` | $\beta$ | Second shape parameter | `1.0` |
+| `loc` | - | Lower shift used by implementation | `0.0` |
+| `scale` | - | Width scale used by implementation | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.beta(a, b, loc=loc, scale=scale)`, i.e. an affine-transformed beta distribution.
+
+### PDF
+$$
+f(x;\alpha,\beta)=
+\frac{\Gamma(\alpha+\beta)}{\Gamma(\alpha)\Gamma(\beta)}
+x^{\alpha-1}(1-x)^{\beta-1}
+$$
+
+### Region
+$$
+x \in (0,1)
+$$

--- a/docs/documentation/prior_spec/distributions/gamma.md
+++ b/docs/documentation/prior_spec/distributions/gamma.md
@@ -1,0 +1,30 @@
+---
+tags:
+    - doc
+---
+# Gamma
+
+Positive prior family with shape-scale parameterization.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `a` | $k$ | Shape | `1.0` |
+| `loc` | - | Location shift used by implementation | `0.0` |
+| `scale` | $\theta$ | Scale | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.gamma(a, loc=loc, scale=scale)`.
+
+### PDF
+$$
+f(x;k,\theta)=
+\frac{1}{\Gamma(k)\theta^k}
+x^{k-1}e^{-x/\theta}
+$$
+
+### Region
+$$
+x \in (0,\infty)
+$$

--- a/docs/documentation/prior_spec/distributions/half_cauchy.md
+++ b/docs/documentation/prior_spec/distributions/half_cauchy.md
@@ -1,0 +1,28 @@
+---
+tags:
+    - doc
+---
+# HalfCauchy
+
+Heavy-tailed positive prior family.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `low` | - | Lower shift used by implementation | `0.0` |
+| `scale` | $\gamma$ | Scale | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.halfcauchy(loc=low, scale=scale)`.
+
+### PDF
+$$
+f(x;\gamma) =
+\frac{2}{\pi\gamma\left(1 + (x/\gamma)^2\right)}
+$$
+
+### Region
+$$
+x \in [0,\infty)
+$$

--- a/docs/documentation/prior_spec/distributions/half_normal.md
+++ b/docs/documentation/prior_spec/distributions/half_normal.md
@@ -1,0 +1,29 @@
+---
+tags:
+    - doc
+---
+# HalfNormal
+
+Non-negative prior family obtained by folding a normal distribution at zero.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `low` | - | Lower shift used by implementation | `0.0` |
+| `scale` | $\sigma$ | Scale | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.halfnorm(loc=low, scale=scale)`.
+
+### PDF
+$$
+f(x;\sigma) =
+\sqrt{\frac{2}{\pi\sigma^2}}
+\exp\left(-\frac{x^2}{2\sigma^2}\right)
+$$
+
+### Region
+$$
+x \in [0,\infty)
+$$

--- a/docs/documentation/prior_spec/distributions/inv_gamma.md
+++ b/docs/documentation/prior_spec/distributions/inv_gamma.md
@@ -1,0 +1,31 @@
+---
+tags:
+    - doc
+---
+# InvGamma
+
+Inverse-gamma prior family.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `a` | $\alpha$ | Shape | `1.0` |
+| `loc` | - | Location shift used by implementation | `0.0` |
+| `scale` | $\beta$ | Scale | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.invgamma(a, loc=loc, scale=scale)`.
+
+### PDF
+$$
+f(x;\alpha,\beta)=
+\frac{\beta^\alpha}{\Gamma(\alpha)}
+x^{-(\alpha+1)}
+\exp\left(-\frac{\beta}{x}\right)
+$$
+
+### Region
+$$
+x \in (0,\infty)
+$$

--- a/docs/documentation/prior_spec/distributions/lkj_chol.md
+++ b/docs/documentation/prior_spec/distributions/lkj_chol.md
@@ -1,0 +1,39 @@
+---
+tags:
+    - doc
+---
+# LKJChol
+
+Prior family over Cholesky factors of correlation matrices.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `eta` | $\eta$ | LKJ shape parameter (`eta > 0`) | `1.0` |
+| `K` | $K$ | Correlation dimension | `-1` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Dimension Parameter"
+    `K` must be provided with a valid positive dimension for runtime use.
+
+### PDF
+$$
+f(R;\eta) = C \times \lbrack \det{R} \rbrack^{\eta-1}
+\\
+\text{ }
+\\
+\text{ }
+\\
+C = 2^{\sum_{k=1}^{K-1} (2(\eta-1)+K-k)(K-k)} \times \prod_{k=1}^{K-1}\Bigg\lbrack \Beta\bigg(\eta + \frac{(K-k-1)}{2}, \eta + \frac{(K-k-1)}{2}\bigg)\Bigg\rbrack^{K-k}
+$$
+
+### Region
+$$
+L \in \mathcal{L}_K =
+\left\{
+L \in \mathbb{R}^{K\times K} :
+L \text{ is lower triangular},\quad
+L_{ii} > 0,\quad
+\sum_{j=1}^{i} L_{ij}^2 = 1
+\right\}
+$$

--- a/docs/documentation/prior_spec/distributions/log_normal.md
+++ b/docs/documentation/prior_spec/distributions/log_normal.md
@@ -1,0 +1,30 @@
+---
+tags:
+    - doc
+---
+# LogNormal
+
+Positive-support prior family based on exponentiated normals.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `s` | $\sigma$ | Shape (std of underlying normal) | `1.0` |
+| `low` | - | Lower shift used by implementation | `0.0` |
+| `scale` | - | Scale used by implementation | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+???+ note "Implementation Parameterization"
+    The implementation follows `scipy.stats.lognorm(s, loc=low, scale=scale)`. The PDF above is the standard unshifted form.
+
+### PDF
+$$
+f(x;\mu,\sigma) =
+\frac{1}{x\sigma\sqrt{2\pi}}
+\exp\left(-\frac{(\log x-\mu)^2}{2\sigma^2}\right)
+$$
+
+### Region
+$$
+x \in (0,\infty)
+$$

--- a/docs/documentation/prior_spec/distributions/normal.md
+++ b/docs/documentation/prior_spec/distributions/normal.md
@@ -1,0 +1,26 @@
+---
+tags:
+    - doc
+---
+# Normal
+
+Standard Gaussian prior family.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `mean` | $\mu$ | Mean | `0.0` |
+| `std` | $\sigma$ | Standard deviation | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+### PDF
+$$
+f(x;\mu,\sigma) =
+\frac{1}{\sqrt{2\pi}\sigma}
+\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right)
+$$
+
+### Region
+$$
+x \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/distributions/trunc_normal.md
+++ b/docs/documentation/prior_spec/distributions/trunc_normal.md
@@ -1,0 +1,28 @@
+---
+tags:
+    - doc
+---
+# TruncNormal
+
+Normal prior truncated to a finite interval.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `low` | $\ell$ | Lower truncation bound | `-6.0` |
+| `high` | $h$ | Upper truncation bound | `6.0` |
+| `loc` | $\mu$ | Location | `0.0` |
+| `scale` | $\sigma$ | Scale | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+### PDF
+$$
+f(x;\mu,\sigma,\ell,h)=
+\frac{\phi\!\left(\frac{x-\mu}{\sigma}\right)}
+{\sigma\left[\Phi\!\left(\frac{h-\mu}{\sigma}\right)-\Phi\!\left(\frac{\ell-\mu}{\sigma}\right)\right]}
+$$
+
+### Region
+$$
+x \in [\ell,h]
+$$

--- a/docs/documentation/prior_spec/distributions/uniform.md
+++ b/docs/documentation/prior_spec/distributions/uniform.md
@@ -1,0 +1,24 @@
+---
+tags:
+    - doc
+---
+# Uniform
+
+Flat bounded prior family.
+
+### Parameters
+| __Argument__ | __Symbol__ | __Meaning__ | __Default__ |
+|:-------------|:-----------|:------------|:-----------:|
+| `low` | $a$ | Lower bound | `0.0` |
+| `high` | $b$ | Upper bound | `1.0` |
+| `random_state` | - | RNG seed / generator | `None` |
+
+### PDF
+$$
+f(x;a,b)=\frac{1}{b-a}
+$$
+
+### Region
+$$
+x \in [a,b]
+$$

--- a/docs/documentation/prior_spec/transforms/affine_logit.md
+++ b/docs/documentation/prior_spec/transforms/affine_logit.md
@@ -1,0 +1,21 @@
+---
+tags:
+    - doc
+---
+# AffineLogit
+
+Bounded-interval transform to unconstrained space via affine scaling + logit.
+
+### Parameters
+| __Argument__ | __Meaning__ |
+|:-------------|:------------|
+| `low` | Lower bound of constrained interval |
+| `high` | Upper bound of constrained interval |
+
+### Transformation
+$$
+x \in (\text{low},\text{high}) \mapsto
+y = \log\left(\frac{z}{1-z}\right) \in \mathbb{R},
+\quad
+z = \frac{x-\text{low}}{\text{high}-\text{low}}
+$$

--- a/docs/documentation/prior_spec/transforms/affine_probit.md
+++ b/docs/documentation/prior_spec/transforms/affine_probit.md
@@ -1,0 +1,21 @@
+---
+tags:
+    - doc
+---
+# AffineProbit
+
+Bounded-interval transform to unconstrained space via affine scaling + probit.
+
+### Parameters
+| __Argument__ | __Meaning__ |
+|:-------------|:------------|
+| `low` | Lower bound of constrained interval |
+| `high` | Upper bound of constrained interval |
+
+### Transformation
+$$
+x \in (\text{low},\text{high}) \mapsto
+y = \Phi^{-1}(z) \in \mathbb{R},
+\quad
+z = \frac{x-\text{low}}{\text{high}-\text{low}}
+$$

--- a/docs/documentation/prior_spec/transforms/identity.md
+++ b/docs/documentation/prior_spec/transforms/identity.md
@@ -1,0 +1,15 @@
+---
+tags:
+    - doc
+---
+# Identity
+
+No-op transform used when parameters are already unconstrained.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in \mathbb{R} \mapsto y = x \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/transforms/log.md
+++ b/docs/documentation/prior_spec/transforms/log.md
@@ -1,0 +1,15 @@
+---
+tags:
+    - doc
+---
+# Log
+
+Log transform from strictly positive space to unconstrained space.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in (0,\infty) \mapsto y = \log(x) \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/transforms/logit.md
+++ b/docs/documentation/prior_spec/transforms/logit.md
@@ -1,0 +1,15 @@
+---
+tags:
+    - doc
+---
+# Logit
+
+Unit-interval transform to unconstrained space.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in (0,1) \mapsto y = \log\left(\frac{x}{1-x}\right) \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/transforms/lower_bounded.md
+++ b/docs/documentation/prior_spec/transforms/lower_bounded.md
@@ -1,0 +1,18 @@
+---
+tags:
+    - doc
+---
+# LowerBounded
+
+Lower-bounded transform to unconstrained space.
+
+### Parameters
+| __Argument__ | __Meaning__ |
+|:-------------|:------------|
+| `low` | Lower bound of constrained interval |
+
+### Transformation
+$$
+x \in (\text{low},\infty) \mapsto
+y = \log(x-\text{low}) \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/transforms/probit.md
+++ b/docs/documentation/prior_spec/transforms/probit.md
@@ -1,0 +1,15 @@
+---
+tags:
+    - doc
+---
+# Probit
+
+Unit-interval transform based on the inverse standard normal CDF.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in (0,1) \mapsto y = \Phi^{-1}(x) \in \mathbb{R}
+$$

--- a/docs/documentation/prior_spec/transforms/softplus.md
+++ b/docs/documentation/prior_spec/transforms/softplus.md
@@ -1,0 +1,19 @@
+---
+tags:
+    - doc
+---
+# Softplus
+
+Smooth positive-space transform used as an alternative to `log`.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in (0,\infty) \mapsto y = \log(e^x - 1) \in \mathbb{R}
+$$
+
+$$
+y \in \mathbb{R} \mapsto x = \log(1 + e^y) \in (0,\infty)
+$$

--- a/docs/documentation/prior_spec/transforms/upper_bounded.md
+++ b/docs/documentation/prior_spec/transforms/upper_bounded.md
@@ -1,0 +1,18 @@
+---
+tags:
+    - doc
+---
+# UpperBounded
+
+Upper-bounded transform to unconstrained space.
+
+### Parameters
+| __Argument__ | __Meaning__ |
+|:-------------|:------------|
+| `high` | Upper bound of constrained interval |
+
+### Transformation
+$$
+x \in (-\infty,\text{high}) \mapsto
+y = \log(\text{high}-x) \in \mathbb{R}
+$$

--- a/docs/guides/estimation_guide.md
+++ b/docs/guides/estimation_guide.md
@@ -235,7 +235,7 @@ More detailed information regarding estimation can be found via the references. 
 ???+ note "References"
     This guide focuses on solver-facing estimation flow. For API-level references, use:
     - [`Estimator`](../documentation/Estimator.md)
-    - [`Prior`](../documentation/Prior.md)
+    - [`Prior`](../documentation/prior_spec/Prior.md)
     - [`DSGESolver`](../documentation/DSGESolver.md)
 
 [Download Guide Notebook](../assets/guide_notebook.ipynb){ .md-button download="" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,12 +139,34 @@ nav:
       - ModelParser: documentation/ModelParser.md
       - DSGESolver: documentation/DSGESolver.md
       - Estimator: documentation/Estimator.md
-      - Prior: documentation/Prior.md
       - CompiledModel: documentation/CompiledModel.md
       - SolvedModel: documentation/SolvedModel.md
       - Shock: documentation/Shock.md
       - KalmanConfig: documentation/KalmanConfig.md
       - FilterResult: documentation/FilterResult.md
+      - Prior Specification:
+        - Prior: documentation/prior_spec/Prior.md
+        - Distributions:
+            - Normal: documentation/prior_spec/distributions/normal.md
+            - LogNormal: documentation/prior_spec/distributions/log_normal.md
+            - HalfNormal: documentation/prior_spec/distributions/half_normal.md
+            - TruncNormal: documentation/prior_spec/distributions/trunc_normal.md
+            - HalfCauchy: documentation/prior_spec/distributions/half_cauchy.md
+            - Beta: documentation/prior_spec/distributions/beta.md
+            - Gamma: documentation/prior_spec/distributions/gamma.md
+            - InvGamma: documentation/prior_spec/distributions/inv_gamma.md
+            - Uniform: documentation/prior_spec/distributions/uniform.md
+            - LKJChol: documentation/prior_spec/distributions/lkj_chol.md
+        - Transformations:
+            - Identity: documentation/prior_spec/transforms/identity.md
+            - Log: documentation/prior_spec/transforms/log.md
+            - Softplus: documentation/prior_spec/transforms/softplus.md
+            - Logit: documentation/prior_spec/transforms/logit.md
+            - Probit: documentation/prior_spec/transforms/probit.md
+            - AffineLogit: documentation/prior_spec/transforms/affine_logit.md
+            - AffineProbit: documentation/prior_spec/transforms/affine_probit.md
+            - LowerBounded: documentation/prior_spec/transforms/lower_bounded.md
+            - UpperBounded: documentation/prior_spec/transforms/upper_bounded.md
       - Utilities:
           - FRED: documentation/utilities/FRED.md
           - KalmanFilter: documentation/utilities/KalmanFilter.md

--- a/tests/bayesian/test_priors.py
+++ b/tests/bayesian/test_priors.py
@@ -136,7 +136,7 @@ def test_make_prior_builds_instances_and_applies_defaults():
 def test_make_prior_passes_transform_kwargs():
     prior = make_prior(
         distribution="uniform",
-        parameters={"a": -2.0, "b": 3.0},
+        parameters={"low": -2.0, "high": 3.0},
         transform="affine_logit",
         transform_kwargs={"low": -2.0, "high": 3.0},
     )


### PR DESCRIPTION
Rename parameter and attribute names across priors and transforms to use `low`/`high` (and `low` for lower-bounded) instead of `a`/`b`/`loc`/`upper`/`lower`. Updated implementations for HalfCauchy, HalfNormal, LogNormal, TruncNormal, Uniform and the affine/upper/lower-bounded transforms to use the new names and adjusted support/ jacobian/parameter conversions accordingly. Move and expand Prior documentation into a new prior_spec section, add per-distribution and per-transform markdown docs, and update mkdocs navigation to include the Prior Specification subtree. Update tests to use the new parameter keys (e.g. uniform uses `low`/`high`). These changes improve naming consistency and documentation for prior specifications.