### PR TITLE
Add regression docs and mkdocs integration

### DIFF
--- a/docs/documentation/monte_carlo/builtin/regression.md
+++ b/docs/documentation/monte_carlo/builtin/regression.md
@@ -9,6 +9,15 @@ tags:
 regression_step(
     name: str,
     *,
+    kind: Literal[
+        "ols",
+        "ridge",
+        "ridge_gs",
+        "lasso",
+        "lasso_gs",
+        "elastic_net",
+        "elastic_net_gs",
+    ] = "ols",
     y_source: InpSources,
     X_source: InpSources,
     filter_key: str = "filter",
@@ -16,18 +25,35 @@ regression_step(
     x_payload_key: str | None = None,
     y_column: Sequence[int] | int | None = None,
     X_columns: Sequence[int] | slice | None = None,
+    intercept: bool = True,
     burn_in: int = 0,
     drop_initial: bool = False,
     variables: Sequence[str] | None = None,
+    **kind_kwargs: Any,
 ) -> MCStep
 ```
 
-`regression_step` conducts an Ordinary Least Squares (OLS) regression of `y_source` on `X_source` and stores the regression summary in `MCPipelineResult.regression_summaries` under the key `name`. The regression is conducted separately for each replication, and the summary statistics are stored as traces across replications.
+`regression_step` conducts a regression of `y_source` on `X_source` and stores the regression summary in `MCPipelineResult.regression_summaries` under the key `name`. The regression is conducted separately for each replication, and summary statistics are stored as traces across replications.
 
-__Sources:__
+__Kind Dispatch:__
+
+| __kind__ | __Result Type__ | __Required `kind_kwargs`__ |
+|:---------|:----------------|---------------------------:|
+| `"ols"` | `#!python OLSResult` | none |
+| `"ridge"` | `#!python RidgeResult` | `alpha` |
+| `"ridge_gs"` | `#!python RidgeResult` | `start`, `stop`, `num` |
+| `"lasso"` | `#!python LassoResult` | `alpha` |
+| `"lasso_gs"` | `#!python LassoResult` | `start`, `stop`, `num` |
+| `"elastic_net"` | `#!python ElasticNetResult` | `alpha`, `l1_ratio` |
+| `"elastic_net_gs"` | `#!python ElasticNetResult` | `start`, `stop`, `num`, `l1_ratio` |
 
 ???+ warning "Target must be 1D"
     `regression_step` does not support multivariate targets. Multiple target values are to be regressed on the same set of regressors, separate `regression_step` components should be appended to the pipeline for each target variable.
+
+???+ note "Forwarded Regression Arguments"
+    `kind_kwargs` are passed directly to the selected regression function. Grid-search kinds also accept the underlying regression options such as `criterion`, `max_iter`, and `tol` when supported by that method.
+
+__Sources:__
 
 | __Source__ | __Description__ |
 |:-----------|----------------:|

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -63,7 +63,7 @@ class MCContext(
     data: MCData | None = None,
     payloads: dict[str, Any] = {},
     results: dict[str, TestResult] = {},
-    regressions: dict[str, OLSResult] = {},
+    regressions: dict[str, RegressionResult] = {},
 )
 ```
 

--- a/docs/documentation/regression/elastic_net.md
+++ b/docs/documentation/regression/elastic_net.md
@@ -1,0 +1,112 @@
+---
+tags:
+    - doc
+---
+# Elastic Net
+
+```python
+from SymbolicDSGE.regression.elastic_net import (
+    ElasticNetResult,
+    elastic_net,
+    elastic_net_gs,
+)
+```
+
+```python
+elastic_net(
+    X: ndarray,
+    y: ndarray,
+    alpha: float,
+    l1_ratio: float,
+    variables: list[str] | None = None,
+    intercept: bool = True,
+    max_iter: int = 1000,
+    tol: float = 1e-10,
+) -> ElasticNetResult
+```
+
+Run Elastic Net regression with a combined L1/L2 penalty.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| X | Design matrix. Shape `(n, k)`. |
+| y | Response vector. Shape `(n,)`. |
+| alpha | Non-negative total penalty weight. |
+| l1_ratio | Penalty split between L1 and L2. Must be in `[0, 1]`. |
+| variables | Optional names for the columns of `X`. Defaults to `x0`, `x1`, ... |
+| intercept | If `True`, fit an unpenalized intercept by centering and restore it in the returned design. |
+| max_iter | Maximum coordinate-descent iterations. |
+| tol | Coordinate-descent convergence tolerance. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python ElasticNetResult` | Regression result with combined penalty diagnostics. |
+
+&nbsp;
+
+```python
+elastic_net_gs(
+    X: ndarray,
+    y: ndarray,
+    start: float,
+    stop: float,
+    num: int,
+    l1_ratio: float,
+    criterion: Literal["aic", "bic", "loss"] = "loss",
+    variables: list[str] | None = None,
+    intercept: bool = True,
+    max_iter: int = 1000,
+    tol: float = 1e-10,
+) -> ElasticNetResult
+```
+
+Run Elastic Net regression over a logarithmic alpha grid and return the best result under the selected criterion.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| start | Positive lower endpoint for the alpha grid. |
+| stop | Positive upper endpoint for the alpha grid. |
+| num | Number of grid points. |
+| criterion | Grid-search objective: AIC, BIC, or residual loss. |
+| X, y, l1_ratio, variables, intercept, max_iter, tol | Same contract as `elastic_net(...)`. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class ElasticNetResult(RegressionResult)
+```
+
+__Additional Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| alpha | `#!python float64` | Selected total penalty weight. |
+| l1_ratio | `#!python float64` | L1 share of the total penalty. |
+| effective_dof | `#!python float64` | Effective degrees of freedom for the selected solution. |
+| intercept | `#!python bool` | Whether the returned design includes an intercept column. |
+| alpha_grid | `#!python ndarray | None` | Grid of alpha values evaluated by `elastic_net_gs(...)`. |
+| coefficient_path | `#!python ndarray | None` | Coefficients evaluated on `alpha_grid`. |
+| objective_trace | `#!python ndarray | None` | Grid-search criterion trace. |
+| rss_trace | `#!python ndarray | None` | Residual-sum-of-squares trace over `alpha_grid`. |
+| effective_dof_trace | `#!python ndarray | None` | Effective degrees of freedom over `alpha_grid`. |
+| status_trace | `#!python ndarray | None` | Solver status code over `alpha_grid`. |
+| penalized_coefficients | `#!python ndarray` | Coefficients subject to the penalty. |
+| active_mask | `#!python ndarray` | Boolean mask over penalized coefficients. |
+| n_active | `#!python int` | Number of active penalized coefficients. |
+| selected_variables | `#!python list[str]` | Variable names with active penalized coefficients. |
+| l1_norm | `#!python float64` | L1 norm of penalized coefficients. |
+| l2_norm_sq | `#!python float64` | Squared L2 norm of penalized coefficients. |
+| l1_penalty | `#!python float64` | Realized L1 penalty component. |
+| l2_penalty | `#!python float64` | Realized L2 penalty component. |
+| penalty | `#!python float64` | Combined realized penalty. |
+
+???+ note "Endpoint Dispatch"
+    `l1_ratio=0.0` delegates to ridge logic and `l1_ratio=1.0` delegates to lasso logic where the selected criterion allows it. The returned object is still normalized to `ElasticNetResult`.
+

--- a/docs/documentation/regression/index.md
+++ b/docs/documentation/regression/index.md
@@ -1,0 +1,50 @@
+---
+tags:
+    - doc
+---
+# Regression
+
+```python
+from SymbolicDSGE import regression
+from SymbolicDSGE.regression import (
+    RegressionKind,
+    RegressionResult,
+    RegressionStatus,
+)
+```
+
+The `regression` subpackage contains the standard linear regression interfaces used directly by users and by Monte Carlo regression steps.
+
+__Public Modules:__
+
+| __Module__ | __Description__ |
+|:-----------|----------------:|
+| `regression.ols` | Ordinary Least Squares regression and OLS inference diagnostics. |
+| `regression.ridge` | Ridge regression and L2 grid search. |
+| `regression.lasso` | Lasso regression and Lasso grid/path utilities. |
+| `regression.elastic_net` | Elastic Net regression and grid search. |
+| `regression.sr` | Symbolic-regression utilities. |
+
+__RegressionKind Values:__
+
+| __Member__ | __String__ | __Dispatch Target__ |
+|:-----------|:----------:|--------------------:|
+| `OLS` | `"ols"` | `regression.ols.ols` |
+| `RIDGE` | `"ridge"` | `regression.ridge.ridge` |
+| `RIDGE_GS` | `"ridge_gs"` | `regression.ridge.ridge_gs` |
+| `LASSO` | `"lasso"` | `regression.lasso.lasso` |
+| `LASSO_GS` | `"lasso_gs"` | `regression.lasso.lasso_gs` |
+| `ELASTIC_NET` | `"elastic_net"` | `regression.elastic_net.elastic_net` |
+| `ELASTIC_NET_GS` | `"elastic_net_gs"` | `regression.elastic_net.elastic_net_gs` |
+
+__RegressionStatus Values:__
+
+| __Member__ | __Code__ | __Description__ |
+|:-----------|:--------:|----------------:|
+| `OK` | `0` | Regression solver completed normally. |
+| `RANK_DEFICIENT` | `-1` | The primary linear solver detected rank deficiency and a fallback or failure path was used. |
+| `NON_CONVERGENT` | `-2` | An iterative solver exhausted its iteration budget before satisfying tolerance. |
+
+???+ note "Intercept Convention"
+    Regression functions use `intercept=True` by default. When enabled, the returned design matrix contains an `Intercept` column as the first variable. Penalized methods do not penalize this intercept term.
+

--- a/docs/documentation/regression/lasso.md
+++ b/docs/documentation/regression/lasso.md
@@ -1,0 +1,98 @@
+---
+tags:
+    - doc
+---
+# Lasso
+
+```python
+from SymbolicDSGE.regression.lasso import LassoResult, lasso, lasso_gs
+```
+
+```python
+lasso(
+    X: ndarray,
+    y: ndarray,
+    alpha: float,
+    variables: list[str] | None = None,
+    intercept: bool = True,
+    max_iter: int = 1000,
+    tol: float = 1e-10,
+) -> LassoResult
+```
+
+Run Lasso regression with an L1 penalty using coordinate descent on the normalized Gram system.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| X | Design matrix. Shape `(n, k)`. |
+| y | Response vector. Shape `(n,)`. |
+| alpha | Non-negative L1 penalty weight. |
+| variables | Optional names for the columns of `X`. Defaults to `x0`, `x1`, ... |
+| intercept | If `True`, fit an unpenalized intercept by centering and restore it in the returned design. |
+| max_iter | Maximum coordinate-descent iterations. |
+| tol | Coordinate-descent convergence tolerance. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python LassoResult` | Regression result with L1 sparsity diagnostics. |
+
+&nbsp;
+
+```python
+lasso_gs(
+    X: ndarray,
+    y: ndarray,
+    start: float,
+    stop: float,
+    num: int,
+    variables: list[str] | None = None,
+    intercept: bool = True,
+    max_iter: int = 1000,
+    tol: float = 1e-10,
+) -> LassoResult
+```
+
+Evaluate a logarithmic alpha grid using the LARS-Lasso path and select the coefficient vector with the lowest residual loss.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| start | Positive lower endpoint for the alpha grid. |
+| stop | Positive upper endpoint for the alpha grid. |
+| num | Number of grid points. |
+| X, y, variables, intercept, max_iter, tol | Same contract as `lasso(...)`. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class LassoResult(RegressionResult)
+```
+
+__Additional Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| alpha | `#!python float64` | Selected L1 penalty weight. |
+| effective_dof | `#!python float64` | Active penalized coefficient count plus the intercept, when present. |
+| intercept | `#!python bool` | Whether the returned design includes an intercept column. |
+| alpha_grid | `#!python ndarray | None` | Grid of alpha values evaluated by `lasso_gs(...)`. |
+| coefficient_path | `#!python ndarray | None` | Coefficients evaluated on `alpha_grid`. |
+| objective_trace | `#!python ndarray | None` | Residual-loss trace over `alpha_grid`. |
+| knot_lambdas | `#!python ndarray | None` | LARS path knot locations from grid-search construction. |
+| knot_coefficients | `#!python ndarray | None` | LARS path coefficients aligned to `knot_lambdas`. |
+| penalized_coefficients | `#!python ndarray` | Coefficients subject to the L1 penalty. |
+| active_mask | `#!python ndarray` | Boolean mask over penalized coefficients. |
+| n_active | `#!python int` | Number of active penalized coefficients. |
+| selected_variables | `#!python list[str]` | Variable names with active penalized coefficients. |
+| l1_norm | `#!python float64` | L1 norm of penalized coefficients. |
+| l1_penalty | `#!python float64` | Realized L1 penalty value. |
+
+???+ note "Path Output"
+    Path fields are populated by `lasso_gs(...)`. Direct `lasso(...)` calls return only the selected coefficient vector and scalar L1 diagnostics.
+

--- a/docs/documentation/regression/ols.md
+++ b/docs/documentation/regression/ols.md
@@ -1,0 +1,60 @@
+---
+tags:
+    - doc
+---
+# OLS
+
+```python
+from SymbolicDSGE.regression.ols import OLSResult, ols
+```
+
+```python
+ols(
+    x: ndarray,
+    y: ndarray,
+    variables: list[str] | None = None,
+    intercept: bool = True,
+) -> OLSResult
+```
+
+Run Ordinary Least Squares regression on a one-dimensional response and a two-dimensional design matrix.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| x | Design matrix. Shape `(n, k)`. |
+| y | Response vector. Shape `(n,)`. |
+| variables | Optional names for the columns of `x`. Defaults to `x0`, `x1`, ... |
+| intercept | If `True`, prepend an intercept column to the design matrix. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python OLSResult` | Regression result with common fitted diagnostics and OLS inference outputs. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class OLSResult(RegressionResult)
+```
+
+`OLSResult` extends `RegressionResult` with standard errors, coefficient tests, confidence intervals, and an F-test.
+
+__Additional Fields and Methods:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| se | `#!python ndarray` | Coefficient standard errors. |
+| t_stat | `#!python ndarray` | Coefficient t-statistics. |
+| partial_r2 | `#!python ndarray` | Partial R-squared values implied by each t-statistic. |
+| p_values | `#!python ndarray` | Two-sided coefficient p-values under the t reference distribution. |
+| `confidence_intervals(alpha=0.05)` | `#!python ndarray` | Lower and upper coefficient bounds. Shape `(k, 2)`. |
+| `summary(alpha=0.05)` | `#!python pandas.DataFrame` | Coefficient, interval, t-statistic, p-value, and partial R-squared table. |
+| `F_test(alpha=0.05)` | `#!python TestResult` | Regression F-test against the relevant F reference distribution. |
+
+???+ note "Rank-Deficient Designs"
+    OLS first attempts a Cholesky solve and falls back to least squares when needed. The `status` field records the solver status used by the result.
+

--- a/docs/documentation/regression/results.md
+++ b/docs/documentation/regression/results.md
@@ -1,0 +1,103 @@
+---
+tags:
+    - doc
+---
+# Regression Results
+
+```python
+from SymbolicDSGE.regression import RegressionResult
+from SymbolicDSGE.regression.ols import MCRegressionResult
+```
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class RegressionResult(
+    variables: list[str],
+    coefficients: ndarray,
+    y: ndarray,
+    X: ndarray,
+    status: RegressionStatus,
+)
+```
+
+`RegressionResult` is the shared result abstraction for standard linear regression outputs. Concrete result types inherit the common fitted-data diagnostics and add method-specific quantities.
+
+__Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| variables | `#!python list[str]` | Names of the design columns represented in `coefficients`. |
+| coefficients | `#!python ndarray` | Estimated coefficient vector. Shape `(k,)`. |
+| y | `#!python ndarray` | Response vector. Shape `(n,)`. |
+| X | `#!python ndarray` | Design matrix used by the regression. Shape `(n, k)`. |
+| x | `#!python ndarray` | Alias for `X`. |
+| status | `#!python RegressionStatus` | Solver status. |
+| n | `#!python int` | Number of observations. |
+| k | `#!python int` | Number of design columns. |
+| y_hat | `#!python ndarray` | Fitted response vector. |
+| residuals | `#!python ndarray` | Response residuals, `y - y_hat`. |
+| ssr | `#!python float64` | Sum of squared residuals. |
+| sst | `#!python float64` | Total sum of squares around the sample mean of `y`. |
+| mse | `#!python float64` | Mean squared error, `ssr / n`. |
+| rmse | `#!python float64` | Root mean squared error. |
+| r2 | `#!python float64` | Coefficient of determination. |
+| r2_adj | `#!python float64` | Adjusted coefficient of determination. |
+| `to_dict()` | `#!python dict` | Dataclass dictionary representation. |
+
+???+ warning "Shape Contract"
+    `RegressionResult` expects a one-dimensional response vector and a two-dimensional design matrix. Multivariate response regressions should be represented as separate result objects.
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class MCRegressionResult(
+    variables: list[str],
+    results: tuple[RegressionResult, ...],
+)
+```
+
+`MCRegressionResult` aggregates per-replication `RegressionResult` objects produced by Monte Carlo regression steps.
+
+__Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| variables | `#!python list[str]` | Shared variable ordering across replications. |
+| results | `#!python tuple[RegressionResult, ...]` | Per-replication regression outputs. |
+| coef_trace | `#!python ndarray` | Coefficients stacked by replication. Shape `(n_rep, k)`. |
+| coefficients | `#!python ndarray` | Alias for `coef_trace`. |
+| status_trace | `#!python tuple[RegressionStatus, ...]` | Solver status for each replication. |
+| n_rep | `#!python int` | Number of stored regression results. |
+| n | `#!python int` | Shared number of observations per replication. |
+| k | `#!python int` | Shared number of design columns. |
+| y_trace | `#!python ndarray` | Response vectors stacked by replication. |
+| x_trace | `#!python ndarray` | Design matrices stacked by replication. |
+| y_hat_trace | `#!python ndarray` | Fitted responses stacked by replication. |
+| residual_trace | `#!python ndarray` | Residual vectors stacked by replication. |
+| ssr_trace | `#!python ndarray` | Per-replication SSR values. |
+| sst_trace | `#!python ndarray` | Per-replication SST values. |
+| mse_trace | `#!python ndarray` | Per-replication MSE values. |
+| rmse_trace | `#!python ndarray` | Per-replication RMSE values. |
+| r2_trace | `#!python ndarray` | Per-replication R-squared values. |
+| r2_adj_trace | `#!python ndarray` | Per-replication adjusted R-squared values. |
+| `summary(alpha=0.05)` | `#!python pandas.DataFrame` | Coefficient trace summary. OLS results include inference columns. |
+| `to_dict()` | `#!python dict` | Compact dictionary representation. |
+
+__OLS-Only Aggregate Diagnostics:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| se_trace | `#!python ndarray` | OLS standard-error trace. |
+| t_stat_trace | `#!python ndarray` | OLS t-statistic trace. |
+| partial_r2_trace | `#!python ndarray` | OLS partial R-squared trace. |
+| pval_trace | `#!python ndarray` | OLS coefficient p-value trace. |
+| F_stat_trace | `#!python ndarray` | OLS F-statistic trace. |
+| F_pval_trace | `#!python ndarray` | OLS F-test p-value trace. |
+| `confidence_intervals(alpha=0.05)` | `#!python ndarray` | Per-replication OLS coefficient intervals. |
+| `F_test(alpha=0.05)` | `#!python MCResult` | Aggregate F-test result container. |
+
+???+ note "OLS-Specific Diagnostics"
+    OLS aggregate diagnostics require every stored result to be an `OLSResult`. For ridge, lasso, and elastic-net aggregates, `summary()` returns coefficient traces without OLS inference columns.

--- a/docs/documentation/regression/ridge.md
+++ b/docs/documentation/regression/ridge.md
@@ -1,0 +1,85 @@
+---
+tags:
+    - doc
+---
+# Ridge
+
+```python
+from SymbolicDSGE.regression.ridge import RidgeResult, ridge, ridge_gs
+```
+
+```python
+ridge(
+    x: ndarray,
+    y: ndarray,
+    alpha: float,
+    variables: list[str] | None = None,
+    intercept: bool = True,
+) -> RidgeResult
+```
+
+Run ridge regression with an L2 penalty.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| x | Design matrix. Shape `(n, k)`. |
+| y | Response vector. Shape `(n,)`. |
+| alpha | Non-negative L2 penalty weight. |
+| variables | Optional names for the columns of `x`. Defaults to `x0`, `x1`, ... |
+| intercept | If `True`, prepend an unpenalized intercept column to the returned design matrix. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python RidgeResult` | Regression result with ridge penalty diagnostics. |
+
+&nbsp;
+
+```python
+ridge_gs(
+    x: ndarray,
+    y: ndarray,
+    start: float,
+    stop: float,
+    num: int,
+    criterion: Literal["aic", "bic", "loss"] = "aic",
+    variables: list[str] | None = None,
+    intercept: bool = True,
+) -> RidgeResult
+```
+
+Run ridge regression over a logarithmic alpha grid and return the best result under the selected criterion.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| start | Positive lower endpoint for the alpha grid. |
+| stop | Positive upper endpoint for the alpha grid. |
+| num | Number of grid points. |
+| criterion | Grid-search objective: AIC, BIC, or residual loss. |
+| x, y, variables, intercept | Same contract as `ridge(...)`. |
+
+&nbsp;
+
+```python
+@dataclass(frozen=True)
+class RidgeResult(RegressionResult)
+```
+
+__Additional Fields and Properties:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| alpha | `#!python float64` | Selected L2 penalty weight. |
+| effective_dof | `#!python float64` | Effective degrees of freedom used by grid-search criteria. |
+| intercept | `#!python bool` | Whether the returned design includes an intercept column. |
+| objective | `#!python RidgeObjective | None` | Grid-search criterion used to select `alpha`, if applicable. |
+| objective_value | `#!python float64 | None` | Realized grid-search criterion value, if applicable. |
+| l2_penalty | `#!python float64` | Realized ridge penalty excluding the intercept term. |
+
+???+ note "Penalty Convention"
+    When `intercept=True`, the intercept is not included in `l2_penalty` and is not regularized by the solver.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,13 @@ nav:
       - Shock: documentation/Shock.md
       - KalmanConfig: documentation/KalmanConfig.md
       - FilterResult: documentation/FilterResult.md
+      - Regression:
+          - Overview: documentation/regression/index.md
+          - Regression Results: documentation/regression/results.md
+          - OLS: documentation/regression/ols.md
+          - Ridge: documentation/regression/ridge.md
+          - Lasso: documentation/regression/lasso.md
+          - Elastic Net: documentation/regression/elastic_net.md
       - Monte Carlo:
           - Overview: documentation/monte_carlo/index.md
           - MCPipeline: documentation/monte_carlo/pipeline.md


### PR DESCRIPTION
Add comprehensive documentation for the regression subpackage (OLS, Ridge, Lasso, Elastic Net, results, and index pages) and register them in mkdocs navigation. Update monte_carlo builtin regression docs to introduce a kind dispatch (ols/ridge/lasso/elastic_net and grid-search variants), add an intercept flag and forwarded kind_kwargs, and clarify sources/notes. Adjust MCContext type for stored regressions from OLSResult to RegressionResult to reflect generalized regression results.

closes #93 