### PR TITLE
Switch HAC to matmul estimator; add symmetry helper

### DIFF
--- a/SymbolicDSGE/_diag_tests/hac_covariance.py
+++ b/SymbolicDSGE/_diag_tests/hac_covariance.py
@@ -4,7 +4,9 @@ from numpy.typing import NDArray
 
 from numba import njit
 
-from typing import Literal, Callable
+from typing import Literal, Callable, cast
+
+NDF = NDArray[float64]
 
 # Andrews (1991) bandwidth constants for different kernels
 _C_BARTLETT = 1.1447
@@ -19,14 +21,14 @@ _ANDREWS_C_Q_GETTER: dict[str, tuple[float, float]] = {
 
 
 # Wooldridge Textbook bandwoidth selection rule
-def wooldridge_bandwidth(x: NDArray[float64]) -> int:
+def wooldridge_bandwidth(x: NDF) -> int:
     n = x.shape[0]
     return int(np.floor(4 * (n / 100) ** (2 / 9)))
 
 
 # Andrews (1991) bandwidth selection rule for HAC covariance estimation
 def andrews_bandwidth(
-    y: NDArray[float64], kernel: Literal["bartlett", "parzen", "qs"] = "bartlett"
+    y: NDF, kernel: Literal["bartlett", "parzen", "qs"] = "bartlett"
 ) -> int:
     n = y.shape[0]
     if n < 2 or np.var(y) <= 1e-14:
@@ -55,7 +57,7 @@ def andrews_bandwidth(
 
 
 def andrews_bandwidth_matrix(
-    r: NDArray[np.float64],
+    r: NDF,
     kernel: Literal["bartlett", "parzen", "qs"] = "bartlett",
 ) -> int:
     r = np.asarray(r, dtype=np.float64)
@@ -146,10 +148,10 @@ def kernel_dispatcher(
 # HAC covariance estimation using the specified kernel and bandwidth
 @njit(cache=True)
 def jit_hac_estimator_matmul(
-    r: NDArray[float64],
+    r: NDF,
     k: Callable[[int, int], float64],  # Kernel function
     L: int,  # Bandwidth
-) -> NDArray[float64]:
+) -> NDF:
     n = r.shape[0]
     S = np.zeros((r.shape[1], r.shape[1]), dtype=float64)
     L = min(L, n - 1)
@@ -165,44 +167,13 @@ def jit_hac_estimator_matmul(
     return S
 
 
-@njit(cache=True)
-def jit_hac_estimator_loop(
-    r: NDArray[float64],
-    k: Callable[[int, int], float64],  # Kernel function
-    L: int,  # Bandwidth
-) -> NDArray[float64]:
-    n, p = r.shape
-    S = np.zeros((p, p), dtype=float64)
-    L = min(L, n - 1)
-
-    for t in range(n):
-        for a in range(p):
-            ra = r[t, a]
-            for b in range(p):
-                S[a, b] += ra * r[t, b]
-
-    for j in range(1, L + 1):
-        w_j = k(j, L)
-        if w_j == 0.0:
-            continue
-
-        for t in range(j, n):
-            for a in range(p):
-                ra = r[t, a]
-                ra_lag = r[t - j, a]
-                for b in range(p):
-                    S[a, b] += w_j * (ra * r[t - j, b] + r[t, b] * ra_lag)
-    S /= n
-    return S
-
-
 # Only used when nopython is disabled on kernel dispatch.
 # For testing and maintaining functionality in cases where numba isn't supported.
 def py_hac_estimator(
-    r: NDArray[float64],
+    r: NDF,
     k: Callable[[int, int], float64],  # Kernel function
     L: int,  # Bandwidth
-) -> NDArray[float64]:
+) -> NDF:
 
     n, p = r.shape
     S = np.zeros((p, p), dtype=float64)
@@ -219,67 +190,19 @@ def py_hac_estimator(
     return S
 
 
-# Buffer-write estimator for compiled Wald test path
-@njit(cache=True)
-def jit_hac_estimator_loop_into(
-    r: NDArray[float64],
-    k: Callable[[int, int], float64],
-    L: int,
-    S: NDArray[float64],
-) -> None:
-    n, p = r.shape
-    L = min(L, n - 1)
-
-    for a in range(p):
-        for b in range(p):
-            S[a, b] = 0.0
-
-    # Gamma_0 numerator
-    for t in range(n):
-        for a in range(p):
-            ra = r[t, a]
-            for b in range(p):
-                S[a, b] += ra * r[t, b]
-
-    # Weighted autocovariances
-    for j in range(1, L + 1):
-        w_j = k(j, L)
-        if w_j == 0.0:
-            continue
-
-        for t in range(j, n):
-            for a in range(p):
-                ra = r[t, a]
-                ra_lag = r[t - j, a]
-
-                for b in range(p):
-                    S[a, b] += w_j * (ra * r[t - j, b] + r[t, b] * ra_lag)
-
-    for a in range(p):
-        for b in range(p):
-            S[a, b] /= n
-
-
-_ESTIMATOR_DISPATCHER = {
-    "matmul": jit_hac_estimator_matmul,
-    "loop": jit_hac_estimator_loop,
-    "py": py_hac_estimator,
-}
-
-
 def hac_covariance(
-    r: NDArray[np.float64],
+    r: NDF,
     kernel: Literal["bartlett", "parzen", "qs"] = "bartlett",
     bandwidth: int | Literal["wooldridge", "andrews", "auto"] | None = "auto",
     center: bool = False,
     nopython: bool = True,
-) -> NDArray[np.float64]:
+) -> NDF:
     r = np.ascontiguousarray(r, dtype=np.float64)
 
     if r.ndim != 2:
         raise ValueError(f"r must be 2D with shape (n, p), got {r.shape}.")
 
-    n, p = r.shape
+    n = r.shape[0]
     if n < 2:
         raise ValueError(f"r must have at least 2 observations, got {n}.")
 
@@ -311,12 +234,6 @@ def hac_covariance(
     k = kernel_dispatcher(kernel, nopython=nopython)
 
     if nopython:
-        if p <= 8:
-            estimator_func = _ESTIMATOR_DISPATCHER["loop"]
-        else:
-            estimator_func = _ESTIMATOR_DISPATCHER["matmul"]
-    else:
-        estimator_func = _ESTIMATOR_DISPATCHER["py"]
+        return cast(NDF, jit_hac_estimator_matmul(r, k, L))
 
-    out: NDArray[float64] = estimator_func(r, k, L)
-    return out
+    return py_hac_estimator(r, k, L)

--- a/SymbolicDSGE/_diag_tests/wald_test.py
+++ b/SymbolicDSGE/_diag_tests/wald_test.py
@@ -1,4 +1,4 @@
-from .hac_covariance import jit_hac_estimator_loop_into, hac_covariance
+from .hac_covariance import jit_hac_estimator_matmul, hac_covariance
 from .moment_calculation_utils import jit_fill_centered, jit_fill_mean_ax0
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
@@ -18,6 +18,8 @@ ERR_BAD_SHAPE = int64(TestStatus.BAD_SHAPE)
 ERR_LINALG = int64(TestStatus.LINALG)
 
 F64_NAN = float64(np.nan)
+SYMMETRY_ATOL = float64(1e-8)
+SYMMETRY_RTOL = float64(1e-5)
 
 
 @njit(cache=True)
@@ -100,7 +102,10 @@ def jit_wald_hac_stat(
     jit_fill_mean_ax0(g, mean_buffer)
     jit_fill_centered(g, mean_buffer, centered_buffer)
 
-    jit_hac_estimator_loop_into(centered_buffer, k, L, omega_buffer)
+    omega = jit_hac_estimator_matmul(centered_buffer, k, L)
+    for i in range(q):
+        for j in range(q):
+            omega_buffer[i, j] = omega[i, j]
 
     out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
         mean_buffer,
@@ -127,6 +132,34 @@ def jit_symmetric_outer_prod_2dim(x: NDF, out: NDF) -> int64:
             for j in range(i, p):
                 out[t, k] = x_i * x[t, j]
                 k += 1
+    return OK
+
+
+@njit(cache=True)
+def jit_fill_symmetric_target_vec(
+    target: NDF,
+    out: NDF,
+    atol: float64 = SYMMETRY_ATOL,
+    rtol: float64 = SYMMETRY_RTOL,
+) -> int64:
+    p = target.shape[0]
+    q = p * (p + 1) // 2
+
+    if target.shape[1] != p or out.shape[0] != q:
+        return ERR_BAD_SHAPE
+
+    k = 0
+    for i in range(p):
+        for j in range(i, p):
+            a = target[i, j]
+            b = target[j, i]
+            if a != b:
+                diff = abs(a - b)
+                if not np.isfinite(diff) or diff > atol + rtol * abs(b):
+                    return ERR_BAD_SHAPE
+            out[k] = a
+            k += 1
+
     return OK
 
 
@@ -163,21 +196,25 @@ def wald_mean_hac(
          Wald test result containing the test statistic, degrees of freedom, and p-value method.
     """
 
-    n, q = g.shape
+    g_arr = np.ascontiguousarray(g, dtype=float64)
+    target_arr = np.ascontiguousarray(target, dtype=float64)
+    n, q = g_arr.shape
 
     mean_buffer = np.empty(q, dtype=float64)
-    jit_fill_mean_ax0(g, mean_buffer)
+    centered_buffer = np.empty_like(g_arr)
+    jit_fill_mean_ax0(g_arr, mean_buffer)
+    jit_fill_centered(g_arr, mean_buffer, centered_buffer)
 
     omega = hac_covariance(
-        g,
+        centered_buffer,
         kernel=kernel,
         bandwidth=bandwidth,
-        center=True,
+        center=False,
         nopython=True,
     )
     out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
         mean_buffer,
-        target,
+        target_arr,
         omega,
         n,
     )
@@ -223,22 +260,25 @@ def wald_covariance_hac(
         Significance level for the test, used for p-value calculation. Default is 0.05.
     """
 
-    if target.ndim != 2 or target.shape[0] != target.shape[1]:
+    g_arr = np.ascontiguousarray(g, dtype=float64)
+    target_arr = np.ascontiguousarray(target, dtype=float64)
+
+    if target_arr.ndim != 2 or target_arr.shape[0] != target_arr.shape[1]:
         raise ValueError("Target covariance matrix must be square")
-    if target.shape[0] != g.shape[1]:
+    if target_arr.shape[0] != g_arr.shape[1]:
         raise ValueError("Target covariance matrix dimension must match g columns")
-    if not np.allclose(target, target.T, atol=1e-8):
+
+    n, p = g_arr.shape
+    q = p * (p + 1) // 2
+    target_vec = np.empty(q, dtype=float64)
+    err = jit_fill_symmetric_target_vec(target_arr, target_vec)
+    if err != OK:
         raise ValueError("Target covariance matrix must be symmetric")
-    vech_idx = np.triu_indices(target.shape[0])
-    target_vec = target[vech_idx]  # p * (p + 1) // 2
 
-    n, _ = g.shape
-    q = target_vec.shape[0]
-
-    centered = np.empty_like(g)
-    mean = np.empty(g.shape[1], dtype=float64)
-    jit_fill_mean_ax0(g, mean)
-    jit_fill_centered(g, mean, centered)
+    centered = np.empty_like(g_arr)
+    mean = np.empty(p, dtype=float64)
+    jit_fill_mean_ax0(g_arr, mean)
+    jit_fill_centered(g_arr, mean, centered)
 
     g_cov = np.empty((n, q), dtype=float64)
     err = jit_symmetric_outer_prod_2dim(centered, g_cov)
@@ -248,13 +288,15 @@ def wald_covariance_hac(
         )
 
     g_cov_mean = np.empty(q, dtype=float64)
+    g_cov_centered = np.empty_like(g_cov)
     jit_fill_mean_ax0(g_cov, g_cov_mean)
+    jit_fill_centered(g_cov, g_cov_mean, g_cov_centered)
 
     omega = hac_covariance(
-        g_cov,
+        g_cov_centered,
         kernel=kernel,
         bandwidth=bandwidth,
-        center=True,
+        center=False,
         nopython=True,
     )
 
@@ -262,7 +304,7 @@ def wald_covariance_hac(
         g_cov_mean,
         target_vec,
         omega,
-        g.shape[0],
+        g_arr.shape[0],
     )
     err, stat, df = out
     if err != OK:
@@ -306,33 +348,42 @@ def wald_second_moment_hac(
         Significance level for the test, used for p-value calculation. Default is 0.05.
     """
 
-    if target.ndim != 2 or target.shape[0] != target.shape[1]:
-        raise ValueError("Target second moment matrix must be square")
-    if target.shape[0] != g.shape[1]:
-        raise ValueError("Target second moment matrix dimension must match g columns")
-    if not np.allclose(target, target.T, atol=1e-8):
-        raise ValueError("Target second moment matrix must be symmetric")
-    vech_idx = np.triu_indices(target.shape[0])
-    target_vec = target[vech_idx]  # p * (p + 1) // 2
+    g_arr = np.ascontiguousarray(g, dtype=float64)
+    target_arr = np.ascontiguousarray(target, dtype=float64)
 
-    n, _ = g.shape
-    q = target_vec.shape[0]
+    if target_arr.ndim != 2 or target_arr.shape[0] != target_arr.shape[1]:
+        raise ValueError("Target second moment matrix must be square")
+    if target_arr.shape[0] != g_arr.shape[1]:
+        raise ValueError("Target second moment matrix dimension must match g columns")
+
+    n, p = g_arr.shape
+    q = p * (p + 1) // 2
+    target_vec = np.empty(q, dtype=float64)
+    err = jit_fill_symmetric_target_vec(target_arr, target_vec)
+    if err != OK:
+        raise ValueError("Target second moment matrix must be symmetric")
 
     g_second_moment = np.empty((n, q), dtype=float64)
-    err = jit_symmetric_outer_prod_2dim(g, g_second_moment)
+    err = jit_symmetric_outer_prod_2dim(g_arr, g_second_moment)
     if err != OK:
         raise ValueError(
             f"Failed to compute symmetric outer product with error code {err}"
         )
 
     g_second_moment_mean = np.empty(q, dtype=float64)
+    g_second_moment_centered = np.empty_like(g_second_moment)
     jit_fill_mean_ax0(g_second_moment, g_second_moment_mean)
+    jit_fill_centered(
+        g_second_moment,
+        g_second_moment_mean,
+        g_second_moment_centered,
+    )
 
     omega = hac_covariance(
-        g_second_moment,
+        g_second_moment_centered,
         kernel=kernel,
         bandwidth=bandwidth,
-        center=True,
+        center=False,
         nopython=True,
     )
 
@@ -340,7 +391,7 @@ def wald_second_moment_hac(
         g_second_moment_mean,
         target_vec,
         omega,
-        g.shape[0],
+        g_arr.shape[0],
     )
     err, stat, df = out
     if err != OK:

--- a/SymbolicDSGE/monte_carlo/operations.py
+++ b/SymbolicDSGE/monte_carlo/operations.py
@@ -50,36 +50,35 @@ def simulate_dgp(
         rep_idx=rep_idx,
         seed_increment=seed_increment,
     )
-    if isinstance(dgp, SolvedModel):
-        states = np.ascontiguousarray(
-            dgp._simulate_state_matrix(
-                T=T,
-                shocks=sim_shocks,
-                shock_scale=shock_scale,
-                x0=x0,
-            ),
-            dtype=np.float64,
-        )
-        obs_names = (
-            tuple(getattr(dgp.compiled, "observable_names", ())) if observables else ()
-        )
-        obs_mat = None
-        raw: dict[str, np.ndarray] = {
-            name: states[:, dgp.compiled.idx[name]] for name in dgp.compiled.var_names
-        }
-        raw["_X"] = states
-        if obs_names:
-            obs_full = dgp._simulate_observable_matrix(states, drop_initial=False)
-            obs_mat = np.ascontiguousarray(obs_full[1:], dtype=np.float64)
-            for i, name in enumerate(obs_names):
-                raw[name] = obs_full[:, i]
-        return MCData(
-            states=states,
-            observables=obs_mat,
-            raw=raw,
-            n_exog=int(getattr(dgp.compiled, "n_exog", -1)),
-            observable_names=obs_names,
-        )
+    states = np.ascontiguousarray(
+        dgp._simulate_state_matrix(
+            T=T,
+            shocks=sim_shocks,
+            shock_scale=shock_scale,
+            x0=x0,
+        ),
+        dtype=np.float64,
+    )
+    obs_names = (
+        tuple(getattr(dgp.compiled, "observable_names", ())) if observables else ()
+    )
+    obs_mat = None
+    raw: dict[str, np.ndarray] = {
+        name: states[:, dgp.compiled.idx[name]] for name in dgp.compiled.var_names
+    }
+    raw["_X"] = states
+    if obs_names:
+        obs_full = dgp._simulate_observable_matrix(states, drop_initial=False)
+        obs_mat = np.ascontiguousarray(obs_full[1:], dtype=np.float64)
+        for i, name in enumerate(obs_names):
+            raw[name] = obs_full[:, i]
+    return MCData(
+        states=states,
+        observables=obs_mat,
+        raw=raw,
+        n_exog=int(getattr(dgp.compiled, "n_exog", -1)),
+        observable_names=obs_names,
+    )
 
 
 def raw_data_datagen(

--- a/tests/diag_tests/test_hac_covariance.py
+++ b/tests/diag_tests/test_hac_covariance.py
@@ -8,8 +8,6 @@ from SymbolicDSGE._diag_tests.hac_covariance import (
     andrews_bandwidth_matrix,
     bartlett_kernel,
     hac_covariance,
-    jit_hac_estimator_loop,
-    jit_hac_estimator_loop_into,
     jit_hac_estimator_matmul,
     kernel_dispatcher,
     parzen_kernel,
@@ -168,17 +166,11 @@ def test_hac_covariance_covers_auto_and_explicit_selection_branches() -> None:
     )
 
 
-def test_hac_jit_estimators_python_paths_match_py_estimator() -> None:
+def test_hac_jit_matmul_python_path_matches_py_estimator() -> None:
     expected = py_hac_estimator(GOLDEN_R, bartlett_kernel, 2)
-    loop_out = jit_hac_estimator_loop.py_func(GOLDEN_R, bartlett_kernel, 2)
     matmul_out = jit_hac_estimator_matmul.py_func(GOLDEN_R, bartlett_kernel, 2)
-    into_out = np.empty((2, 2), dtype=np.float64)
 
-    jit_hac_estimator_loop_into.py_func(GOLDEN_R, bartlett_kernel, 2, into_out)
-
-    np.testing.assert_allclose(loop_out, expected)
     np.testing.assert_allclose(matmul_out, expected)
-    np.testing.assert_allclose(into_out, expected)
 
 
 def test_andrews_bandwidth_matrix_validates_shape_and_accepts_vectors() -> None:

--- a/tests/diag_tests/test_wald_test.py
+++ b/tests/diag_tests/test_wald_test.py
@@ -16,6 +16,7 @@ from SymbolicDSGE._diag_tests.wald_test import (
     ERR_BAD_SHAPE,
     ERR_LINALG,
     OK,
+    jit_fill_symmetric_target_vec,
     jit_wald_hac_stat,
     jit_symmetric_outer_prod_2dim,
     jit_wald_stat_from_mean_and_cov,
@@ -313,6 +314,22 @@ def test_symmetric_outer_product_fills_upper_triangle_moments() -> None:
         out,
         np.array([[1.0, 2.0, 4.0], [9.0, -3.0, 1.0]], dtype=np.float64),
     )
+
+
+def test_symmetric_target_vector_helper_fills_and_rejects_bad_shapes() -> None:
+    target = np.array([[1.0, 0.25], [0.25, 2.0]], dtype=np.float64)
+    out = np.empty(3, dtype=np.float64)
+
+    err = jit_fill_symmetric_target_vec.py_func(target, out)
+
+    assert err == OK
+    np.testing.assert_allclose(out, np.array([1.0, 0.25, 2.0], dtype=np.float64))
+
+    bad_target = np.array([[1.0, 0.1], [0.2, 1.0]], dtype=np.float64)
+    assert jit_fill_symmetric_target_vec.py_func(bad_target, out) == ERR_BAD_SHAPE
+
+    bad_out = np.empty(2, dtype=np.float64)
+    assert jit_fill_symmetric_target_vec.py_func(target, bad_out) == ERR_BAD_SHAPE
 
 
 def test_wald_public_wrappers_validate_targets_and_report_failures() -> None:

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -44,19 +44,16 @@ from SymbolicDSGE.regression.ridge import RidgeResult
 class _FakeSolvedModel:
     def __init__(self, offset: float = 0.0) -> None:
         self.offset = offset
-        self.compiled = SimpleNamespace(n_exog=1, observable_names=["obs"])
+        self.compiled = SimpleNamespace(
+            idx={"x": 0, "z": 1},
+            var_names=["x", "z"],
+            n_exog=1,
+            observable_names=["obs"],
+        )
         self.kalman_calls: list[dict] = []
         self.sim_shocks: list[dict[str, np.ndarray]] = []
 
-    def sim(
-        self,
-        T,
-        shocks=None,
-        shock_scale=1.0,
-        x0=None,
-        observables=False,
-    ):
-        del shock_scale, x0
+    def _draw_shocks(self, shocks=None) -> None:
         shock_draws = {}
         if shocks is not None:
             for name, shock in shocks.items():
@@ -70,12 +67,42 @@ class _FakeSolvedModel:
                 else:
                     shock_draws[name] = np.asarray(shock, dtype=np.float64)
         self.sim_shocks.append(shock_draws)
+
+    def _simulate_state_matrix(
+        self,
+        T,
+        shocks=None,
+        shock_scale=1.0,
+        x0=None,
+    ):
+        del shock_scale, x0
+        self._draw_shocks(shocks)
         t = np.arange(T + 1, dtype=np.float64)
-        states = np.column_stack(
+        return np.column_stack(
             [
                 t + self.offset,
                 ((t % 3.0) - 1.0) + 0.5 * self.offset,
             ]
+        )
+
+    def _simulate_observable_matrix(self, states, *, drop_initial=False):
+        start = 1 if drop_initial else 0
+        obs = 0.5 * states[:, 0] + states[:, 1]
+        return np.ascontiguousarray(obs[start:].reshape(-1, 1), dtype=np.float64)
+
+    def sim(
+        self,
+        T,
+        shocks=None,
+        shock_scale=1.0,
+        x0=None,
+        observables=False,
+    ):
+        states = self._simulate_state_matrix(
+            T=T,
+            shocks=shocks,
+            shock_scale=shock_scale,
+            x0=x0,
         )
         out = {
             "_X": states,
@@ -83,7 +110,10 @@ class _FakeSolvedModel:
             "z": states[:, 1],
         }
         if observables:
-            out["obs"] = 0.5 * states[:, 0] + states[:, 1]
+            out["obs"] = self._simulate_observable_matrix(
+                states,
+                drop_initial=False,
+            )[:, 0]
         return out
 
     def kalman(self, y, **kwargs):


### PR DESCRIPTION
This pull request refactors and streamlines the HAC covariance estimation and Wald test code, improving clarity, robustness, and test coverage. The main changes include consolidating and simplifying estimator implementations, improving symmetry validation for covariance matrices, and updating tests to match the new structure.

**HAC Covariance Estimation Refactor:**
- Removed the `jit_hac_estimator_loop` and `jit_hac_estimator_loop_into` estimators, consolidating all JIT estimation to `jit_hac_estimator_matmul` for both production and test code. The estimator selection logic in `hac_covariance` is simplified to use only `matmul` or the pure Python version. [[1]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L168-R176) [[2]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L222-R205) [[3]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L314-R239) [[4]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL1-R1) [[5]](diffhunk://#diff-5490efdc0c3f0da7e7fd41614e08a0790672e9a17f374700d13b62abc54aaa15L11-L12) [[6]](diffhunk://#diff-5490efdc0c3f0da7e7fd41614e08a0790672e9a17f374700d13b62abc54aaa15L171-L181)
- Introduced a type alias `NDF` for `NDArray[float64]` to make type annotations more concise and consistent throughout the file. [[1]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L7-R9) [[2]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L22-R31) [[3]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L58-R60) [[4]](diffhunk://#diff-e3ebe6fddda7c7cbee6e7f23f34a652f3c782e64564b87287cfe4d0d534acfb9L149-R154)

**Symmetry and Target Vector Handling:**
- Added a new JIT-compiled helper `jit_fill_symmetric_target_vec` to robustly validate and extract the upper-triangular vector from symmetric target matrices, with configurable tolerances. This is now used in all relevant Wald test wrappers. [[1]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR138-R165) [[2]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL226-R281) [[3]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL309-R394) [[4]](diffhunk://#diff-cef56d344094bf2c565f120c9d09595b37015a1b314604b80707c14ae61c5941R19) [[5]](diffhunk://#diff-cef56d344094bf2c565f120c9d09595b37015a1b314604b80707c14ae61c5941R319-R334)

**Wald Test Wrappers and Covariance Usage:**
- All Wald test wrappers now explicitly center input data before passing to `hac_covariance`, and set `center=False` to avoid double-centering. They also ensure all arrays are contiguous and of correct dtype for JIT compatibility. [[1]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL166-R217) [[2]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL226-R281) [[3]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efR291-R307) [[4]](diffhunk://#diff-9b3abc829ae30a9e6133ab090f888c28887677a6a480007a7019f79305e4b6efL309-R394)

**Testing Improvements:**
- Updated and added tests to match the new estimator structure and to thoroughly check the new symmetric target vector helper, including rejection of non-symmetric or mis-shaped inputs. [[1]](diffhunk://#diff-5490efdc0c3f0da7e7fd41614e08a0790672e9a17f374700d13b62abc54aaa15L171-L181) [[2]](diffhunk://#diff-cef56d344094bf2c565f120c9d09595b37015a1b314604b80707c14ae61c5941R319-R334)

**Test Utility and Mock Model Updates:**
- Refactored the `_FakeSolvedModel` in test code to more closely match the real model interface, including state and observable simulation. [[1]](diffhunk://#diff-e20b5d7e65a9cdf9176b4b1187e48ec92693786daccf70617c36f981ba454838L47-R56) [[2]](diffhunk://#diff-e20b5d7e65a9cdf9176b4b1187e48ec92693786daccf70617c36f981ba454838R70-R116)

These changes improve maintainability, correctness, and testability of the HAC covariance and Wald test infrastructure.

closes #102 