### PR TITLE
Ljung-Box test with Monte Carlo support.

### DIFF
--- a/SymbolicDSGE/_diag_tests/ljung_box.py
+++ b/SymbolicDSGE/_diag_tests/ljung_box.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy import float64
+from numpy.typing import NDArray
+from numba import njit
+
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.result import TestResult
+
+from .status import TestStatus
+
+NDF = NDArray[float64]
+LOOP_LIMIT_N = 1e6
+
+OK = int(TestStatus.OK)
+UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
+BAD_SHAPE = int(TestStatus.BAD_SHAPE)
+BAD_LAG = int(TestStatus.BAD_LAG)
+
+
+@njit(cache=True)
+def acorr(x: NDF, L: int) -> tuple[int, NDF]:
+    """Autocorrelation of x up to lag L."""
+    n = x.size
+    out = np.empty(L + 1, dtype=float64)
+
+    mu = 0.0
+    denom = 0.0
+    z = np.empty_like(x)
+
+    if n <= LOOP_LIMIT_N:
+        for i in range(n):
+            mu += x[i]
+        mu /= n
+
+        for i in range(n):
+            z[i] = x[i] - mu
+            denom += z[i] * z[i]
+
+    else:
+        mu = x.mean()
+        z = x - mu
+        denom = np.dot(z, z)
+
+    if denom <= 0.0:
+        for ell in range(L + 1):
+            out[ell] = np.nan
+        return UDEF_VARIANCE, out
+
+    out[0] = 1.0  # L0
+
+    for ell in range(1, L + 1):
+        num = 0.0
+        for t in range(ell, n):
+            num += z[t] * z[t - ell]
+        out[ell] = num / denom
+    return OK, out
+
+
+@njit(cache=True)
+def lb_stat(x: NDF, L: int) -> tuple[int, float64]:
+    """Ljung-Box test statistic for x up to lag L."""
+    if x.ndim != 1:
+        return BAD_SHAPE, float64(np.nan)
+
+    n = x.size
+    if n <= 1:
+        return UDEF_VARIANCE, float64(np.nan)
+
+    if L >= n:
+        L = n - 1
+    if L <= 0:
+        return BAD_LAG, float64(np.nan)
+
+    err, rho = acorr(x, L)
+    if err != OK:
+        return err, float64(np.nan)  # type(np.nan) == float
+
+    n = x.size
+    stat = 0.0
+    for ell in range(1, L + 1):
+        stat += (rho[ell] * rho[ell]) / (n - ell)
+    stat *= n * (n + 2)
+    return OK, float64(stat)
+
+
+def ljung_box(x: NDF, L: int, alpha: float = 0.05) -> TestResult:
+    """Ljung-Box test for x up to lag L."""
+    err, stat = lb_stat(x, L)
+    name = f"Ljung-Box (L={L})"
+    return TestResult(
+        test_name=name,
+        statistic=stat,
+        dist=ReferenceDistribution.CHI2,
+        pval_method=PvalMethod.SF,
+        df=L,
+        alpha=float64(alpha),
+        status=TestStatus(err),
+        _auto_pval=True,
+    )

--- a/SymbolicDSGE/_diag_tests/ljung_box.py
+++ b/SymbolicDSGE/_diag_tests/ljung_box.py
@@ -5,9 +5,8 @@ from numpy import float64
 from numpy.typing import NDArray
 from numba import njit
 
-from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
-from SymbolicDSGE._diag_tests.result import TestResult
-
+from .distributions import PvalMethod, ReferenceDistribution
+from .result import TestResult
 from .status import TestStatus
 
 NDF = NDArray[float64]
@@ -88,13 +87,16 @@ def lb_stat(x: NDF, L: int) -> tuple[int, float64]:
 def ljung_box(x: NDF, L: int, alpha: float = 0.05) -> TestResult:
     """Ljung-Box test for x up to lag L."""
     err, stat = lb_stat(x, L)
-    name = f"Ljung-Box (L={L})"
+    df = L
+    if x.ndim == 1 and x.size > 1 and L >= x.size:
+        df = x.size - 1
+    name = f"Ljung-Box (L={df})"
     return TestResult(
         test_name=name,
         statistic=stat,
         dist=ReferenceDistribution.CHI2,
         pval_method=PvalMethod.SF,
-        df=L,
+        df=df,
         alpha=float64(alpha),
         status=TestStatus(err),
         _auto_pval=True,

--- a/SymbolicDSGE/_diag_tests/result.py
+++ b/SymbolicDSGE/_diag_tests/result.py
@@ -11,6 +11,7 @@ from .distributions import (
     PvalMethod,
     ReferenceDistribution,
 )
+from .status import TestStatus
 
 DfSpec = FloatScalar | Sequence[FloatScalar] | NDArray[float64]
 NormalizedDf = float64 | tuple[float64, ...]
@@ -65,6 +66,7 @@ class TestResult:
     pval_method: PvalMethod
     alpha: float64
     statistic: float64
+    status: TestStatus
     _auto_pval: bool = field(default=True, repr=False, compare=False)
 
     _frozen_dist: FrozenDistribution | None = field(
@@ -76,6 +78,7 @@ class TestResult:
         statistic = float64(self.statistic)
         object.__setattr__(self, "statistic", statistic)
         object.__setattr__(self, "df", _normalize_df(self.df))
+        object.__setattr__(self, "status", TestStatus(self.status))
 
         if self._auto_pval:
             self.compute_pval()
@@ -134,6 +137,7 @@ class TestResult:
             "pval_method": self.pval_method.value,
             "alpha": self.alpha,
             "statistic": self.statistic,
+            "status": self.status,
             "pval": self.pval,
         }
 

--- a/SymbolicDSGE/_diag_tests/status.py
+++ b/SymbolicDSGE/_diag_tests/status.py
@@ -1,0 +1,11 @@
+from enum import IntEnum
+
+
+class TestStatus(IntEnum):
+    __test__ = False
+
+    OK = 0
+    BAD_SHAPE = -1
+    LINALG = -2
+    UDEF_VARIANCE = -3
+    BAD_LAG = -4

--- a/SymbolicDSGE/_diag_tests/wald_test.py
+++ b/SymbolicDSGE/_diag_tests/wald_test.py
@@ -2,6 +2,7 @@ from .hac_covariance import jit_hac_estimator_loop_into, hac_covariance
 from .moment_calculation_utils import jit_fill_centered, jit_fill_mean_ax0
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
+from .status import TestStatus
 import numpy as np
 from numpy import float64, int64
 from numpy.typing import NDArray
@@ -12,9 +13,9 @@ from typing import Callable, Literal
 
 NDF = NDArray[float64]
 
-OK = int64(0)
-ERR_BAD_SHAPE = int64(-1)
-ERR_LINALG = int64(-2)
+OK = int64(TestStatus.OK)
+ERR_BAD_SHAPE = int64(TestStatus.BAD_SHAPE)
+ERR_LINALG = int64(TestStatus.LINALG)
 
 F64_NAN = float64(np.nan)
 
@@ -191,6 +192,7 @@ def wald_mean_hac(
         statistic=stat,
         pval_method=PvalMethod.SF,
         alpha=float64(alpha),
+        status=TestStatus.OK,
         _auto_pval=_auto_pval,
     )
     return res
@@ -273,6 +275,7 @@ def wald_covariance_hac(
         statistic=stat,
         pval_method=PvalMethod.SF,
         alpha=float64(alpha),
+        status=TestStatus.OK,
         _auto_pval=_auto_pval,
     )
     return res
@@ -350,6 +353,7 @@ def wald_second_moment_hac(
         statistic=stat,
         pval_method=PvalMethod.SF,
         alpha=float64(alpha),
+        status=TestStatus.OK,
         _auto_pval=_auto_pval,
     )
     return res

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -7,10 +7,12 @@ from .config import (
     run_reference_filter,
     run_regression,
     run_wald_test,
+    run_ljung_box_test,
     simulate_dgp,
     simulation_step,
     transform_step,
     wald_test_step,
+    ljung_box_test_step,
 )
 from .core import MCPipeline
 from .mc_constructs import (
@@ -50,8 +52,10 @@ __all__ = [
     "run_reference_filter",
     "run_regression",
     "run_wald_test",
+    "run_ljung_box_test",
     "simulate_dgp",
     "simulation_step",
     "transform_step",
     "wald_test_step",
+    "ljung_box_test_step",
 ]

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -11,6 +11,8 @@ from .._diag_tests.wald_test import (
     wald_mean_hac,
     wald_second_moment_hac,
 )
+from .._diag_tests.ljung_box import ljung_box
+
 from ..core.shock_generators import Shock
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
@@ -193,17 +195,7 @@ def run_wald_test(
     reference: SolvedModel,
     dgp: SolvedModel | None,
     rep_idx: int,
-    source: Literal[
-        "states",
-        "observables",
-        "x_pred",
-        "x_filt",
-        "y_pred",
-        "y_filt",
-        "innov",
-        "std_innov",
-        "payload",
-    ],
+    source: InpSources,
     target: NDF,
     kind: Literal["mean", "covariance", "second_moment"] = "mean",
     filter_key: str = "filter",
@@ -254,6 +246,47 @@ def run_wald_test(
             _auto_pval=False,
         )
     raise ValueError(f"Unsupported Wald test kind: {kind}")
+
+
+def run_ljung_box_test(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    column: Sequence[int] | int | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    lags: int = 10,
+    alpha: float = 0.05,
+) -> TestResult:
+    del reference, dgp, rep_idx
+
+    col_idx: Sequence[int] | None
+    if isinstance(column, int):
+        col_idx = [column]
+    else:
+        col_idx = column
+
+    arr = _resolve_context_array(
+        context,
+        source=source,
+        filter_key=filter_key,
+        payload_key=payload_key,
+        columns=col_idx,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    n = arr.size  # size == n iff 1D array
+    if any(arr.shape == shape for shape in [(n,), (n, 1), (1, n)]):
+        arr = arr.flatten()
+    else:
+        raise ValueError("Ljung-Box test requires a single column of data.")
+
+    return ljung_box(arr, L=lags, alpha=alpha)
 
 
 def run_regression(
@@ -349,6 +382,12 @@ def reference_filter_step(name: str = "filter", **kwargs: Any) -> MCStep:
 
 def wald_test_step(name: str, **kwargs: Any) -> MCStep:
     return MCStep(name=name, op_type=OpType.TEST, func=run_wald_test, kwargs=kwargs)
+
+
+def ljung_box_test_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(
+        name=name, op_type=OpType.TEST, func=run_ljung_box_test, kwargs=kwargs
+    )
 
 
 def regression_step(name: str, **kwargs: Any) -> MCStep:

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -280,13 +280,10 @@ def run_ljung_box_test(
         burn_in=burn_in,
         drop_initial=drop_initial,
     )
-    n = arr.size  # size == n iff 1D array
-    if any(arr.shape == shape for shape in [(n,), (n, 1), (1, n)]):
-        arr = arr.flatten()
-    else:
+    if arr.shape[1] != 1:
         raise ValueError("Ljung-Box test requires a single column of data.")
 
-    return ljung_box(arr, L=lags, alpha=alpha)
+    return ljung_box(arr[:, 0], L=lags, alpha=alpha)
 
 
 def run_regression(

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -144,7 +144,7 @@ class MCPipeline:
         if step.op_type is OpType.REGRESSION and not isinstance(out, OLSResult):
             raise TypeError("REGRESSION steps must return OLSResult.")
         if step.op_type is OpType.REGRESSION:
-            context.regressions[step.name] = out
+            context.regressions[step.name] = out  # pyright: ignore
         if step.op_type is OpType.TEST:
             if not isinstance(out, TestResult):
                 raise TypeError("TEST steps must return TestResult.")

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -12,7 +12,7 @@ from .._diag_tests.result import MCResult, TestResult
 from ..core.shock_generators import Shock
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
-from ..regression.ols import MCRegressionResult, OLSResult, Status
+from ..regression.ols import MCRegressionResult, OLSResult, RegressionStatus
 
 NDF = NDArray[float64]
 NDB = NDArray[np.bool_]
@@ -202,7 +202,9 @@ class MCPipelineResult:
         }
 
     @property
-    def regression_status_traces(self) -> Mapping[str, tuple[Status, ...]]:
+    def regression_status_traces(
+        self,
+    ) -> Mapping[str, tuple[RegressionStatus, ...]]:
         return {
             name: summary.status_trace
             for name, summary in self.regression_summaries.items()

--- a/SymbolicDSGE/regression/ols/__init__.py
+++ b/SymbolicDSGE/regression/ols/__init__.py
@@ -1,9 +1,9 @@
-from .ols_result import MCRegressionResult, OLSResult, Status
+from .ols_result import MCRegressionResult, OLSResult, RegressionStatus
 from .core import ols
 
 __all__ = [
     "MCRegressionResult",
     "OLSResult",
-    "Status",
+    "RegressionStatus",
     "ols",
 ]

--- a/SymbolicDSGE/regression/ols/core.py
+++ b/SymbolicDSGE/regression/ols/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .ols_result import OLSResult, Status
+from .ols_result import OLSResult, RegressionStatus
 from .solvers import chol_solve, ltsq_solve
 
 from numpy import float64
@@ -23,6 +23,6 @@ def ols(x: NDF, y: NDF, variables: list[str] | None = None) -> OLSResult:
         coefficients=coef,
         y=y,
         x=x,
-        status=Status(status),
+        status=RegressionStatus(status),
         _L=L,
     )

--- a/SymbolicDSGE/regression/ols/ols_result.py
+++ b/SymbolicDSGE/regression/ols/ols_result.py
@@ -5,6 +5,7 @@ from SymbolicDSGE._diag_tests.distributions import (
     ReferenceDistribution,
     PvalMethod,
 )
+from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE.regression.ols.diag_utils import r2, r2_adj, se
 from ..._diag_tests.result import MCResult, TestResult
 
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 NDF = NDArray[float64]
 
 
-class Status(IntEnum):
+class RegressionStatus(IntEnum):
     OK = 0
     RANK_DEFICIENT = -1
 
@@ -42,7 +43,7 @@ class OLSResult:
     k: int = field(init=False)
 
     # Meta
-    status: Status
+    status: RegressionStatus
     _L: NDF = field(repr=False)
 
     def __post_init__(self) -> None:
@@ -127,6 +128,7 @@ class OLSResult:
             pval_method=PvalMethod.SF,
             alpha=float64(alpha),
             statistic=F_stat,
+            status=TestStatus.OK,
             _auto_pval=True,
         )
 
@@ -140,7 +142,7 @@ class MCRegressionResult:
     results: tuple[OLSResult, ...] = field(repr=False)
 
     coef_trace: NDF = field(init=False)
-    status_trace: tuple[Status, ...] = field(init=False)
+    status_trace: tuple[RegressionStatus, ...] = field(init=False)
     n_rep: int = field(init=False)
     n: int = field(init=False)
     k: int = field(init=False)
@@ -163,7 +165,7 @@ class MCRegressionResult:
             )
 
         coef_trace: list[NDF] = []
-        status_trace: list[Status] = []
+        status_trace: list[RegressionStatus] = []
         for result in results:
             if result.variables != variables:
                 raise ValueError("MC regression results have incompatible variables.")

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -2,10 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 1,
    "id": "8b55608d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Detected IPython. Loading juliacall extension. See https://juliapy.github.io/PythonCall.jl/stable/compat/#IPython\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -15,6 +23,7 @@
     "    MCPipeline,\n",
     "    reference_filter_step,\n",
     "    simulation_step,\n",
+    "    ljung_box_test_step,\n",
     "    wald_test_step,\n",
     "    regression_step,\n",
     ")"
@@ -22,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 2,
    "id": "fbd00cbe",
    "metadata": {},
    "outputs": [],
@@ -46,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 7,
    "id": "7868d0e5",
    "metadata": {},
    "outputs": [],
@@ -72,6 +81,27 @@
     "            kind=\"mean\",\n",
     "            burn_in=20,\n",
     "        ),\n",
+    "        ljung_box_test_step(\n",
+    "            \"OGap_autocorr\",\n",
+    "            source=\"std_innov\",\n",
+    "            column=0,\n",
+    "            lags=10,\n",
+    "            burn_in=20,\n",
+    "        ),\n",
+    "        ljung_box_test_step(\n",
+    "            \"Infl_autocorr\",\n",
+    "            source=\"std_innov\",\n",
+    "            column=1,\n",
+    "            lags=10,\n",
+    "            burn_in=20,\n",
+    "        ),\n",
+    "        ljung_box_test_step(\n",
+    "            \"Rate_autocorr\",\n",
+    "            source=\"std_innov\",\n",
+    "            column=2,\n",
+    "            lags=10,\n",
+    "            burn_in=20,\n",
+    "        ),\n",
     "        wald_test_step(\n",
     "            \"std_innov_second_moment\",\n",
     "            source=\"std_innov\",\n",
@@ -93,17 +123,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 12,
    "id": "c4a12aa7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(True, 100000)"
+       "(True, 10000)"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -112,7 +142,7 @@
     "mc = pipeline.run(\n",
     "    reference=reference,\n",
     "    dgp=dgp,\n",
-    "    n_rep=100_000,\n",
+    "    n_rep=10000,\n",
     "    retain_payloads=False,\n",
     "    retain_test_results=False,\n",
     ")\n",
@@ -122,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 13,
    "id": "48110503",
    "metadata": {},
    "outputs": [
@@ -157,18 +187,42 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>std_innov_mean</th>\n",
-       "      <td>2.739</td>\n",
-       "      <td>0.55</td>\n",
-       "      <td>0.051</td>\n",
-       "      <td>0.05</td>\n",
-       "      <td>0.052</td>\n",
+       "      <td>2.700</td>\n",
+       "      <td>0.554</td>\n",
+       "      <td>0.048</td>\n",
+       "      <td>0.044</td>\n",
+       "      <td>0.053</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>OGap_autocorr</th>\n",
+       "      <td>25.265</td>\n",
+       "      <td>0.033</td>\n",
+       "      <td>0.815</td>\n",
+       "      <td>0.808</td>\n",
+       "      <td>0.823</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Infl_autocorr</th>\n",
+       "      <td>32.467</td>\n",
+       "      <td>0.005</td>\n",
+       "      <td>0.982</td>\n",
+       "      <td>0.980</td>\n",
+       "      <td>0.985</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Rate_autocorr</th>\n",
+       "      <td>12.583</td>\n",
+       "      <td>0.362</td>\n",
+       "      <td>0.142</td>\n",
+       "      <td>0.135</td>\n",
+       "      <td>0.149</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std_innov_second_moment</th>\n",
-       "      <td>722.509</td>\n",
-       "      <td>0.00</td>\n",
+       "      <td>723.430</td>\n",
+       "      <td>0.000</td>\n",
        "      <td>1.000</td>\n",
-       "      <td>1.00</td>\n",
+       "      <td>1.000</td>\n",
        "      <td>1.000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -177,15 +231,21 @@
       ],
       "text/plain": [
        "                         mean_statistic  mean_pval  rejection_rate  ci_low  \\\n",
-       "std_innov_mean                    2.739       0.55           0.051    0.05   \n",
-       "std_innov_second_moment         722.509       0.00           1.000    1.00   \n",
+       "std_innov_mean                    2.700      0.554           0.048   0.044   \n",
+       "OGap_autocorr                    25.265      0.033           0.815   0.808   \n",
+       "Infl_autocorr                    32.467      0.005           0.982   0.980   \n",
+       "Rate_autocorr                    12.583      0.362           0.142   0.135   \n",
+       "std_innov_second_moment         723.430      0.000           1.000   1.000   \n",
        "\n",
        "                         ci_high  \n",
-       "std_innov_mean             0.052  \n",
+       "std_innov_mean             0.053  \n",
+       "OGap_autocorr              0.823  \n",
+       "Infl_autocorr              0.985  \n",
+       "Rate_autocorr              0.149  \n",
        "std_innov_second_moment    1.000  "
       ]
      },
-     "execution_count": 44,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -208,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 11,
    "id": "8fd2a185",
    "metadata": {},
    "outputs": [
@@ -216,9 +276,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:241: RuntimeWarning: divide by zero encountered in divide\n",
+      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:243: RuntimeWarning: divide by zero encountered in divide\n",
       "  return np.asarray(self.coef_trace / self.se_trace, dtype=np.float64)\n",
-      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:241: RuntimeWarning: invalid value encountered in divide\n",
+      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:243: RuntimeWarning: invalid value encountered in divide\n",
       "  return np.asarray(self.coef_trace / self.se_trace, dtype=np.float64)\n"
      ]
     },
@@ -229,13 +289,13 @@
        "       [-9.02108236e+00,  1.20414017e+16, -8.66127074e+00],\n",
        "       [ 6.23597534e+00,  9.79023680e+15,  1.19236384e+01],\n",
        "       ...,\n",
-       "       [-1.26734612e+01,  7.59721111e+15,  2.64252436e+00],\n",
-       "       [ 4.03000697e+00,  3.33538808e+16,  1.02339460e+01],\n",
-       "       [-1.07428930e+01,  2.17203879e+16,  1.03783222e+01]],\n",
-       "      shape=(100000, 3))"
+       "       [ 1.40651523e+01,  1.40077306e+16, -1.68391717e+00],\n",
+       "       [-5.21561551e+00,  2.51389192e+16, -1.21344348e+01],\n",
+       "       [-6.97955443e+00,  9.20164848e+15, -9.43444567e+00]],\n",
+       "      shape=(500, 3))"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -111,7 +111,7 @@ __Fields and Properties:__
 | pval_traces | `#!python Mapping[str, ndarray]` | Shortcut for each test summary's p-value trace. |
 | rejection_traces | `#!python Mapping[str, ndarray]` | Boolean rejection trace for each test summary. |
 | coefficient_traces | `#!python Mapping[str, ndarray]` | Shortcut for each regression summary's coefficient trace. |
-| regression_status_traces | `#!python Mapping[str, tuple[Status, ...]]` | Shortcut for each regression summary's status trace. |
+| regression_status_traces | `#!python Mapping[str, tuple[RegressionStatus, ...]]` | Shortcut for each regression summary's status trace. |
 
 ???+ note "P-Value Evaluation"
     Scalar `TestResult` objects produced inside Monte Carlo Wald steps defer p-value and frozen-distribution construction until `pval`, `frozen_dist`, or `compute_pval()` is accessed. Aggregate `MCResult` objects compute vectorized p-values when `MCPipelineResult.test_summaries` is built.

--- a/tests/diag_tests/test_ljung_box.py
+++ b/tests/diag_tests/test_ljung_box.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import chi2
+
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.ljung_box import (
+    BAD_LAG,
+    BAD_SHAPE,
+    OK,
+    UDEF_VARIANCE,
+    acorr,
+    lb_stat,
+    ljung_box,
+)
+from SymbolicDSGE._diag_tests.status import TestStatus
+
+
+def _manual_acorr(x: np.ndarray, L: int) -> np.ndarray:
+    z = x - x.mean()
+    denom = z @ z
+    out = np.empty(L + 1, dtype=np.float64)
+    out[0] = 1.0
+    for ell in range(1, L + 1):
+        out[ell] = (z[ell:] @ z[:-ell]) / denom
+    return out
+
+
+def _manual_ljung_box(x: np.ndarray, L: int) -> float:
+    rho = _manual_acorr(x, L)
+    n = x.size
+    out = 0.0
+    for ell in range(1, L + 1):
+        out += rho[ell] ** 2 / (n - ell)
+    return n * (n + 2) * out
+
+
+def test_acorr_matches_manual_autocorrelation() -> None:
+    x = np.array([1.0, 2.0, 0.0, 4.0, 3.0], dtype=np.float64)
+    L = 3
+
+    err, out = acorr(x, L)
+
+    assert err == OK
+    assert OK == TestStatus.OK
+    np.testing.assert_allclose(out, _manual_acorr(x, L))
+
+
+def test_acorr_reports_undefined_variance_for_constant_series() -> None:
+    err, out = acorr(np.ones(5, dtype=np.float64), 2)
+
+    assert err == UDEF_VARIANCE
+    assert UDEF_VARIANCE == TestStatus.UDEF_VARIANCE
+    assert np.isnan(out).all()
+
+
+def test_lb_stat_matches_manual_ljung_box_statistic() -> None:
+    x = np.array([1.0, 2.0, 0.0, 4.0, 3.0, -1.0], dtype=np.float64)
+    L = 3
+
+    err, stat = lb_stat(x, L)
+
+    assert err == OK
+    assert stat == pytest.approx(_manual_ljung_box(x, L))
+
+
+def test_lb_stat_caps_lag_at_available_observations() -> None:
+    x = np.array([1.0, 2.0, 0.0, 4.0], dtype=np.float64)
+
+    err, stat = lb_stat(x, 20)
+
+    assert err == OK
+    assert stat == pytest.approx(_manual_ljung_box(x, x.size - 1))
+
+
+def test_lb_stat_reports_input_status_codes() -> None:
+    err, stat = lb_stat(np.ones((2, 2), dtype=np.float64), 1)
+    assert err == BAD_SHAPE
+    assert BAD_SHAPE == TestStatus.BAD_SHAPE
+    assert np.isnan(stat)
+
+    err, stat = lb_stat(np.array([1.0], dtype=np.float64), 1)
+    assert err == UDEF_VARIANCE
+    assert np.isnan(stat)
+
+    err, stat = lb_stat(np.array([1.0, 2.0], dtype=np.float64), 0)
+    assert err == BAD_LAG
+    assert BAD_LAG == TestStatus.BAD_LAG
+    assert np.isnan(stat)
+
+
+def test_ljung_box_builds_chi_square_test_result() -> None:
+    x = np.array([1.0, 2.0, 0.0, 4.0, 3.0, -1.0], dtype=np.float64)
+    L = 3
+
+    out = ljung_box(x, L=L, alpha=0.1)
+    expected_stat = _manual_ljung_box(x, L)
+
+    assert out.test_name == "Ljung-Box (L=3)"
+    assert out.dist is ReferenceDistribution.CHI2
+    assert out.pval_method is PvalMethod.SF
+    assert out.df == np.float64(3.0)
+    assert out.alpha == np.float64(0.1)
+    assert out.status is TestStatus.OK
+    assert out.statistic == pytest.approx(expected_stat)
+    assert out.pval == pytest.approx(chi2(df=3).sf(expected_stat))
+
+
+def test_ljung_box_reports_effective_lag_in_df_and_name() -> None:
+    x = np.array([1.0, 2.0, 0.0, 4.0], dtype=np.float64)
+
+    out = ljung_box(x, L=20)
+
+    assert out.test_name == "Ljung-Box (L=3)"
+    assert out.df == np.float64(3.0)
+    assert out.statistic == pytest.approx(_manual_ljung_box(x, 3))
+    assert out.pval == pytest.approx(chi2(df=3).sf(out.statistic))
+
+
+def test_ljung_box_returns_status_for_invalid_lag_without_raising() -> None:
+    out = ljung_box(np.array([1.0, 2.0], dtype=np.float64), L=0)
+
+    assert out.status is TestStatus.BAD_LAG
+    assert np.isnan(out.statistic)
+    assert np.isnan(out.pval)

--- a/tests/diag_tests/test_result.py
+++ b/tests/diag_tests/test_result.py
@@ -6,6 +6,7 @@ from scipy.stats import chi2, f
 
 from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
 from SymbolicDSGE._diag_tests.result import MCResult, TestResult as DiagTestResult
+from SymbolicDSGE._diag_tests.status import TestStatus
 
 
 def test_test_result_computes_p_value_from_reference_distribution() -> None:
@@ -16,10 +17,12 @@ def test_test_result_computes_p_value_from_reference_distribution() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic=np.float64(10.0),
+        status=TestStatus.OK,
     )
 
     assert out.pval == pytest.approx(chi2(df=2).sf(10.0))
     assert out.is_significant()
+    assert out.status is TestStatus.OK
 
 
 def test_test_result_can_defer_p_value_until_requested() -> None:
@@ -30,6 +33,7 @@ def test_test_result_can_defer_p_value_until_requested() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic=np.float64(10.0),
+        status=TestStatus.OK,
         _auto_pval=False,
     )
 
@@ -50,6 +54,7 @@ def test_test_result_supports_multi_df_reference_distribution() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic=np.float64(3.0),
+        status=TestStatus.OK,
     )
 
     assert out.df == (np.float64(2.0), np.float64(10.0))
@@ -64,6 +69,7 @@ def test_test_result_to_dict_excludes_frozen_distribution() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic=np.float64(10.0),
+        status=TestStatus.OK,
     )
 
     assert out.to_dict() == {
@@ -73,6 +79,7 @@ def test_test_result_to_dict_excludes_frozen_distribution() -> None:
         "pval_method": "sf",
         "alpha": np.float64(0.05),
         "statistic": np.float64(10.0),
+        "status": TestStatus.OK,
         "pval": out.pval,
     }
 

--- a/tests/diag_tests/test_wald_test.py
+++ b/tests/diag_tests/test_wald_test.py
@@ -7,6 +7,7 @@ from SymbolicDSGE._diag_tests.hac_covariance import (
     kernel_dispatcher,
     wooldridge_bandwidth,
 )
+from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE._diag_tests.wald_test import (
     ERR_BAD_SHAPE,
     ERR_LINALG,
@@ -105,6 +106,7 @@ def test_jit_wald_hac_stat_matches_manual_statistic() -> None:
     manual_stat = g.shape[0] * manual_mean @ np.linalg.solve(manual_omega, manual_mean)
 
     assert err == OK
+    assert OK == TestStatus.OK
     assert df == 2
     assert np.isclose(stat, manual_stat)
 
@@ -126,6 +128,7 @@ def test_wald_mean_hac_uses_right_tail_p_value_method() -> None:
     out = wald_mean_hac(g, np.zeros(2, dtype=np.float64), bandwidth=0)
 
     assert out.pval_method is PvalMethod.SF
+    assert out.status is TestStatus.OK
 
 
 def test_wald_mean_hac_rejects_large_mean_deviation() -> None:
@@ -226,6 +229,7 @@ def test_jit_wald_hac_stat_returns_shape_error_for_bad_target() -> None:
     )
 
     assert err == ERR_BAD_SHAPE
+    assert ERR_BAD_SHAPE == TestStatus.BAD_SHAPE
     assert np.isnan(stat)
     assert df == 2
 
@@ -254,5 +258,6 @@ def test_jit_wald_stat_from_mean_and_cov_returns_linalg_error_for_singular_covar
     )
 
     assert err == ERR_LINALG
+    assert ERR_LINALG == TestStatus.LINALG
     assert np.isnan(stat)
     assert df == 2

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from SymbolicDSGE import Shock
+from SymbolicDSGE._diag_tests.ljung_box import ljung_box
+from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE._diag_tests.wald_test import wald_mean_hac
 from SymbolicDSGE.kalman.filter import FilterResult
 from SymbolicDSGE.monte_carlo import (
@@ -13,6 +15,7 @@ from SymbolicDSGE.monte_carlo import (
     MCData,
     MCStep,
     OpType,
+    ljung_box_test_step,
     raw_data_step,
     reference_filter_step,
     regression_step,
@@ -178,6 +181,65 @@ def test_raw_data_pipeline_accepts_observables_without_states() -> None:
     assert out.contexts[0].data is not None
     assert out.contexts[0].data.states is None
     np.testing.assert_allclose(out.contexts[0].data.observables, observables[0])
+
+
+def test_ljung_box_pipeline_selects_column_and_aggregates_results() -> None:
+    reference = _FakeSolvedModel()
+    first = np.column_stack(
+        [
+            np.array([1.0, 2.0, 0.0, 4.0, 3.0], dtype=np.float64),
+            np.array([0.0, 1.0, 0.5, -1.0, 2.0], dtype=np.float64),
+        ]
+    )
+    second = np.column_stack(
+        [
+            np.array([2.0, 1.0, 3.0, 0.0, 4.0], dtype=np.float64),
+            np.array([1.5, -0.5, 0.0, 2.5, 1.0], dtype=np.float64),
+        ]
+    )
+    observables = np.stack([first, second])
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables, observable_names=("a", "b")),
+            ljung_box_test_step(
+                "lb_b",
+                source="observables",
+                column=[1],
+                lags=2,
+                alpha=0.1,
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=reference, n_rep=2)
+
+    expected = np.asarray(
+        [ljung_box(observables[i, :, 1], L=2, alpha=0.1).statistic for i in range(2)],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(out.statistic_traces["lb_b"], expected)
+    assert out.test_summaries["lb_b"].n == 2
+    assert out.test_summaries["lb_b"].df == np.float64(2.0)
+    assert out.test_results is not None
+    assert all(result.status is TestStatus.OK for result in out.test_results["lb_b"])
+
+
+def test_ljung_box_pipeline_rejects_multi_column_inputs() -> None:
+    reference = _FakeSolvedModel()
+    observables = np.array([[1.0, 2.0]], dtype=np.float64)
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables, observable_names=("a", "b")),
+            ljung_box_test_step(
+                "lb",
+                source="observables",
+                lags=1,
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="single column"):
+        pipeline.run(reference=reference, n_rep=1)
 
 
 def test_raw_data_pipeline_rejects_empty_raw_data() -> None:

--- a/tests/regression/test_ols_solvers.py
+++ b/tests/regression/test_ols_solvers.py
@@ -7,11 +7,15 @@ from scipy.stats import t
 from SymbolicDSGE._diag_tests.distributions import ReferenceDistribution
 from SymbolicDSGE.regression.ols import MCRegressionResult as ExportedMCRegressionResult
 from SymbolicDSGE.regression.ols import OLSResult as ExportedOLSResult
-from SymbolicDSGE.regression.ols import Status as ExportedStatus
+from SymbolicDSGE.regression.ols import RegressionStatus as ExportedRegressionStatus
 from SymbolicDSGE.regression.ols import ols as exported_ols
 from SymbolicDSGE.regression.ols.diag_utils import r2, r2_adj, se, se_from_pinv
 from SymbolicDSGE.regression.ols.core import ols
-from SymbolicDSGE.regression.ols.ols_result import MCRegressionResult, OLSResult, Status
+from SymbolicDSGE.regression.ols.ols_result import (
+    MCRegressionResult,
+    OLSResult,
+    RegressionStatus,
+)
 from SymbolicDSGE.regression.ols.solvers import (
     OK,
     RANK_DEFICIENT,
@@ -49,7 +53,7 @@ def test_chol_solve_returns_factor_for_standard_error_calculation() -> None:
 def test_ols_package_exports_public_entry_points() -> None:
     assert ExportedOLSResult is OLSResult
     assert ExportedMCRegressionResult is MCRegressionResult
-    assert ExportedStatus is Status
+    assert ExportedRegressionStatus is RegressionStatus
     assert exported_ols is ols
 
 
@@ -70,7 +74,7 @@ def test_ols_core_uses_cholesky_solver_and_default_variable_names() -> None:
 
     expected_coef = np.linalg.solve(x.T @ x, x.T @ y)
     assert out.variables == ["x0", "x1"]
-    assert out.status is Status.OK
+    assert out.status is RegressionStatus.OK
     np.testing.assert_allclose(out.coefficients, expected_coef)
 
 
@@ -90,7 +94,7 @@ def test_ols_core_falls_back_to_lstsq_for_rank_deficient_design() -> None:
 
     expected_coef, *_ = np.linalg.lstsq(x, y, rcond=None)
     assert out.variables == ["const", "x", "two_x"]
-    assert out.status is Status.RANK_DEFICIENT
+    assert out.status is RegressionStatus.RANK_DEFICIENT
     np.testing.assert_allclose(out.coefficients, expected_coef)
 
 
@@ -195,7 +199,7 @@ def test_ols_result_exposes_summary_diagnostics_and_f_test() -> None:
         coefficients=coef,
         y=y,
         x=x,
-        status=Status(status),
+        status=RegressionStatus(status),
         _L=L,
     )
 
@@ -238,7 +242,7 @@ def test_ols_result_exposes_summary_diagnostics_and_f_test() -> None:
 
     as_dict = out.to_dict()
     assert as_dict["variables"] == ["const", "trend"]
-    assert as_dict["status"] == Status.OK
+    assert as_dict["status"] == RegressionStatus.OK
 
 
 def test_rank_deficient_ols_result_uses_pseudoinverse_standard_errors() -> None:
@@ -258,11 +262,11 @@ def test_rank_deficient_ols_result_uses_pseudoinverse_standard_errors() -> None:
         coefficients=coef,
         y=y,
         x=x,
-        status=Status(status),
+        status=RegressionStatus(status),
         _L=L,
     )
 
-    assert out.status is Status.RANK_DEFICIENT
+    assert out.status is RegressionStatus.RANK_DEFICIENT
     np.testing.assert_allclose(out.se, se_from_pinv(x, y, out.y_hat))
 
 
@@ -355,7 +359,7 @@ def test_mc_regression_result_computes_vectorized_diagnostics() -> None:
 
     as_dict = out.to_dict()
     assert as_dict["variables"] == ["const", "trend"]
-    assert as_dict["status_trace"] == (Status.OK, Status.OK)
+    assert as_dict["status_trace"] == (RegressionStatus.OK, RegressionStatus.OK)
 
 
 def test_mc_regression_result_falls_back_to_per_rep_se_for_rank_deficient_runs() -> (
@@ -377,7 +381,10 @@ def test_mc_regression_result_falls_back_to_per_rep_se_for_rank_deficient_runs()
 
     out = MCRegressionResult.from_results(results)
 
-    assert out.status_trace == (Status.RANK_DEFICIENT, Status.RANK_DEFICIENT)
+    assert out.status_trace == (
+        RegressionStatus.RANK_DEFICIENT,
+        RegressionStatus.RANK_DEFICIENT,
+    )
     np.testing.assert_allclose(
         out.se_trace,
         np.vstack([result.se for result in results]),


### PR DESCRIPTION
This pull request introduces the Ljung-Box autocorrelation test to the Monte Carlo pipeline and improves the handling and reporting of test and regression statuses across the codebase. The main changes include implementing the Ljung-Box test, integrating it into the Monte Carlo framework and documentation, and refactoring status enums for clarity and consistency.

**Ljung-Box Test Implementation and Integration:**

* Added a new `ljung_box` test in `SymbolicDSGE/_diag_tests/ljung_box.py`, including efficient autocorrelation and test statistic computation, and returning results as a `TestResult` with status handling.
* Integrated the Ljung-Box test into the Monte Carlo pipeline: added `run_ljung_box_test` and `ljung_box_test_step` in `monte_carlo/config.py`, updated `__init__.py` exports, and demonstrated usage in the documentation notebook. [[1]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaR14-R15) [[2]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaR251-R288) [[3]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaR384-R389) [[4]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R10-R15) [[5]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R55-R60) [[6]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601R26-R34) [[7]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601R84-R104)

**Test Status Handling and Reporting:**

* Introduced a unified `TestStatus` enum in `_diag_tests/status.py` and refactored all test code (`wald_test.py`, `result.py`, etc.) to use this enum for clearer and more robust status reporting in `TestResult`. [[1]](diffhunk://#diff-6bb2f0f331651ff2d2df5c23cf50974aa1e3ced07c15bcb8fa01ce52a9a6ac2eR1-R11) [[2]](diffhunk://#diff-8fa5568eb20718948e4ab7fb67db68f16d5a4cac0e4f9df5300deef609210309R14) [[3]](diffhunk://#diff-8fa5568eb20718948e4ab7fb67db68f16d5a4cac0e4f9df5300deef609210309R69) [[4]](diffhunk://#diff-8fa5568eb20718948e4ab7fb67db68f16d5a4cac0e4f9df5300deef609210309R81) [[5]](diffhunk://#diff-8fa5568eb20718948e4ab7fb67db68f16d5a4cac0e4f9df5300deef609210309R140) [[6]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR5) [[7]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL15-R18) [[8]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR195) [[9]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR278) [[10]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR356) [[11]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6R8) [[12]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6R131)

**Regression Status Refactor:**

* Renamed the regression status enum from `Status` to `RegressionStatus` throughout the regression module for clarity and consistency, updating all relevant type annotations and imports. [[1]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6L28-R29) [[2]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6L45-R46) [[3]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6L143-R145) [[4]](diffhunk://#diff-861f7c5b16056276a93d787573388afb4c57fbce088d102ec240c315d11160c6L166-R168) [[5]](diffhunk://#diff-e478adcc2a86c09dbbaf56b71f0eaa3a18e194ab70b0fbd77d295f6152840054L15-R15) [[6]](diffhunk://#diff-e478adcc2a86c09dbbaf56b71f0eaa3a18e194ab70b0fbd77d295f6152840054L205-R207) [[7]](diffhunk://#diff-1944b9d870e5a4a3694c79f2a8c637608a5ffb71a228df55f86963fe1fc91606L1-R7) [[8]](diffhunk://#diff-44567bdd7a694ade785d704610e53b248a7ee1016f2c5329dec45b3daef85f0cL3-R3) [[9]](diffhunk://#diff-44567bdd7a694ade785d704610e53b248a7ee1016f2c5329dec45b3daef85f0cL26-R26)

**Documentation and Example Updates:**

* Updated the Monte Carlo Jupyter notebook to demonstrate the new Ljung-Box test step, including example usage and output. [[1]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601L5-R16) [[2]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601R26-R34) [[3]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601L49-R58) [[4]](diffhunk://#diff-33832b7bc786817d74509c9201ca93dfc832c9064af622fe71529ecc7b2d9601R84-R104)

**Minor Improvements:**

* Small fixes to context array resolution, type annotations, and error handling to support the new test and status reporting. [[1]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaL196-R198) [[2]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9L147-R147)

These changes collectively add new statistical testing capability, improve result reporting, and make the codebase more robust and maintainable.

closes #76