### PR TITLE
Variable Order Inference

### DIFF
--- a/SymbolicDSGE/core/compiled_model.py
+++ b/SymbolicDSGE/core/compiled_model.py
@@ -21,12 +21,25 @@ ND = NDArray
 
 
 @dataclass(frozen=True)
+class VariableLayout:
+    declared_names: tuple[str, ...]
+    canonical_names: tuple[str, ...]
+    exo_state_names: tuple[str, ...]
+    endo_state_names: tuple[str, ...]
+    control_names: tuple[str, ...]
+    n_exog: int
+    n_state: int
+    idx: dict[str, int]
+
+
+@dataclass(frozen=True)
 class CompiledModel:
     config: ModelConfig
     kalman: KalmanConfig | None
 
     cur_syms: list[Symbol]
 
+    layout: VariableLayout
     var_names: list[str]
     idx: dict[str, int]
 

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -469,7 +469,7 @@ class SolvedModel:
         # Arguments in form [*cur_vars, *params]
         params = self.compiled.config.calibration.parameters
         param_vals = [
-            float64(params[p]) for p in self.config.calibration.parameters
+            float64(params[p]) for p in self.compiled.calib_params
         ]  # Ensure dtype + order
 
         # Assume state is in canonical order of cur_syms (Checked at compile time)

--- a/SymbolicDSGE/core/solver.py
+++ b/SymbolicDSGE/core/solver.py
@@ -1,8 +1,7 @@
-from logging import warning
 import warnings
 import sympy as sp
 from sympy import Symbol, Function, Expr
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 from textwrap import dedent
 
 import numpy as np
@@ -16,7 +15,7 @@ import pandas as pd
 
 from .. import _linearsolve as linearsolve
 from .config import ModelConfig
-from .compiled_model import CompiledModel
+from .compiled_model import CompiledModel, VariableLayout
 from .linearization import linearize_model
 from .solved_model import SolvedModel
 
@@ -37,7 +36,7 @@ class DSGESolver:
     def compile(
         self,
         *,
-        variable_order: list[Function] | None = None,
+        variable_order: Sequence[Function | str] | None = None,
         n_state: int | None = None,
         n_exog: int | None = None,
         params_order: list[str] | None = None,
@@ -59,27 +58,51 @@ class DSGESolver:
 
         shifted = [self._offset_lags(o, t) for o in obj]
 
-        # Deterministic var order
-        if not variable_order:
-            var_order: list[str] = [
-                v.func.__name__ if hasattr(v, "func") else v.__name__
-                for v in ordered_variables
-            ]
-            var_order = [v.__name__ for v in ordered_variables]
-        else:
-            var_order = [  # pyright: ignore
-                v.__name__ if hasattr(v, "func") else v for v in variable_order
-            ]
-
         name_to_func = {v.__name__: v for v in ordered_variables}
+        inferred_layout = self._infer_variable_layout(conf)
+        resolved_n_exog = self._resolve_layout_count(
+            provided=n_exog,
+            inferred=inferred_layout.n_exog,
+            name="n_exog",
+        )
+        resolved_n_state = self._resolve_layout_count(
+            provided=n_state,
+            inferred=inferred_layout.n_state,
+            name="n_state",
+        )
+
+        if variable_order is None:
+            var_order = list(inferred_layout.canonical_names)
+        else:
+            var_order = [self._coerce_variable_name(v) for v in variable_order]
+            self._validate_explicit_variable_order(
+                var_order=var_order,
+                inferred_layout=inferred_layout,
+                n_exog=resolved_n_exog,
+                n_state=resolved_n_state,
+            )
+
         missing = [v for v in var_order if v not in name_to_func]
         if missing:
             raise ValueError(
                 f"The following variables in var_order do not exist in the model: {missing}"
             )
+        if len(set(var_order)) != len(var_order):
+            raise ValueError("variable_order contains duplicate variables.")
+
+        layout = VariableLayout(
+            declared_names=inferred_layout.declared_names,
+            canonical_names=tuple(var_order),
+            exo_state_names=tuple(var_order[:resolved_n_exog]),
+            endo_state_names=tuple(var_order[resolved_n_exog:resolved_n_state]),
+            control_names=tuple(var_order[resolved_n_state:]),
+            n_exog=resolved_n_exog,
+            n_state=resolved_n_state,
+            idx={name: i for i, name in enumerate(var_order)},
+        )
 
         var_funcs = [name_to_func[name] for name in var_order]
-        idx = {name: i for i, name in enumerate(var_order)}
+        idx = dict(layout.idx)
 
         for i, obj in enumerate(shifted):
             bad = self._bad_time_offsets(obj, var_funcs, t)
@@ -93,7 +116,7 @@ class DSGESolver:
         fwd_syms = [Symbol(f"fwd_{n}") for n in var_order]
 
         subs_map = {}
-        for name, f, cur, fwd in zip(var_order, var_funcs, cur_syms, fwd_syms):
+        for _, f, cur, fwd in zip(var_order, var_funcs, cur_syms, fwd_syms):
 
             subs_map[f(t)] = cur  # pyright: ignore
             subs_map[f(t + 1)] = fwd  # pyright: ignore
@@ -110,18 +133,14 @@ class DSGESolver:
         compiled: list[Expr] = [sp.simplify(o.subs(subs_map)) for o in shifted]
         shock_zero_subs = {shock: 0.0 for shock in conf.shock_map.keys()}
         compiled_numeric: list[Expr] = [
-            sp.simplify(expr.subs(shock_zero_subs)) for expr in compiled
+            sp.simplify(expr.subs(shock_zero_subs))  # pyright: ignore
+            for expr in compiled
         ]
 
         lambda_args = [*fwd_syms, *cur_syms, *params]
         objective_scalar_funcs = [
             njit(sp.lambdify(lambda_args, c, modules="numpy")) for c in compiled_numeric
         ]
-
-        if n_state is None or n_exog is None:
-            raise ValueError(
-                "For linearsolve backend you must provide n_state and n_exog explicitly."
-            )
 
         shifted_obs = [
             self._offset_lags(expr, t) for expr in conf.equations.observable.values()
@@ -132,18 +151,25 @@ class DSGESolver:
             for expr in observable_exprs
         ]
 
-        symbolic_jacobian: sp.Matrix = conf.equations.obs_jacobian
-        variables = [ordered_variables[idx[name]] for name in var_order]
+        if observable_exprs:
+            symbolic_jacobian = sp.Matrix(
+                [
+                    [sp.diff(expr, cur_sym) for cur_sym in cur_syms]
+                    for expr in observable_exprs
+                ]
+            )
+        else:
+            symbolic_jacobian = sp.zeros(0, len(cur_syms))
 
-        jac_scalars = list(symbolic_jacobian)
+        jac_scalars = list(symbolic_jacobian)  # pyright: ignore
         jac_scalar_funcs = tuple(
-            njit(sp.lambdify([*variables, *params], scalar, modules="numpy"))
+            njit(sp.lambdify([*cur_syms, *params], scalar, modules="numpy"))
             for scalar in jac_scalars
         )
 
         n_obs, n_vars = symbolic_jacobian.shape
 
-        arg_names = [f"var{i}" for i in range(len(variables))] + [
+        arg_names = [f"var{i}" for i in range(len(cur_syms))] + [
             f"param{i}" for i in range(len(params))
         ]
         args_str = ", ".join(f"{name}: float64" for name in arg_names)
@@ -183,12 +209,15 @@ def jacobian_func({args_str}) -> NDF:
             warnings.simplefilter(
                 "ignore", category=numba.errors.NumbaExperimentalFeatureWarning
             )
-            jacobian_func.compile(tuple(numba.float64 for _ in arg_names))
+            jacobian_func.compile(  # pyright: ignore
+                tuple(numba.float64 for _ in arg_names)
+            )
 
         return CompiledModel(
             config=conf,
             kalman=kalman_conf,
             cur_syms=cur_syms,
+            layout=layout,
             var_names=var_order,
             calib_params=params,
             idx=idx,
@@ -199,9 +228,157 @@ def jacobian_func({args_str}) -> NDF:
             observable_funcs=observable_funcs,
             observable_jacobian=jacobian_func,
             observable_jacobian_funcs=jac_scalar_funcs,
-            n_state=int(n_state),
-            n_exog=int(n_exog),
+            n_state=layout.n_state,
+            n_exog=layout.n_exog,
         )
+
+    @staticmethod
+    def _coerce_variable_name(var: Any) -> str:
+        if isinstance(var, str):
+            return var
+        if hasattr(var, "__name__"):
+            return str(var.__name__)
+        if hasattr(var, "name"):
+            return str(var.name)
+        if hasattr(var, "func") and hasattr(var.func, "__name__"):
+            return str(var.func.__name__)
+        return str(var)
+
+    @staticmethod
+    def _resolve_layout_count(
+        *,
+        provided: int | None,
+        inferred: int,
+        name: str,
+    ) -> int:
+        if provided is None:
+            return inferred
+        provided_int = int(provided)
+        if provided_int != inferred:
+            raise ValueError(
+                f"{name}={provided_int} does not match inferred {name}={inferred}."
+            )
+        return provided_int
+
+    def _infer_variable_layout(self, conf: ModelConfig) -> VariableLayout:
+        declared_names = tuple(v.__name__ for v in conf.variables.variables)
+        declared_set = set(declared_names)
+        t = self.t
+
+        shock_targets = [
+            self._coerce_variable_name(target) for target in conf.shock_map.values()
+        ]
+        unknown_targets = [name for name in shock_targets if name not in declared_set]
+        if unknown_targets:
+            raise ValueError(
+                "shock_map targets unknown model variable(s): "
+                + ", ".join(unknown_targets)
+            )
+        if len(set(shock_targets)) != len(shock_targets):
+            raise ValueError(
+                "shock_map contains multiple shocks for the same variable."
+            )
+
+        shocked = set(shock_targets)
+        exo_state_names = tuple(name for name in declared_names if name in shocked)
+
+        state_candidates: set[str] = set()
+        for eq in conf.equations.model:
+            lhs_info = self._function_call_offset(eq.lhs, declared_set, t)
+            if lhs_info is not None:
+                name, offset = lhs_info
+                if offset == 1:
+                    state_candidates.add(name)
+
+            expr = sp.simplify(eq.lhs - eq.rhs)  # pyright: ignore
+            for call in expr.atoms(sp.Function):
+                call_info = self._function_call_offset(call, declared_set, t)
+                if call_info is None:
+                    continue
+                name, offset = call_info
+                if offset == -1:
+                    state_candidates.add(name)
+
+        endo_state_names = tuple(
+            name
+            for name in declared_names
+            if name in state_candidates and name not in shocked
+        )
+        state_names = (*exo_state_names, *endo_state_names)
+        control_names = tuple(
+            name for name in declared_names if name not in set(state_names)
+        )
+        canonical_names = (*state_names, *control_names)
+
+        return VariableLayout(
+            declared_names=declared_names,
+            canonical_names=canonical_names,
+            exo_state_names=exo_state_names,
+            endo_state_names=endo_state_names,
+            control_names=control_names,
+            n_exog=len(exo_state_names),
+            n_state=len(state_names),
+            idx={name: i for i, name in enumerate(canonical_names)},
+        )
+
+    @staticmethod
+    def _function_call_offset(
+        expr: Any,
+        declared_names: set[str],
+        t: Symbol,
+    ) -> tuple[str, int] | None:
+        if not hasattr(expr, "func") or not hasattr(expr.func, "__name__"):
+            return None
+        name = str(expr.func.__name__)
+        if name not in declared_names or not getattr(expr, "args", None):
+            return None
+
+        arg0 = expr.args[0]
+        if t not in getattr(arg0, "free_symbols", set()):
+            return None
+        offset = sp.simplify(arg0 - t)
+        if offset.is_Integer or offset.is_integer is True:
+            return name, int(offset)
+        return None
+
+    @staticmethod
+    def _validate_explicit_variable_order(
+        *,
+        var_order: Sequence[str],
+        inferred_layout: VariableLayout,
+        n_exog: int,
+        n_state: int,
+    ) -> None:
+        declared = set(inferred_layout.declared_names)
+        unknown = [name for name in var_order if name not in declared]
+        if unknown:
+            raise ValueError(
+                f"The following variables in var_order do not exist in the model: {unknown}"
+            )
+        if len(set(var_order)) != len(var_order):
+            raise ValueError("variable_order contains duplicate variables.")
+        if set(var_order) != declared:
+            raise ValueError("variable_order must contain every model variable.")
+
+        expected_exo = set(inferred_layout.exo_state_names)
+        got_exo = set(var_order[:n_exog])
+        if got_exo != expected_exo:
+            raise ValueError(
+                "variable_order is incompatible with inferred state layout. "
+                f"Expected first n_exog variables to be shocked states "
+                f"{list(inferred_layout.exo_state_names)}."
+            )
+
+        expected_states = set(
+            (*inferred_layout.exo_state_names, *inferred_layout.endo_state_names)
+        )
+        got_states = set(var_order[:n_state])
+        if got_states != expected_states:
+            raise ValueError(
+                "variable_order is incompatible with inferred state layout. "
+                f"Expected first n_state variables to be states "
+                f"{list((*inferred_layout.exo_state_names, *inferred_layout.endo_state_names))}."
+            )
 
     def solve(
         self,

--- a/tests/core/test_canonical_variable_layout.py
+++ b/tests/core/test_canonical_variable_layout.py
@@ -1,0 +1,170 @@
+# type: ignore
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import yaml
+
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.kalman.interface import KalmanInterface
+
+
+EXPECTED_CANONICAL_ORDER = ["u", "v", "r", "Pi", "x", "r_star"]
+EXPECTED_IDX = {name: i for i, name in enumerate(EXPECTED_CANONICAL_ORDER)}
+
+
+def _write_misordered_test_model(tmp_path):
+    with open("MODELS/test.yaml", "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    # Deliberately put controls and the unshocked state before shocked states.
+    # The canonical solver layout should still be [shocked states, unshocked
+    # states, controls].
+    data["variables"] = ["Pi", "x", "r_star", "u", "v", "r"]
+    data["kalman"] = {
+        "y": ["Infl", "Rate"],
+        "P0": {
+            "mode": "diag",
+            "scale": 1.0,
+            "diag": {
+                "u": 1.0,
+                "v": 2.0,
+                "r": 3.0,
+                "Pi": 4.0,
+                "x": 5.0,
+                "r_star": 6.0,
+            },
+        },
+    }
+
+    path = tmp_path / "misordered_test.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _compile_misordered_test_model(tmp_path):
+    path = _write_misordered_test_model(tmp_path)
+    model, kalman = ModelParser(path).get_all()
+    solver = DSGESolver(model, kalman)
+    return solver.compile()
+
+
+def test_compile_default_layout_canonicalizes_misordered_yaml_variables(tmp_path):
+    compiled = _compile_misordered_test_model(tmp_path)
+
+    assert compiled.var_names == EXPECTED_CANONICAL_ORDER
+    assert compiled.idx == EXPECTED_IDX
+    assert compiled.layout.declared_names == ("Pi", "x", "r_star", "u", "v", "r")
+    assert compiled.layout.canonical_names == tuple(EXPECTED_CANONICAL_ORDER)
+    assert compiled.layout.exo_state_names == ("u", "v")
+    assert compiled.layout.endo_state_names == ("r",)
+    assert compiled.layout.control_names == ("Pi", "x", "r_star")
+    assert compiled.n_exog == 2
+    assert compiled.n_state == 3
+
+
+def test_measurement_dispatchers_accept_canonical_state_order_after_yaml_reorder(
+    tmp_path,
+):
+    compiled = _compile_misordered_test_model(tmp_path)
+    params = np.array(
+        [compiled.config.calibration.parameters[p] for p in compiled.calib_params],
+        dtype=np.float64,
+    )
+    state = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], dtype=np.float64)
+
+    measurement = compiled.construct_measurement_array_func(["Infl", "Rate"])(
+        state,
+        params,
+    )
+    jacobian = compiled.construct_observable_jacobian_array_func(["Infl", "Rate"])(
+        np.zeros_like(state),
+        params,
+    )
+
+    expected_jacobian = np.zeros((2, len(EXPECTED_CANONICAL_ORDER)), dtype=np.float64)
+    expected_jacobian[0, EXPECTED_IDX["Pi"]] = 1.0
+    expected_jacobian[1, EXPECTED_IDX["r"]] = 1.0
+
+    np.testing.assert_allclose(measurement, np.array([43.25, 30.0]))
+    np.testing.assert_allclose(jacobian, expected_jacobian)
+
+
+def test_kalman_order_sensitive_matrices_use_canonical_compiled_layout(tmp_path):
+    compiled = _compile_misordered_test_model(tmp_path)
+    solved = SolvedModel(
+        compiled=compiled,
+        policy=SimpleNamespace(f=np.zeros((3, 3), dtype=np.float64)),
+        A=np.eye(len(EXPECTED_CANONICAL_ORDER), dtype=np.float64),
+        B=np.vstack(
+            [
+                np.eye(2, dtype=np.float64),
+                np.zeros((len(EXPECTED_CANONICAL_ORDER) - 2, 2), dtype=np.float64),
+            ]
+        ),
+    )
+    ki = KalmanInterface.__new__(KalmanInterface)
+    ki.model = solved
+
+    np.testing.assert_allclose(
+        ki._build_Q(),
+        np.diag([0.50**2, 0.25**2]).astype(np.float64),
+    )
+    np.testing.assert_allclose(
+        ki._build_P0(),
+        np.diag([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).astype(np.float64),
+    )
+
+
+def test_simulation_shock_unpack_accepts_shocks_by_canonical_exogenous_names(tmp_path):
+    compiled = _compile_misordered_test_model(tmp_path)
+    solved = SolvedModel(
+        compiled=compiled,
+        policy=SimpleNamespace(f=np.zeros((3, 3), dtype=np.float64)),
+        A=np.eye(len(EXPECTED_CANONICAL_ORDER), dtype=np.float64),
+        B=np.vstack(
+            [
+                np.eye(2, dtype=np.float64),
+                np.zeros((len(EXPECTED_CANONICAL_ORDER) - 2, 2), dtype=np.float64),
+            ]
+        ),
+    )
+
+    unpacked = solved._shock_unpack(
+        {
+            "u": np.array([1.0, 2.0], dtype=np.float64),
+            "v": np.array([3.0, 4.0], dtype=np.float64),
+        }
+    )
+
+    assert [idx for idx, _ in unpacked] == [EXPECTED_IDX["u"], EXPECTED_IDX["v"]]
+    np.testing.assert_allclose(unpacked[0][1], np.array([1.0, 2.0]))
+    np.testing.assert_allclose(unpacked[1][1], np.array([3.0, 4.0]))
+
+
+def test_compile_rejects_layout_count_overrides_that_disagree(tmp_path):
+    path = _write_misordered_test_model(tmp_path)
+    model, kalman = ModelParser(path).get_all()
+    solver = DSGESolver(model, kalman)
+
+    with pytest.raises(ValueError, match="n_exog=.*inferred"):
+        solver.compile(n_state=3, n_exog=1)
+
+    with pytest.raises(ValueError, match="n_state=.*inferred"):
+        solver.compile(n_state=2, n_exog=2)
+
+
+def test_compile_rejects_explicit_order_with_wrong_state_groups(tmp_path):
+    path = _write_misordered_test_model(tmp_path)
+    model, kalman = ModelParser(path).get_all()
+    solver = DSGESolver(model, kalman)
+
+    with pytest.raises(ValueError, match="first n_exog variables"):
+        solver.compile(
+            variable_order=["Pi", "x", "r_star", "u", "v", "r"],
+            n_state=3,
+            n_exog=2,
+        )

--- a/tests/core/test_solved_model.py
+++ b/tests/core/test_solved_model.py
@@ -219,6 +219,7 @@ def test_solved_model_non_affine_measurement_and_jit_cache():
     compiled = SimpleNamespace(
         observable_funcs=[_obs_shift, _obs_scale],
         observable_names=["ObsShift", "ObsScale"],
+        calib_params=[alpha],
         cur_syms=[Symbol("x")],
         config=SimpleNamespace(calibration=SimpleNamespace(parameters={alpha: 2.0})),
     )

--- a/tests/core/test_solver_compiled.py
+++ b/tests/core/test_solver_compiled.py
@@ -227,12 +227,15 @@ def test_compile_rejects_unknown_param_order(parsed_test):
         )
 
 
-def test_compile_requires_n_state_and_n_exog(parsed_test):
+def test_compile_infers_n_state_and_n_exog(parsed_test):
     model, kalman = parsed_test
     solver = DSGESolver(model, kalman)
 
-    with pytest.raises(ValueError, match="must provide n_state and n_exog"):
-        solver.compile()
+    compiled = solver.compile()
+
+    assert compiled.n_state == 3
+    assert compiled.n_exog == 2
+    assert compiled.var_names[: compiled.n_state] == ["u", "v", "r"]
 
 
 def test_compile_rejects_equations_with_time_offsets_beyond_one(parsed_test):


### PR DESCRIPTION
This pull request introduces a robust and explicit canonical variable layout system to the model compilation process, ensuring that variable ordering is consistent and correct regardless of the order specified in model YAML files. The changes also add comprehensive validation for variable ordering and state groupings, improve error handling, and include a new test suite for these behaviors. Additionally, the compilation process now infers `n_state` and `n_exog` values if not explicitly provided, rather than requiring them as arguments.

**Canonical Variable Layout and Validation:**

* Introduced a new `VariableLayout` dataclass to represent canonical variable ordering, state/control groupings, and index mappings, and integrated it into `CompiledModel` and the solver compilation process (`compiled_model.py`, `solver.py`). [[1]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fR23-R42) [[2]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L19-R18) [[3]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L62-R105) [[4]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L186-R220)
* The solver now infers canonical variable order and state/control groups from model structure, even if the YAML variable list is misordered, and validates any explicit variable order provided by the user. [[1]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L62-R105) [[2]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L202-R380)
* Added error checks to ensure that user-specified variable orders contain all model variables, have no duplicates, and match the expected state/control groupings.

**Compilation and API Improvements:**

* The `compile` method now accepts `Sequence[Function | str]` for `variable_order` and can infer `n_state` and `n_exog` if not provided, improving API flexibility and usability. [[1]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L40-R39) [[2]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L62-R105) [[3]](diffhunk://#diff-2d198ecb9efe862ce7266918e94b58feee99b1c64563f5bf0443633b13d0fe0dL230-R238)
* Cleaned up Jacobian construction to use canonical variable order and improved handling of observable expressions.

**Testing Enhancements:**

* Added a new test module `test_canonical_variable_layout.py` that verifies canonicalization of variable order, correct state/control grouping, error handling for mismatches, and compatibility with Kalman and simulation interfaces.
* Updated existing tests to reflect the new default behavior of inferring state counts and canonical ordering. [[1]](diffhunk://#diff-2d198ecb9efe862ce7266918e94b58feee99b1c64563f5bf0443633b13d0fe0dL230-R238) [[2]](diffhunk://#diff-a0cfc339214dbb7b8e45c67697522c2f8fd4f1591ba943e5e0a5b37555e83ee5R222)

These changes significantly improve the reliability, clarity, and user-friendliness of model compilation and state variable handling in the codebase.

closes #95 