### PR TITLE
Add Monte Carlo performance reporting and verbosity

### DIFF
--- a/SymbolicDSGE/_diag_tests/ljung_box.py
+++ b/SymbolicDSGE/_diag_tests/ljung_box.py
@@ -84,7 +84,9 @@ def lb_stat(x: NDF, L: int) -> tuple[int, float64]:
     return OK, float64(stat)
 
 
-def ljung_box(x: NDF, L: int, alpha: float = 0.05) -> TestResult:
+def ljung_box(
+    x: NDF, L: int, alpha: float = 0.05, _auto_pval: bool = True
+) -> TestResult:
     """Ljung-Box test for x up to lag L."""
     err, stat = lb_stat(x, L)
     df = L
@@ -99,5 +101,5 @@ def ljung_box(x: NDF, L: int, alpha: float = 0.05) -> TestResult:
         df=df,
         alpha=float64(alpha),
         status=TestStatus(err),
-        _auto_pval=True,
+        _auto_pval=_auto_pval,
     )

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -28,6 +28,8 @@ from .mc_constructs import (
     OpType,
     RegressionOp,
     TestOp,
+    report_mc_performance,
+    report_mc_step_performance,
 )
 
 __all__ = [
@@ -48,6 +50,8 @@ __all__ = [
     "raw_data_datagen",
     "raw_data_step",
     "reference_filter_step",
+    "report_mc_performance",
+    "report_mc_step_performance",
     "regression_step",
     "run_reference_filter",
     "run_regression",

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -283,7 +283,7 @@ def run_ljung_box_test(
     if arr.shape[1] != 1:
         raise ValueError("Ljung-Box test requires a single column of data.")
 
-    return ljung_box(arr[:, 0], L=lags, alpha=alpha)
+    return ljung_box(arr[:, 0], L=lags, alpha=alpha, _auto_pval=False)
 
 
 def run_regression(

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from time import perf_counter
 from typing import Mapping, Sequence
 
 import numpy as np
@@ -17,6 +18,8 @@ from .mc_constructs import (
     MCPipelineResult,
     MCStep,
     OpType,
+    report_mc_performance,
+    report_mc_step_performance,
 )
 
 
@@ -54,28 +57,45 @@ class MCPipeline:
         retain_test_results: bool = True,
         retain_contexts: bool = False,
         fail_fast: bool = True,
+        verbosity: int = 1,
     ) -> MCPipelineResult:
         if n_rep <= 0:
             raise ValueError("n_rep must be positive.")
+        if verbosity not in (0, 1, 2):
+            raise ValueError("verbosity must be 0, 1, or 2.")
 
         contexts: list[MCContext] = []
         payload_traces: list[Mapping[str, object]] = []
         failures: list[MCFailure] = []
         results_by_step: dict[str, list[TestResult]] = {}
         regression_results_by_step: dict[str, list[OLSResult]] = {}
+        step_elapsed_s: dict[str, float] = {step.name: 0.0 for step in self.steps}
+        step_counts: dict[str, int] = {step.name: 0 for step in self.steps}
+        step_failures: dict[str, int] = {step.name: 0 for step in self.steps}
 
+        run_start = perf_counter()
         for rep_idx in range(n_rep):
             context = MCContext(rep_idx=rep_idx, reference=reference, dgp=dgp)
+            failed_step_name: str | None = None
             try:
                 for step in self.steps:
-                    self._run_step(context, step)
+                    failed_step_name = step.name
+                    step_start = perf_counter()
+                    try:
+                        self._run_step(context, step)
+                    except Exception:
+                        step_failures[step.name] += 1
+                        raise
+                    finally:
+                        step_elapsed_s[step.name] += perf_counter() - step_start
+                        step_counts[step.name] += 1
             except Exception as exc:
                 if fail_fast:
                     raise
                 failures.append(
                     MCFailure(
                         rep_idx=rep_idx,
-                        step_name=step.name,  # pyright: ignore
+                        step_name=failed_step_name or "",
                         error_type=type(exc).__name__,
                         message=str(exc),
                     )
@@ -94,7 +114,8 @@ class MCPipeline:
 
         test_summaries = _summarize_tests(results_by_step)
         regression_summaries = _summarize_regressions(regression_results_by_step)
-        return MCPipelineResult(
+        elapsed_s = perf_counter() - run_start
+        result = MCPipelineResult(
             n_rep=n_rep,
             n_successful=len(contexts),
             test_summaries=test_summaries,
@@ -107,7 +128,16 @@ class MCPipeline:
             contexts=tuple(contexts) if retain_contexts else None,
             failures=tuple(failures),
             regression_summaries=regression_summaries,
+            elapsed_s=elapsed_s,
+            step_elapsed_s=step_elapsed_s,
+            step_counts=step_counts,
+            step_failures=step_failures,
         )
+        if verbosity == 1:
+            report_mc_performance(result)
+        elif verbosity == 2:
+            report_mc_step_performance(result)
+        return result
 
     def _run_step(self, context: MCContext, step: MCStep) -> None:
         kwargs = dict(step.kwargs)

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -169,10 +169,42 @@ class MCPipelineResult:
     contexts: tuple[MCContext, ...] | None
     failures: tuple[MCFailure, ...] = ()
     regression_summaries: Mapping[str, MCRegressionResult] = field(default_factory=dict)
+    elapsed_s: float = 0.0
+    step_elapsed_s: Mapping[str, float] = field(default_factory=dict)
+    step_counts: Mapping[str, int] = field(default_factory=dict)
+    step_failures: Mapping[str, int] = field(default_factory=dict)
 
     @property
     def succeeded(self) -> bool:
         return len(self.failures) == 0
+
+    @property
+    def it_s(self) -> float:
+        return _iterations_per_second(self.n_rep, self.elapsed_s)
+
+    @property
+    def step_it_s(self) -> Mapping[str, float]:
+        return {
+            name: _iterations_per_second(
+                self.step_counts.get(name, 0),
+                elapsed_s,
+            )
+            for name, elapsed_s in self.step_elapsed_s.items()
+        }
+
+    def report_performance(
+        self,
+        *,
+        print_func: Callable[[str], None] = print,
+    ) -> None:
+        report_mc_performance(self, print_func=print_func)
+
+    def report_step_performance(
+        self,
+        *,
+        print_func: Callable[[str], None] = print,
+    ) -> None:
+        report_mc_step_performance(self, print_func=print_func)
 
     @property
     def statistic_traces(self) -> Mapping[str, NDF]:
@@ -209,3 +241,40 @@ class MCPipelineResult:
             name: summary.status_trace
             for name, summary in self.regression_summaries.items()
         }
+
+
+def _iterations_per_second(n_iter: int, elapsed_s: float) -> float:
+    if n_iter == 0:
+        return 0.0
+    if elapsed_s <= 0.0:
+        return float("inf")
+    return n_iter / elapsed_s
+
+
+def _conclusion_word(succeeded: bool) -> str:
+    return "successfully" if succeeded else "unsuccessfully"
+
+
+def report_mc_performance(
+    result: MCPipelineResult,
+    *,
+    print_func: Callable[[str], None] = print,
+) -> None:
+    print_func(
+        "MC run concluded "
+        f"{_conclusion_word(result.succeeded)} with {result.it_s:.2f} it/s."
+    )
+
+
+def report_mc_step_performance(
+    result: MCPipelineResult,
+    *,
+    print_func: Callable[[str], None] = print,
+) -> None:
+    step_rates = result.step_it_s
+    for step_name in result.step_elapsed_s:
+        step_succeeded = result.step_failures.get(step_name, 0) == 0
+        print_func(
+            f"{step_name} concluded {_conclusion_word(step_succeeded)} "
+            f"with {step_rates.get(step_name, 0.0):.2f} it/s."
+        )

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "7868d0e5",
    "metadata": {},
    "outputs": [],
@@ -112,7 +112,7 @@
     "        regression_step(\n",
     "            \"OutGap_regression\",\n",
     "            X_source=\"x_pred\",\n",
-    "            y_source=\"y_pred\",\n",
+    "            y_source=\"innov\",\n",
     "            y_column=0,\n",
     "            X_columns=[2, 3, 4],\n",
     "            variables=[\"r\", \"x\", \"Pi\"],\n",
@@ -123,17 +123,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "id": "c4a12aa7",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MC run concluded successfully with 215.42 it/s.\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "(True, 10000)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,6 +152,7 @@
     "    n_rep=10000,\n",
     "    retain_payloads=False,\n",
     "    retain_test_results=False,\n",
+    "    verbosity=1,\n",
     ")\n",
     "\n",
     "mc.succeeded, mc.n_successful"
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 29,
    "id": "48110503",
    "metadata": {},
    "outputs": [
@@ -245,7 +253,7 @@
        "std_innov_second_moment    1.000  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -268,40 +276,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 34,
    "id": "8fd2a185",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:243: RuntimeWarning: divide by zero encountered in divide\n",
-      "  return np.asarray(self.coef_trace / self.se_trace, dtype=np.float64)\n",
-      "C:\\Users\\guney\\Documents\\GitHub\\SymbolicDSGE\\SymbolicDSGE\\regression\\ols\\ols_result.py:243: RuntimeWarning: invalid value encountered in divide\n",
-      "  return np.asarray(self.coef_trace / self.se_trace, dtype=np.float64)\n"
+      "False\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "array([[ 1.18126313e+01,  1.08308432e+16, -3.83714486e+00],\n",
-       "       [-9.02108236e+00,  1.20414017e+16, -8.66127074e+00],\n",
-       "       [ 6.23597534e+00,  9.79023680e+15,  1.19236384e+01],\n",
-       "       ...,\n",
-       "       [ 1.40651523e+01,  1.40077306e+16, -1.68391717e+00],\n",
-       "       [-5.21561551e+00,  2.51389192e+16, -1.21344348e+01],\n",
-       "       [-6.97955443e+00,  9.20164848e+15, -9.43444567e+00]],\n",
-       "      shape=(500, 3))"
+       "((np.float64(-0.14), np.float64(0.4906)),\n",
+       " (np.float64(-0.13), np.float64(0.4943)),\n",
+       " (np.float64(-2.24), np.float64(0.1103)))"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mc.regression_summaries[\"OutGap_regression\"].t_stat_trace"
+    "print(\n",
+    "    any(\n",
+    "        res.value != 0\n",
+    "        for res in mc.regression_summaries[\"OutGap_regression\"].status_trace\n",
+    "    )\n",
+    ")\n",
+    "tuple(\n",
+    "    zip(\n",
+    "        mc.regression_summaries[\"OutGap_regression\"].t_stat_trace.mean(axis=0).round(2),\n",
+    "        mc.regression_summaries[\"OutGap_regression\"].pval_trace.mean(axis=0).round(4),\n",
+    "    )\n",
+    ")"
    ]
   }
  ],

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -89,6 +89,10 @@ class MCPipelineResult(
     contexts: tuple[MCContext, ...] | None,
     failures: tuple[MCFailure, ...] = (),
     regression_summaries: Mapping[str, MCRegressionResult] = {},
+    elapsed_s: float = 0.0,
+    step_elapsed_s: Mapping[str, float] = {},
+    step_counts: Mapping[str, int] = {},
+    step_failures: Mapping[str, int] = {},
 )
 ```
 
@@ -106,12 +110,20 @@ __Fields and Properties:__
 | contexts | `#!python tuple[MCContext, ...] | None` | Optional full contexts. |
 | failures | `#!python tuple[MCFailure, ...]` | Failures collected when `fail_fast=False`. |
 | regression_summaries | `#!python Mapping[str, MCRegressionResult]` | Per-regression aggregate result containers. |
+| elapsed_s | `#!python float` | Total elapsed wall time for the pipeline run. |
+| step_elapsed_s | `#!python Mapping[str, float]` | Elapsed wall time by step name. |
+| step_counts | `#!python Mapping[str, int]` | Number of attempted calls by step name. |
+| step_failures | `#!python Mapping[str, int]` | Number of collected failures by step name. |
 | succeeded | `#!python bool` | `True` when no failures were collected. |
+| it_s | `#!python float` | Replications attempted per elapsed second. |
+| step_it_s | `#!python Mapping[str, float]` | Step calls attempted per elapsed second by step name. |
 | statistic_traces | `#!python Mapping[str, ndarray]` | Shortcut for each test summary's statistic trace. |
 | pval_traces | `#!python Mapping[str, ndarray]` | Shortcut for each test summary's p-value trace. |
 | rejection_traces | `#!python Mapping[str, ndarray]` | Boolean rejection trace for each test summary. |
 | coefficient_traces | `#!python Mapping[str, ndarray]` | Shortcut for each regression summary's coefficient trace. |
 | regression_status_traces | `#!python Mapping[str, tuple[RegressionStatus, ...]]` | Shortcut for each regression summary's status trace. |
+| `report_performance()` | `#!python None` | Print the aggregate pipeline throughput report. |
+| `report_step_performance()` | `#!python None` | Print one throughput report line per pipeline step. |
 
 ???+ note "P-Value Evaluation"
     Scalar `TestResult` objects produced inside Monte Carlo Wald steps defer p-value and frozen-distribution construction until `pval`, `frozen_dist`, or `compute_pval()` is accessed. Aggregate `MCResult` objects compute vectorized p-values when `MCPipelineResult.test_summaries` is built.

--- a/docs/documentation/monte_carlo/pipeline.md
+++ b/docs/documentation/monte_carlo/pipeline.md
@@ -30,6 +30,7 @@ MCPipeline.run(
     retain_test_results: bool = True,
     retain_contexts: bool = False,
     fail_fast: bool = True,
+    verbosity: int = 1,
 ) -> MCPipelineResult
 ```
 
@@ -44,6 +45,7 @@ __Inputs:__
 | retain_test_results | Store scalar `TestResult` objects from each successful replication. |
 | retain_contexts | Store full `MCContext` objects. This is useful for debugging and memory-heavy for large runs. |
 | fail_fast | If `True`, raise on the first failed replication. If `False`, collect `MCFailure` entries and summarize successful replications. |
+| verbosity | Performance-reporting level: `0` prints nothing, `1` prints one aggregate throughput line, and `2` prints one throughput line per step. |
 
 __Returns:__
 

--- a/docs/documentation/monte_carlo/result_access.md
+++ b/docs/documentation/monte_carlo/result_access.md
@@ -22,5 +22,14 @@ __Summary Fields and Methods:__
 
 If `retain_test_results=True`, `MCPipelineResult.test_results` stores scalar per-replication `TestResult` objects keyed by test step name.
 
+__Performance Reporting:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| `report_mc_performance(result)` | Print the aggregate pipeline throughput report. |
+| `report_mc_step_performance(result)` | Print one throughput report line per pipeline step. |
+| `MCPipelineResult.report_performance()` | Method form of `report_mc_performance(...)`. |
+| `MCPipelineResult.report_step_performance()` | Method form of `report_mc_step_performance(...)`. |
+
 ???+ warning "Retention and Memory Use"
     `retain_contexts=True` and `retain_payloads=True` can store large arrays from every successful replication. For large Monte Carlo runs, prefer retaining aggregate summaries and scalar test results unless full per-replication payloads are needed for debugging or downstream analysis.

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -19,6 +19,8 @@ from SymbolicDSGE.monte_carlo import (
     raw_data_step,
     reference_filter_step,
     regression_step,
+    report_mc_performance,
+    report_mc_step_performance,
     simulation_step,
     transform_step,
     wald_test_step,
@@ -287,6 +289,83 @@ def test_pipeline_retention_controls_drop_payload_and_result_traces() -> None:
     assert out.contexts is None
     assert "state_mean" in out.test_summaries
     assert out.statistic_traces["state_mean"].shape == (2,)
+
+
+def test_pipeline_result_reports_overall_and_step_performance() -> None:
+    reference = _FakeSolvedModel()
+    states = _batched_states()
+    pipeline = MCPipeline(
+        [
+            raw_data_step(states=states, n_exog=0),
+            wald_test_step(
+                "state_mean",
+                source="states",
+                target=np.zeros(2, dtype=np.float64),
+                bandwidth=0,
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=reference, n_rep=2)
+
+    assert out.elapsed_s >= 0.0
+    assert out.it_s > 0.0
+    assert set(out.step_elapsed_s) == {"datagen", "state_mean"}
+    assert out.step_counts == {"datagen": 2, "state_mean": 2}
+    assert out.step_failures == {"datagen": 0, "state_mean": 0}
+    assert set(out.step_it_s) == {"datagen", "state_mean"}
+
+    lines: list[str] = []
+    report_mc_performance(out, print_func=lines.append)
+    assert lines[0].startswith("MC run concluded successfully with ")
+    assert lines[0].endswith(" it/s.")
+
+    lines.clear()
+    out.report_step_performance(print_func=lines.append)
+    assert len(lines) == 2
+    assert lines[0].startswith("datagen concluded successfully with ")
+    assert lines[0].endswith(" it/s.")
+    assert lines[1].startswith("state_mean concluded successfully with ")
+    assert lines[1].endswith(" it/s.")
+
+    lines.clear()
+    report_mc_step_performance(out, print_func=lines.append)
+    assert len(lines) == 2
+
+
+def test_pipeline_run_verbosity_controls_performance_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    reference = _FakeSolvedModel()
+    states = _batched_states()
+    pipeline = MCPipeline(
+        [
+            raw_data_step(states=states, n_exog=0),
+            wald_test_step(
+                "state_mean",
+                source="states",
+                target=np.zeros(2, dtype=np.float64),
+                bandwidth=0,
+            ),
+        ]
+    )
+
+    pipeline.run(reference=reference, n_rep=2)
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 1
+    assert lines[0].startswith("MC run concluded successfully with ")
+
+    pipeline.run(reference=reference, n_rep=2, verbosity=0)
+    assert capsys.readouterr().out == ""
+
+    pipeline.run(reference=reference, n_rep=2, verbosity=2)
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("datagen concluded successfully with ")
+    assert lines[1].startswith("state_mean concluded successfully with ")
+
+    with pytest.raises(ValueError, match="verbosity"):
+        pipeline.run(reference=reference, n_rep=2, verbosity=3)
 
 
 def test_sim_filter_wald_pipeline_uses_reference_filter_payload() -> None:
@@ -581,3 +660,14 @@ def test_pipeline_collects_failures_when_fail_fast_is_false() -> None:
     assert out.failures[0].rep_idx == 2
     assert out.failures[0].step_name == "datagen"
     assert out.statistic_traces["state_mean"].shape == (2,)
+    assert out.step_counts == {"datagen": 3, "state_mean": 2}
+    assert out.step_failures == {"datagen": 1, "state_mean": 0}
+
+    lines: list[str] = []
+    out.report_performance(print_func=lines.append)
+    assert lines[0].startswith("MC run concluded unsuccessfully with ")
+
+    lines.clear()
+    report_mc_step_performance(out, print_func=lines.append)
+    assert lines[0].startswith("datagen concluded unsuccessfully with ")
+    assert lines[1].startswith("state_mean concluded successfully with ")


### PR DESCRIPTION
Track and report Monte Carlo pipeline performance: add elapsed_s, step_elapsed_s, step_counts and step_failures to MCPipelineResult; compute iteration rates and expose report_performance/report_step_performance helper methods. MCPipeline.run now measures per-step and total elapsed time (perf_counter), counts step calls and failures, accepts a verbosity argument (0/1/2) to control printed throughput reports, and validates verbosity. New top-level helpers report_mc_performance and report_mc_step_performance produce human-readable throughput lines. Tests, docs and the example notebook updated to reflect the new reporting behavior. Additionally, ljung_box gained an _auto_pval flag and run_ljung_box_test now disables auto p-value construction (passes _auto_pval=False) to control deferred p-value evaluation.

closes #80 