### PR TITLE
Add Monte Carlo documentation

### DIFF
--- a/docs/documentation/monte_carlo/built_in_steps.md
+++ b/docs/documentation/monte_carlo/built_in_steps.md
@@ -1,0 +1,163 @@
+---
+tags:
+    - doc
+---
+# Built-In Steps
+
+## DGP Simulation
+
+```python
+simulation_step(
+    name: str = "datagen",
+    *,
+    T: int,
+    shocks: Mapping[str, Shock | Callable | ndarray] | None = None,
+    seed_increment: int | Literal["auto"] = "auto",
+    shock_scale: float = 1.0,
+    x0: ndarray | None = None,
+    observables: bool = True,
+) -> MCStep
+```
+
+`simulation_step` wraps `simulate_dgp(...)`. It requires `MCPipeline.run(..., dgp=...)` and calls `dgp.sim(...)` in each replication.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| T | Number of simulated periods, excluding the initial state. |
+| shocks | Shock specification passed into DGP simulation after per-replication seed handling. |
+| seed_increment | Integer seed offset per replication, or `"auto"` to increment by the number of seeded `Shock` objects. |
+| shock_scale | Shock scaling passed into `SolvedModel.sim(...)`. |
+| x0 | Optional initial state. |
+| observables | If `True`, observable paths are included in `MCData.observables`. |
+
+???+ info "Seed Convention"
+    For generator-style `Shock` objects with integer seeds, replication `rep_idx` receives `shock.seed + rep_idx * seed_increment`. With `seed_increment="auto"`, the increment is the number of seeded `Shock` entries. Array shocks and callable shocks are passed through unchanged.
+
+## Raw Data
+
+```python
+raw_data_step(
+    name: str = "datagen",
+    *,
+    states: ndarray | None = None,
+    observables: ndarray | None = None,
+    n_exog: int = -1,
+    raw: Mapping[str, ndarray] | None = None,
+    observable_names: Sequence[str] = (),
+) -> MCStep
+```
+
+`raw_data_step` wraps `raw_data_datagen(...)`. It does not require a DGP model.
+
+__Accepted Shapes:__
+
+| __Field__ | __Accepted Shapes__ | __Description__ |
+|:----------|:--------------------:|----------------:|
+| states | `(T, n_state)` or `(n_rep, T, n_state)` | A 2D array is reused for every replication. A 3D array selects `arr[rep_idx]`. |
+| observables | `(T,)`, `(T, n_obs)`, or `(n_rep, T, n_obs)` | A 1D observable path is reshaped to `(T, 1)`. A 2D array is reused for every replication. |
+| raw values | `(T,)`, `(T, n)`, or `(n_rep, T, n)` | Extra raw arrays are selected with the same convention as observables. |
+
+???+ note "State-Only and Observable-Only Runs"
+    `raw_data_step` accepts state-only and observable-only payloads. A reference filter step requires observables, while tests using `source="states"` require states.
+
+## Reference Filtering
+
+```python
+reference_filter_step(
+    name: str = "filter",
+    *,
+    filter_mode: Literal["linear", "extended"] = "linear",
+    observables: list[str] | None = None,
+    x0: ndarray | None = None,
+    p0_mode: Literal["diag", "eye"] | None = None,
+    p0_scale: float | None = None,
+    jitter: float | None = None,
+    symmetrize: bool | None = None,
+    return_shocks: bool = False,
+    R: ndarray | None = None,
+    estimate_R_diag: bool = False,
+    R_scale: float = 1.0,
+) -> MCStep
+```
+
+`reference_filter_step` wraps `run_reference_filter(...)`. It reads `context.data.observables` and calls `reference.kalman(...)`.
+
+When `observables=None`, generated `MCData.observable_names` are used if available. If names are not available, `reference.kalman(...)` falls back to its normal observable resolution.
+
+## Wald Testing
+
+```python
+wald_test_step(
+    name: str,
+    *,
+    source: Literal[
+        "states",
+        "observables",
+        "x_pred",
+        "x_filt",
+        "y_pred",
+        "y_filt",
+        "innov",
+        "std_innov",
+        "payload",
+    ],
+    target: ndarray,
+    kind: Literal["mean", "covariance", "second_moment"] = "mean",
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    kernel: Literal["bartlett", "parzen", "qs"] = "bartlett",
+    bandwidth: int | Literal["andrews", "wooldridge", "auto"] | None = "auto",
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`wald_test_step` wraps `run_wald_test(...)`. It selects a 1D or 2D array from generated data, a `FilterResult`, or a named payload, then runs the requested HAC Wald diagnostic.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |
+
+__Kinds:__
+
+| __Kind__ | __Description__ |
+|:---------|----------------:|
+| `mean` | Tests `E[g_t] = target`. |
+| `covariance` | Tests the vech representation of the covariance matrix against `target`. |
+| `second_moment` | Tests the vech representation of the raw second moment against `target`. |
+
+## Transform Steps
+
+```python
+transform_step(
+    name: str,
+    func: Callable[..., Any],
+    *,
+    store_key: str | None = None,
+    **kwargs: Any,
+) -> MCStep
+```
+
+`transform_step` creates a custom per-replication operation. The callable receives the normalized operation arguments:
+
+```python
+func(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    **kwargs,
+) -> Any
+```
+
+If the callable returns an `MCData` object, the pipeline replaces `context.data` with that return value. The return value is stored in `context.payloads[store_key or name]`.

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -1,0 +1,112 @@
+---
+tags:
+    - doc
+---
+# Core Containers
+
+```python
+@dataclass(frozen=True)
+class MCStep(
+    name: str,
+    op_type: OpType,
+    func: Callable[..., Any],
+    kwargs: Mapping[str, Any] = {},
+    store_key: str | None = None,
+)
+```
+
+`MCStep` describes one operation in the pipeline. Most users should create steps through `simulation_step`, `raw_data_step`, `transform_step`, `reference_filter_step`, and `wald_test_step`.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| name | `#!python str` | Unique step name. Test steps use this as the key in `MCPipelineResult.summaries`. |
+| op_type | `#!python OpType` | Operation type: `DATAGEN`, `TRANSFORM`, `FILTER`, `TEST`, or `POSTPROC`. |
+| func | `#!python Callable` | Callable executed by the pipeline. |
+| kwargs | `#!python Mapping[str, Any]` | Keyword arguments stored with the step and passed into `func`. |
+| store_key | `#!python str \| None` | Optional payload key. If omitted, `name` is used. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class MCData(
+    states: ndarray | None = None,
+    observables: ndarray | None = None,
+    n_exog: int = -1,
+    raw: Mapping[str, ndarray] = {},
+    observable_names: tuple[str, ...] = (),
+)
+```
+
+`MCData` is the standard per-replication data payload. State-only and observable-only payloads are supported, but downstream steps may require one or the other.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| states | `#!python ndarray \| None` | Simulated or supplied state matrix. |
+| observables | `#!python ndarray \| None` | Simulated or supplied observable matrix. |
+| n_exog | `#!python int` | Number of exogenous shocks when known. |
+| raw | `#!python Mapping[str, ndarray]` | Additional raw arrays, usually from `SolvedModel.sim(...)`. |
+| observable_names | `#!python tuple[str, ...]` | Observable column names used by the reference filter when explicit names are not supplied. |
+
+&nbsp;
+
+```python
+@dataclass
+class MCContext(
+    rep_idx: int,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    data: MCData | None = None,
+    payloads: dict[str, Any] = {},
+    results: dict[str, TestResult] = {},
+)
+```
+
+`MCContext` is the mutable object passed through a single replication. Custom transform, filter, test, and post-processing operations receive it as `context`.
+
+__Methods:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| `require_data()` | Return `data` or raise if no data-generation step has populated it. |
+| `require_payload(key)` | Return a payload by key or raise if the key is missing. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class MCPipelineResult(
+    n_rep: int,
+    n_successful: int,
+    summaries: Mapping[str, MCResult],
+    test_results: Mapping[str, tuple[TestResult, ...]] | None,
+    payloads: tuple[Mapping[str, Any], ...] | None,
+    contexts: tuple[MCContext, ...] | None,
+    failures: tuple[MCFailure, ...] = (),
+)
+```
+
+`MCPipelineResult` is the aggregate return object from `MCPipeline.run(...)`.
+
+__Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| n_rep | `#!python int` | Requested replication count. |
+| n_successful | `#!python int` | Number of completed replications. |
+| summaries | `#!python Mapping[str, MCResult]` | Per-test aggregate result containers. |
+| test_results | `#!python Mapping[str, tuple[TestResult, ...]] \| None` | Optional scalar per-replication test results. |
+| payloads | `#!python tuple[Mapping[str, Any], ...] \| None` | Optional per-replication payload dictionaries. |
+| contexts | `#!python tuple[MCContext, ...] \| None` | Optional full contexts. |
+| failures | `#!python tuple[MCFailure, ...]` | Failures collected when `fail_fast=False`. |
+| succeeded | `#!python bool` | `True` when no failures were collected. |
+| statistic_traces | `#!python Mapping[str, ndarray]` | Shortcut for each summary's statistic trace. |
+| pval_traces | `#!python Mapping[str, ndarray]` | Shortcut for each summary's p-value trace. |
+| rejection_traces | `#!python Mapping[str, ndarray]` | Boolean rejection trace for each summary. |
+
+???+ note "P-Value Evaluation"
+    Scalar `TestResult` objects produced inside Monte Carlo Wald steps defer p-value and frozen-distribution construction until `pval`, `frozen_dist`, or `compute_pval()` is accessed. Aggregate `MCResult` objects compute vectorized p-values when `MCPipelineResult.summaries` is built.

--- a/docs/documentation/monte_carlo/index.md
+++ b/docs/documentation/monte_carlo/index.md
@@ -1,0 +1,10 @@
+---
+tags:
+    - doc
+---
+# Monte Carlo
+
+The `monte_carlo` module provides a bounded pipeline for repeated simulation, filtering, transformation, and diagnostic testing. The main use case is to treat one `SolvedModel` as the data-generating process (DGP), treat another `SolvedModel` as the reference model, and aggregate diagnostic test results over independent replications.
+
+???+ info "Reference and DGP Roles"
+    The built-in simulation step draws data from `dgp`. The built-in filtering step then runs `reference.kalman(...)` on the generated observables. The reference model is not simulated by the built-in DGP pipeline.

--- a/docs/documentation/monte_carlo/pipeline.md
+++ b/docs/documentation/monte_carlo/pipeline.md
@@ -1,0 +1,53 @@
+---
+tags:
+    - doc
+---
+# MCPipeline
+
+```python
+class MCPipeline(steps: Sequence[MCStep])
+```
+
+`MCPipeline` stores the ordered operations executed inside each Monte Carlo replication.
+
+__Rules:__
+
+| __Rule__ | __Description__ |
+|:---------|----------------:|
+| One data-generation step | The first step must have `op_type=OpType.DATAGEN`. |
+| No later data-generation steps | Only one `DATAGEN` step is supported. |
+| Unique step names | Each step name must be unique because names are used as payload and result keys. |
+| Per-replication payloads | Steps may pass results through `MCContext.payloads` inside the same replication. Aggregate summaries are created after all successful replications finish. |
+
+__Methods:__
+
+```python
+MCPipeline.run(
+    *,
+    reference: SolvedModel,
+    dgp: SolvedModel | None = None,
+    n_rep: int,
+    retain_payloads: bool = True,
+    retain_test_results: bool = True,
+    retain_contexts: bool = False,
+    fail_fast: bool = True,
+) -> MCPipelineResult
+```
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| reference | Reference `SolvedModel` used by reference-side operations such as Kalman filtering. |
+| dgp | Optional DGP `SolvedModel`. Required by `simulation_step`, but not required by `raw_data_step`. |
+| n_rep | Number of Monte Carlo replications. |
+| retain_payloads | Store each successful replication's payload dictionary in the result container. |
+| retain_test_results | Store scalar `TestResult` objects from each successful replication. |
+| retain_contexts | Store full `MCContext` objects. This is useful for debugging and memory-heavy for large runs. |
+| fail_fast | If `True`, raise on the first failed replication. If `False`, collect `MCFailure` entries and summarize successful replications. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python MCPipelineResult` | Aggregate container with test summaries, optional per-replication payloads, optional scalar test results, optional contexts, and failures. |

--- a/docs/documentation/monte_carlo/result_access.md
+++ b/docs/documentation/monte_carlo/result_access.md
@@ -1,0 +1,24 @@
+---
+tags:
+    - doc
+---
+# Result Access
+
+`MCPipelineResult.summaries` maps each test step name to an `MCResult` aggregate.
+
+__Summary Fields and Methods:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| statistic_trace | `#!python ndarray` | Test statistic from each successful replication. |
+| pval_trace | `#!python ndarray` | Vectorized p-values for `statistic_trace`. |
+| mean_statistic | `#!python float64` | Mean test statistic over successful replications. |
+| mean_pval | `#!python float64` | Mean p-value over successful replications. |
+| rejection_rate | `#!python float64` | Share of p-values below `alpha`. |
+| pval_confidence_interval(...) | `#!python tuple[float64, float64]` | Confidence interval for the rejection rate. |
+| statistic_confidence_interval(...) | `#!python tuple[float64, float64]` | Confidence interval for the mean test statistic. |
+
+If `retain_test_results=True`, `MCPipelineResult.test_results` stores scalar per-replication `TestResult` objects keyed by test step name.
+
+???+ warning "Retention and Memory Use"
+    `retain_contexts=True` and `retain_payloads=True` can store large arrays from every successful replication. For large Monte Carlo runs, prefer retaining aggregate summaries and scalar test results unless full per-replication payloads are needed for debugging or downstream analysis.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,12 @@ nav:
       - Shock: documentation/Shock.md
       - KalmanConfig: documentation/KalmanConfig.md
       - FilterResult: documentation/FilterResult.md
+      - Monte Carlo:
+          - Overview: documentation/monte_carlo/index.md
+          - MCPipeline: documentation/monte_carlo/pipeline.md
+          - Core Containers: documentation/monte_carlo/core_containers.md
+          - Built-In Steps: documentation/monte_carlo/built_in_steps.md
+          - Result Access: documentation/monte_carlo/result_access.md
       - Prior Specification:
           - Prior: documentation/prior_spec/Prior.md
           - Distributions:


### PR DESCRIPTION
Add comprehensive documentation for the monte_carlo module: new docs files include index.md (overview), pipeline.md (MCPipeline usage), core_containers.md (MCStep, MCData, MCContext, MCPipelineResult), built_in_steps.md (simulation, raw data, reference filter, Wald test, transform steps), and result_access.md (accessing MCPipelineResult summaries). Also update mkdocs.yml to include the new Monte Carlo pages in the site navigation.