### PR TITLE
Add docs for SolvedModel.fit_kf and MCMCResult HPD

### DIFF
--- a/docs/Documentation/SolvedModel.md
+++ b/docs/Documentation/SolvedModel.md
@@ -220,6 +220,41 @@ __Returns:__
 &nbsp;
 
 ```python
+SolvedModel.fit_kf(
+    y: ndarray | DataFrame,
+    observable: str,
+    template_config: TemplateConfig,
+    sr_params: PySRParams,
+    variables: list[str] | None = None, # (1)!
+) -> FitResult
+```
+
+1. `None`: Use all compiled model variables as symbolic-regression inputs.
+
+Fit a symbolic regression model to Kalman Filter output for a selected observable.
+
+???+ note "Regression Target"
+    Internally, the method first runs `#!python SolvedModel.kalman(...)` using the model's observable set. If `#!python template_config.include_expression=True`, the regression target is the predicted measurement for `observable`; otherwise the target is the observable's Kalman innovation.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| y | Observation data passed through the Kalman filter stage before symbolic regression. |
+| observable | Observable name whose filter output should be fit. |
+| template_config | Template-expression configuration used to build the symbolic-regression search space. |
+| sr_params | Symbolic-regression backend hyperparameters. |
+| variables | Optional subset of model variables to expose as regression inputs. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python FitResult` | Regression fit output containing all candidate expressions and the best-ranked symbolic approximation. |
+
+&nbsp;
+
+```python
 SolvedModel.to_dict() -> dict[str, Any]
 ```
 Dictionary representation of the class instance.

--- a/docs/documentation/Estimator.md
+++ b/docs/documentation/Estimator.md
@@ -150,3 +150,54 @@ Estimator.mcmc(
 | n_draws | `#!python int` | Retained draw count |
 | burn_in | `#!python int` | Burn-in iterations |
 | thin | `#!python int` | Thinning interval |
+
+__Methods:__
+
+```python
+MCMCResult.hpd_intervals(
+    alpha: float = 0.05, # (1)!
+) -> dict[str, tuple[float, float]]
+```
+
+1. Significance level. Must satisfy `#!python 0 <= alpha < 1`; each interval covers approximately `#!python 1 - alpha` of the retained marginal draws.
+
+Compute marginal highest-posterior-density (HPD) intervals for each parameter column.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| alpha | Significance level used to determine the empirical HPD coverage. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python dict[str, tuple[float, float]]` | Mapping from parameter name to the shortest empirical marginal interval containing approximately `#!python 1 - alpha` of the retained posterior draws. |
+
+&nbsp;
+
+```python
+MCMCResult.joint_hpd_set(
+    alpha: float = 0.05, # (1)!
+) -> tuple[np.ndarray, np.ndarray, float, np.ndarray]
+```
+
+1. Significance level. Must satisfy `#!python 0 <= alpha < 1`; the returned set covers at least `#!python 1 - alpha` of the retained joint draws.
+
+Compute an empirical joint HPD set for the full parameter vector.
+
+???+ note "Finite-Sample Joint HPD Approximation"
+    Retained draws are ranked by `#!python logpost_trace` and all draws at or above the cutoff are included in the set. If multiple draws are tied at the boundary log-posterior, they are all retained, so the realized coverage can be slightly larger than `#!python 1 - alpha`.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| alpha | Significance level used to determine the empirical HPD coverage. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python tuple[np.ndarray, np.ndarray, float, np.ndarray]` | Tuple `#!python (samples, logpost, threshold, indices)` where `samples` are the retained parameter vectors in the joint HPD set, `logpost` are their posterior values, `threshold` is the cutoff log-posterior, and `indices` are positions of the retained draws in the original stored chain. |


### PR DESCRIPTION
Document new API methods: add SolvedModel.fit_kf signature, behavior (regression target choice, inputs, and return FitResult) to docs/Documentation/SolvedModel.md; and add MCMCResult.hpd_intervals and MCMCResult.joint_hpd_set signatures, parameter descriptions, return types, and a note on finite-sample joint HPD ties to docs/documentation/Estimator.md. These additions clarify usage and edge-case behavior for symbolic-regression fitting and HPD interval computations.