### PR TITLE
Clarify prior support checks/messages

### DIFF
--- a/SymbolicDSGE/bayesian/priors.py
+++ b/SymbolicDSGE/bayesian/priors.py
@@ -58,25 +58,18 @@ class Prior:
 
     def _confirm_bound_match(self) -> None:
         _sup = self.dist.support
-        _map = self.transform.maps_to
         _trans_sup = self.transform.support
-        if _sup != _map:
-            raise ValueError(
-                f"Distribution support {self.dist.support} does not match transform maps_to {self.transform.maps_to}"
-            )
-
         if _sup != _trans_sup:
             raise ValueError(
-                "The transform's support function must match the distribution's support when using a ConstrainedPrior. "
-                "ConstrainedPrior assumes the distribution is already constrained to the desired support; "
-                "Transformations will not use jacobian corrections. "
+                "Distribution support does not match transform support. "
+                "When priors are defined in parameter space, transform.support must match dist.support. "
             )
 
         if not self.dist.support.is_finite:
             warnings.warn(
-                "ConstrainedPrior created with non-finite support. "
-                "This class assumes a pre-constrained distribution and the transformation will not be applied with jacobian correction. "
-                "If this is intentional, you can ignore this warning. Otherwise, consider using an unconstrained distribution with a transformation that maps to the desired support."
+                "Prior created with non-finite support. "
+                "This can be valid (e.g., Normal + Identity), but verify that the transform is appropriate "
+                "for optimization/sampling in unconstrained space."
             )
 
     @property

--- a/tests/bayesian/test_priors.py
+++ b/tests/bayesian/test_priors.py
@@ -295,23 +295,23 @@ def test_prior_grad_logpdf_uses_inverse_chain_rule_and_jacobian_gradient():
     assert np.allclose(dist.grad_x, z - 1.0)
 
 
-def test_confirm_bound_match_raises_on_dist_support_vs_transform_maps_to_mismatch():
+def test_confirm_bound_match_raises_on_dist_support_vs_transform_support_mismatch_gamma_identity():
     prior = make_prior(
         distribution="gamma",
         parameters={"a": 2.0, "loc": 0.0, "scale": 1.0},
         transform="identity",
     )
-    with pytest.raises(ValueError, match="does not match transform maps_to"):
+    with pytest.raises(ValueError, match="does not match transform support"):
         prior._confirm_bound_match()
 
 
-def test_confirm_bound_match_raises_on_dist_support_vs_transform_support_mismatch():
+def test_confirm_bound_match_raises_on_dist_support_vs_transform_support_mismatch_normal_log():
     prior = make_prior(
         distribution="normal",
         parameters={"mean": 0.0, "std": 1.0},
         transform="log",
     )
-    with pytest.raises(ValueError, match="transform's support function must match"):
+    with pytest.raises(ValueError, match="does not match transform support"):
         prior._confirm_bound_match()
 
 


### PR DESCRIPTION
Update ConstrainedPrior support validation to compare distribution support with transform.support (removing reliance on transform.maps_to), and simplify the associated ValueError and warning texts to be clearer about expectations for parameter-space priors and unconstrained optimization/sampling. Adjusted tests to expect the new messages and renamed two tests to indicate the specific distribution+transform cases (gamma+identity and normal+log).