### PR TITLE
Support injecting ModelParametrizer into fit_kf

### DIFF
--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -24,6 +24,7 @@ from ..kalman.filter import FilterResult
 from ..regression.sr_interface import SRInterface
 from ..regression.config import TemplateConfig
 from ..regression.model_defaults import PySRParams
+from ..regression.model_parametrizer import ModelParametrizer
 from ..regression.fit_result import FitResult
 
 _JIT_CACHE: dict[int, Callable] = {}
@@ -557,17 +558,32 @@ class SolvedModel:
         self,
         y: NDF | pd.DataFrame,
         observable: str,
-        template_config: TemplateConfig,
-        sr_params: PySRParams,
+        template_config: TemplateConfig | None = None,
+        sr_params: PySRParams | None = None,
         variables: list[str] | None = None,
+        parametrizer: ModelParametrizer | None = None,
     ) -> FitResult:
+        if parametrizer is None:
+            if template_config is None or sr_params is None:
+                raise ValueError(
+                    "Provide either a pre-built parametrizer or both template_config and sr_params."
+                )
+            parametrizer = ModelParametrizer(
+                variables or self.compiled.var_names,
+                sr_params,
+                template_config,
+            )
+        elif variables is not None and set(variables) != set(
+            parametrizer.variable_names
+        ):
+            raise ValueError(
+                "Provided variables do not match the parametrizer's variable names."
+            )
 
         interface = SRInterface(
             model=self,
-            variable_names=variables,
             obs_name=observable,
-            config=template_config,
-            params=sr_params,
+            parametrizer=parametrizer,
         )
 
         return interface.fit_to_kf(y)

--- a/SymbolicDSGE/regression/sr_interface.py
+++ b/SymbolicDSGE/regression/sr_interface.py
@@ -1,7 +1,5 @@
 from sympy import Expr
 from .symbolic_regression import SymbolicRegressor
-from .config import TemplateConfig
-from .model_defaults import PySRParams
 from .model_parametrizer import ModelParametrizer
 from .fit_result import FitResult
 
@@ -25,20 +23,12 @@ class SRInterface:
     def __init__(
         self,
         model: "SolvedModel",
-        variable_names: list[str] | None,
         obs_name: str,
-        config: TemplateConfig,
-        params: PySRParams,
+        parametrizer: ModelParametrizer,
     ):
         self._model = model
 
-        self._variable_names = variable_names or model.compiled.var_names
-
-        parametrizer = ModelParametrizer(
-            self._variable_names,
-            params,
-            config,
-        )
+        self._variable_names = parametrizer.variable_names
         expr = self._get_equation(obs_name)
         parametrizer.make_and_add_template(expr)
         self._obs_name = obs_name

--- a/coverage/tests-badge.svg
+++ b/coverage/tests-badge.svg
@@ -1,1 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="tests: passing"><title>tests: passing</title><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="88" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#r)"><rect width="37" height="20" fill="#333333"/><rect x="37" width="51" height="20" fill="#2e7d32"/><rect width="88" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text aria-hidden="true" x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text><text x="195" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text><text aria-hidden="true" x="615" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="410">passing</text><text x="615" y="140" transform="scale(.1)" fill="#fff" textLength="410">passing</text></g></svg>
+<svg width="80" height="20" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tests: failing">
+  <title>tests: failing</title>
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="800" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="366" height="200" fill="#555"/>
+    <rect width="434" height="200" fill="#E43" x="366"/>
+    <rect width="800" height="200" fill="url(#a)"/>
+  </g>
+  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="60" y="148" textLength="266" fill="#000" opacity="0.25">tests</text>
+    <text x="50" y="138" textLength="266">tests</text>
+    <text x="421" y="148" textLength="334" fill="#000" opacity="0.25">failing</text>
+    <text x="411" y="138" textLength="334">failing</text>
+  </g>
+  
+</svg>

--- a/docs/Documentation/SolvedModel.md
+++ b/docs/Documentation/SolvedModel.md
@@ -223,15 +223,20 @@ __Returns:__
 SolvedModel.fit_kf(
     y: ndarray | DataFrame,
     observable: str,
-    template_config: TemplateConfig,
-    sr_params: PySRParams,
+    template_config: TemplateConfig | None = None,
+    sr_params: PySRParams | None = None,
     variables: list[str] | None = None, # (1)!
+    parametrizer: ModelParametrizer | None = None, # (2)!
 ) -> FitResult
 ```
 
 1. `None`: Use all compiled model variables as symbolic-regression inputs.
+2. `None`: Build a default `ModelParametrizer` from `template_config`, `sr_params`, and `variables`.
 
 Fit a symbolic regression model to Kalman Filter output for a selected observable.
+
+???+ note "Parametrizer Injection"
+    Pass a pre-built `#!python ModelParametrizer` when you need to customize the symbolic-regression setup before the Kalman/SR integration adds the template, for example by calling `#!python add_built_in_ops(...)`. If `#!python parametrizer` is omitted, both `#!python template_config` and `#!python sr_params` must be provided and the method will construct the default parametrizer internally.
 
 ???+ note "Regression Target"
     Internally, the method first runs `#!python SolvedModel.kalman(...)` using the model's observable set. If `#!python template_config.include_expression=True`, the regression target is the predicted measurement for `observable`; otherwise the target is the observable's Kalman innovation.
@@ -242,9 +247,10 @@ __Inputs:__
 |:---------|----------------:|
 | y | Observation data passed through the Kalman filter stage before symbolic regression. |
 | observable | Observable name whose filter output should be fit. |
-| template_config | Template-expression configuration used to build the symbolic-regression search space. |
-| sr_params | Symbolic-regression backend hyperparameters. |
+| template_config | Template-expression configuration used to build the default symbolic-regression parametrizer. |
+| sr_params | Symbolic-regression backend hyperparameters used by the default parametrizer path. |
 | variables | Optional subset of model variables to expose as regression inputs. |
+| parametrizer | Optional pre-built `#!python ModelParametrizer` used instead of constructing one inside `#!python fit_kf`. |
 
 __Returns:__
 

--- a/tests/core/test_solved_model_fit_kf_contract.py
+++ b/tests/core/test_solved_model_fit_kf_contract.py
@@ -1,0 +1,73 @@
+# type: ignore
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import SymbolicDSGE.core.solved_model as solved_model_module
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.regression.config import TemplateConfig
+from SymbolicDSGE.regression.model_defaults import PySRParams
+from SymbolicDSGE.regression.model_parametrizer import ModelParametrizer
+
+
+def _make_solved_model() -> SolvedModel:
+    return SolvedModel(
+        compiled=SimpleNamespace(var_names=["x"]),
+        policy=None,
+        A=np.zeros((1, 1), dtype=np.float64),
+        B=np.zeros((1, 1), dtype=np.float64),
+    )
+
+
+def test_fit_kf_accepts_prebuilt_parametrizer(monkeypatch):
+    captured = {}
+
+    class _FakeSRInterface:
+        def __init__(self, *, model, obs_name, parametrizer):
+            captured["model"] = model
+            captured["obs_name"] = obs_name
+            captured["parametrizer"] = parametrizer
+
+        def fit_to_kf(self, y):
+            captured["y"] = y
+            return "fit-result"
+
+    monkeypatch.setattr(solved_model_module, "SRInterface", _FakeSRInterface)
+
+    solved = _make_solved_model()
+    parametrizer = ModelParametrizer(
+        ["x"],
+        PySRParams(precision=32),
+        TemplateConfig(),
+    )
+    y = np.zeros((4, 1), dtype=np.float64)
+
+    out = solved.fit_kf(
+        y=y,
+        observable="obs",
+        parametrizer=parametrizer,
+    )
+
+    assert out == "fit-result"
+    assert captured["model"] is solved
+    assert captured["obs_name"] == "obs"
+    assert captured["parametrizer"] is parametrizer
+    assert captured["y"] is y
+
+
+def test_fit_kf_rejects_mismatched_variables_for_prebuilt_parametrizer():
+    solved = _make_solved_model()
+    parametrizer = ModelParametrizer(
+        ["x"],
+        PySRParams(precision=32),
+        TemplateConfig(),
+    )
+
+    with pytest.raises(ValueError, match="do not match the parametrizer"):
+        solved.fit_kf(
+            y=np.zeros((2, 1), dtype=np.float64),
+            observable="obs",
+            variables=["z"],
+            parametrizer=parametrizer,
+        )

--- a/tests/regression/test_sr_interface_contract.py
+++ b/tests/regression/test_sr_interface_contract.py
@@ -1,0 +1,46 @@
+# type: ignore
+from types import SimpleNamespace
+
+import sympy as sp
+
+from SymbolicDSGE.regression.config import TemplateConfig
+from SymbolicDSGE.regression.model_defaults import PySRParams
+from SymbolicDSGE.regression.model_parametrizer import ModelParametrizer
+from SymbolicDSGE.regression.sr_interface import SRInterface
+from SymbolicDSGE.regression.symbolic_regression import SymbolicRegressor
+
+
+class _BuiltinParametrizer(ModelParametrizer):
+    def __init__(self, variable_names, params, config):
+        super().__init__(variable_names, params, config)
+        self.add_built_in_ops(["sqrt"])
+
+
+def test_sr_interface_uses_prebuilt_parametrizer(monkeypatch):
+    monkeypatch.setattr(SymbolicRegressor, "_load_params", lambda self: object())
+
+    t = sp.Symbol("t", integer=True)
+    x = sp.Function("x")
+    parametrizer = _BuiltinParametrizer(
+        ["x"],
+        PySRParams(precision=32),
+        TemplateConfig(),
+    )
+    model = SimpleNamespace(
+        compiled=SimpleNamespace(var_names=["x"]),
+        config=SimpleNamespace(
+            equations=SimpleNamespace(observable={"y": x(t) + 1}),
+            calibration=SimpleNamespace(parameters={}),
+        ),
+    )
+
+    interface = SRInterface(
+        model=model,
+        obs_name="y",
+        parametrizer=parametrizer,
+    )
+
+    assert interface.sr.parametrizer is parametrizer
+    assert interface.selected_var_names == ["x"]
+    assert interface.sr.parametrizer.params.expression_spec is not None
+    assert any("ssqrt" in op for op in (parametrizer.params.unary_operators or []))


### PR DESCRIPTION
Allow callers to pass a pre-built ModelParametrizer into SolvedModel.fit_kf (optional). If no parametrizer is provided, fit_kf will construct a default one from template_config and sr_params; it raises a ValueError if both are missing. If a parametrizer is provided, variables must match the parametrizer's variable names (otherwise ValueError). SRInterface was changed to accept a parametrizer (and uses its variable_names) instead of template_config/params/variable_names. Documentation updated to describe the new parametrizer injection path, and tests added to cover the prebuilt-parametrizer contract and variable-mismatch behavior.