### PR TITLE
Document inferred variable layout and compile API

### DIFF
--- a/docs/Documentation/CompiledModel.md
+++ b/docs/Documentation/CompiledModel.md
@@ -11,6 +11,28 @@ class CompiledModel()
 
 `CompiledModel` contains the model components mapped to numeric/vectorized/lambdified counterparts.
 
+```python
+@dataclass(frozen=True)
+class VariableLayout()
+```
+
+`VariableLayout` records the variable grouping inferred during compilation.
+
+__Layout Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| declared_names | `#!python tuple[str, ...]` | Variables in config declaration order. |
+| canonical_names | `#!python tuple[str, ...]` | Variables in compiled solver order. |
+| exo_state_names | `#!python tuple[str, ...]` | Shock-map targets placed in the shocked/exogenous state block. |
+| endo_state_names | `#!python tuple[str, ...]` | Unshocked variables inferred as states from model dynamics. |
+| control_names | `#!python tuple[str, ...]` | Variables not inferred as states. |
+| n_exog | `#!python int` | Number of shocked/exogenous state variables. |
+| n_state | `#!python int` | Total number of state variables. |
+| idx | `#!python dict[str, int]` | Variable-name to canonical index mapping. |
+
+&nbsp;
+
 __Fields:__
 
 | __Name__ | __Type__ | __Description__ |
@@ -18,7 +40,8 @@ __Fields:__
 | config | `#!python ModelConfig` | Model config that was compiled. |
 | kalman | `#!python KalmanConfig \| None` | Parsed Kalman config attached at compile time. |
 | cur_syms | `#!python list[sympy.Symbol]` | Symbolized current-period state vector (`cur_*` symbols). |
-| var_names | `#!python list[str]` | Variables as strings. |
+| layout | `#!python VariableLayout` | Config-declared and compiler-inferred variable layout metadata. |
+| var_names | `#!python list[str]` | Variables in compiled canonical order. |
 | idx | `#!python dict[str, int]` | Variable-name to index mapping used by solver/simulation. |
 | objective_eqs | `#!python list[sp.Expr]` | Solver targets in symbolic representation. (not used in the solver) |
 | objective_funcs | `#!python list[Callable]` | Solver objectives as standalone `#!python Callable`s. |
@@ -28,8 +51,8 @@ __Fields:__
 | observable_eqs | `#!python list[sp.Expr]` | Measurement equations in symbolic representation. |
 | observable_funcs | `#!python list[Callable]` | Measurement equations as `Callable`s. |
 | observable_jacobian | `#!python Callable[..., np.ndarray]` | Compiled Jacobian function of measurement equations. |
-| n_state | `#!python int` | Number of state variables. |
-| n_exog | `#!python int` | Number of exogenous variables. |
+| n_state | `#!python int` | Number of state variables in the compiled layout. |
+| n_exog | `#!python int` | Number of shocked/exogenous state variables in the compiled layout. |
 
 &nbsp;
 

--- a/docs/Documentation/DSGESolver.md
+++ b/docs/Documentation/DSGESolver.md
@@ -23,32 +23,28 @@ __Methods:__
 ```python
 DSGESolver.compile(
     *,
-    variable_order: list[sp.Function] | None = None,
-    n_state: int = None,
-    n_exog: int = None,
+    variable_order: list[sp.Function | str] | None = None,
+    n_state: int | None = None,
+    n_exog: int | None = None,
     params_order: list[str] | None = None,
     linearize: bool = False,
 ) -> CompiledModel
 ```
 
-???+ warning "Variable Ordering Convention"
-    The model expects the first `#!python n_exog` variables to be the exogenous components. Before solving the model either;
+???+ note "Inferred Variable Layout"
+    `DSGESolver.compile(...)` infers the solver layout from the model config. Shock-map targets define the shocked/exogenous state block, dynamic equations define the remaining state variables, and the rest are treated as controls.
 
-    - Ensure the variable ordering in the config file follows this convention.
-    - Supply an order specification at compile time.
+    If `#!python variable_order`, `#!python n_state`, or `#!python n_exog` are supplied, they are treated as explicit expectations. The compiler sanity-checks them against the config-derived layout and raises if they disagree.
 
-??? info "Planned Changes"
-    Current input constraints will be eliminated as `#! SymbolicDSGE` moves towards the beta releases. `n_exog` and `n_state` will be inferred through flags in the config; and variable ordering will be managed internally.
-
-Produces a `#!python CompiledModel` object respecting the given orders. `#!python n_exog` and `#!python n_state` must be supplied for the current `#!python linearsolve` backend.
+Produces a `#!python CompiledModel` object using the inferred canonical variable layout unless an explicit, validated order is supplied.
 
  __Inputs:__
 
 | __Name__ | __Description__ |
 |:---------|----------------:|
-| variable_order | Custom ordering of variables if desired. |
-| n_state | Number of state variables. |
-| n_exog | Number of exogenous variables. |
+| variable_order | Optional expected variable order. If supplied, it must agree with the config-derived state/exogenous grouping. |
+| n_state | Optional expected number of state variables. Raises if it disagrees with inference. |
+| n_exog | Optional expected number of shocked/exogenous state variables. Raises if it disagrees with inference. |
 | params_order | Custom ordering of model parameters if desired. |
 | linearize | Apply symbolic linearization to a copied model config before compilation. |
 

--- a/docs/Guides/model_config_guide.md
+++ b/docs/Guides/model_config_guide.md
@@ -18,7 +18,7 @@ tags:
 - Shock symbol declarations
 
 This guide contains detailed information about config sections, how they are parsed, and the conventions users are expected to follow for correct parsing.
-The ordering of fields does not matter for the parser, however ordering of the components can change the model behavior. We will start with an empty config and build components to create a valid model in this guide.
+The ordering of top-level fields does not matter for the parser. Component order is preserved as a stable tie-breaker in places where the model does not imply a unique order, but variables do not need to be manually arranged for the solver backend. We will start with an empty config and build components to create a valid model in this guide.
 
 To start with, the configuration accepts a `name` field to specify the model's alias. This name is accessible in the parsed model but never used; it remains in the model object as a reference for users.
 
@@ -28,7 +28,11 @@ name: "Test Model"
 
 ## Variables
 
-The `variables` field contains the names and some optional configuration for all primary model variables. (no time indices or parameters) It is declared as a list or mapping and the ordering of variables will be respected in the solver unless explicitly given a separate ordering. In addition to variable names, each variable requires an explicit boolean entry in the `constrained` field. Having this toggle allows the constraint equations to be predefined in the config but only used when explicitly enabled.
+The `variables` field contains the names and some optional configuration for all primary model variables. (no time indices or parameters) It is declared as a list or mapping. At compile time, the solver infers its canonical layout from the model config: variables targeted by `shock_map` form the shocked/exogenous state block, dynamic equations define the remaining state variables, and all other variables are controls. Declaration order is preserved within those inferred groups.
+
+If an explicit compile-time `variable_order`, `n_state`, or `n_exog` is supplied, it is treated as an expectation and sanity-checked against the inferred layout. A mismatch raises before solving.
+
+In addition to variable names, each variable requires an explicit boolean entry in the `constrained` field. Having this toggle allows the constraint equations to be predefined in the config but only used when explicitly enabled.
 
 When using a mapping instead of a list, the preferred linearization method and the parameter corresponding to a variable's steady-state level can be specified. This additional information is only used when linearizing a non-linear model.
 

--- a/docs/Guides/quickstart.md
+++ b/docs/Guides/quickstart.md
@@ -52,11 +52,8 @@ from SymbolicDSGE import DSGESolver
 
 solver = DSGESolver(model, kalman)
 compiled = solver.compile(
-    variable_order=None, # (1)!
-    params_order=None, # (2)!
-    n_state=3, # (3)!
-    n_exog=2, # (4)!
-    linearize=False, # (5)!
+    params_order=None, # (1)!
+    linearize=False, # (2)!
 )
 
 print("Equations with symbols removed: \n", "\n".join(map(str, compiled.objective_eqs)))
@@ -65,11 +62,8 @@ print("Equations as passed to the solver: \n", compiled.equations)
 
 ```
 
-1. `#!python None | list[Function]`. `#!python None` uses the order in the config file.
-2. `#!python None | list[str]`. `#!python None` uses the order in the config file.
-3. Number of state variables (must be supplied)
-4. Number of exogenous variables (must be supplied)
-5. Set to `#!python True` to symbolically linearize the model config before compiling it
+1. `#!python None | list[str]`. `#!python None` uses the parameter order in the config file.
+2. Set to `#!python True` to symbolically linearize the model config before compiling it.
 
 At compilation, the equations are transformed as shown in the code output:
 ```
@@ -85,8 +79,10 @@ Equations as passed to the solver:
  <function DSGESolver.compile.<locals>.equations at 0x0000012D16AB5B20>
 ```
 
-???+ warning "Variable Placement"
-    The solver relies on the exogenous variables being placed in the first indices. You should ensure the first `n_exog` entries of the order correctly map to the exogenous variables. (either through the config or via the ordering)
+???+ note "Variable Layout"
+    The compiler infers the canonical solver layout from the configuration. Shock-map targets form the shocked/exogenous state block, dynamic equations determine the remaining state variables, and the rest are controls.
+
+    If you pass `#!python variable_order`, `#!python n_state`, or `#!python n_exog`, they are treated as explicit expectations. The compiler checks them against the inferred layout and raises if they do not match the config.
 
 ???+ note "Linearization"
     When passing the linearization flag, the parsed `ModelConfig` must have the linearization parameters defined. (refer to the [Config Guide](./model_config_guide.md))

--- a/docs/guides/estimation_guide.md
+++ b/docs/guides/estimation_guide.md
@@ -29,14 +29,10 @@ parsed = ModelParser("MODELS/POST82.yaml").get_all()
 model, kalman = parsed
 
 solver = DSGESolver(model, kalman)
-compiled = solver.compile(
-    n_state=3, # (1)!
-    n_exog=3, # (2)!
-)
+compiled = solver.compile()
 ```
 
-1. Number of state variables for the linear solver backend.
-2. Number of exogenous variables; first `n_exog` variables must match the exogenous order contract.
+`compile()` infers the solver variable layout from the model config. If you supply `#!python variable_order`, `#!python n_state`, or `#!python n_exog`, they are checked against the inferred layout and a mismatch raises before the model is solved.
 
 ???+ note "Data Input"
     In this example, observed "measurements" are pulled from `FRED` and transformed into model units first. In this guide we assume you already have `observed` as a `DataFrame` with observable columns.

--- a/docs/guides/monte_carlo_guide.md
+++ b/docs/guides/monte_carlo_guide.md
@@ -38,10 +38,7 @@ steady_state = np.zeros(5, dtype=np.float64)  # (2)!
 
 # Solve the reference model
 solver = DSGESolver(model, kalman)
-compiled = solver.compile(
-    n_state=3,
-    n_exog=3,
-)
+compiled = solver.compile()
 reference = solver.solve(compiled, steady_state=steady_state)
 
 # Change parameters and re-compile to get the DGP model


### PR DESCRIPTION
Add documentation for a new VariableLayout dataclass and update CompiledModel to expose layout metadata and canonical var ordering. Clarify DSGESolver.compile API (type annotations, optional parameters) and document that the compiler infers the solver variable layout from the model config (shock_map -> exogenous block, dynamics -> state vars, remainder -> controls). Explain that explicit variable_order, n_state, and n_exog are treated as expectations and are sanity-checked if supplied. Update guides and examples (quickstart, model config, estimation, Monte Carlo) to remove mandatory n_state/n_exog in examples and reflect the new inference and validation behavior, plus minor wording clarifications about component ordering.

closes #97 