### PR TITLE
Make pysr optional and lazy-load sr deps

### DIFF
--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -1,5 +1,15 @@
 from dataclasses import dataclass, asdict
-from typing import Any, Callable, Tuple, Union, Literal, TypedDict, Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Tuple,
+    Union,
+    Literal,
+    TypedDict,
+    Mapping,
+    cast,
+)
 import textwrap
 
 
@@ -21,16 +31,22 @@ from ..kalman.config import KalmanConfig
 from ..kalman.interface import KalmanInterface
 from ..kalman.filter import FilterResult
 
-
-from ..regression.sr.sr_interface import SRInterface
-from ..regression.sr.config import TemplateConfig
-from ..regression.sr.model_defaults import PySRParams
-from ..regression.sr.model_parametrizer import ModelParametrizer
-from ..regression.sr.fit_result import FitResult
+if TYPE_CHECKING:
+    from ..regression.sr.config import TemplateConfig
+    from ..regression.sr.fit_result import FitResult
+    from ..regression.sr.model_defaults import PySRParams
+    from ..regression.sr.model_parametrizer import ModelParametrizer
 
 _JIT_CACHE: dict[int, Callable] = {}
 ND = NDArray
 NDF = NDArray[float64]
+
+
+def _load_sr_fit_dependencies() -> tuple[type, type]:
+    from ..regression.sr.model_parametrizer import ModelParametrizer
+    from ..regression.sr.sr_interface import SRInterface
+
+    return ModelParametrizer, SRInterface
 
 
 class MeasurementSpec(TypedDict):
@@ -605,16 +621,17 @@ class SolvedModel:
         self,
         y: NDF | pd.DataFrame,
         observable: str,
-        template_config: TemplateConfig | None = None,
-        sr_params: PySRParams | None = None,
+        template_config: "TemplateConfig | None" = None,
+        sr_params: "PySRParams | None" = None,
         variables: list[str] | None = None,
-        parametrizer: ModelParametrizer | None = None,
-    ) -> FitResult:
+        parametrizer: "ModelParametrizer | None" = None,
+    ) -> "FitResult":
         if parametrizer is None:
             if template_config is None or sr_params is None:
                 raise ValueError(
                     "Provide either a pre-built parametrizer or both template_config and sr_params."
                 )
+            ModelParametrizer, SRInterface = _load_sr_fit_dependencies()
             parametrizer = ModelParametrizer(
                 variables or self.compiled.var_names,
                 sr_params,
@@ -626,6 +643,8 @@ class SolvedModel:
             raise ValueError(
                 "Provided variables do not match the parametrizer's variable names."
             )
+        else:
+            _, SRInterface = _load_sr_fit_dependencies()
 
         interface = SRInterface(
             model=self,
@@ -633,4 +652,4 @@ class SolvedModel:
             parametrizer=parametrizer,
         )
 
-        return interface.fit_to_kf(y)
+        return cast("FitResult", interface.fit_to_kf(y))

--- a/SymbolicDSGE/regression/__init__.py
+++ b/SymbolicDSGE/regression/__init__.py
@@ -1,4 +1,7 @@
-from . import elastic_net, lasso, ols, ridge, sr
+from importlib import import_module
+from typing import Any
+
+from . import elastic_net, lasso, ols, ridge
 from .result import RegressionResult
 from .enums import RegressionKind, RegressionStatus
 
@@ -12,3 +15,9 @@ __all__ = [
     "ridge",
     "sr",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "sr":
+        return import_module(f"{__name__}.sr")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/SymbolicDSGE/regression/sr/__init__.py
+++ b/SymbolicDSGE/regression/sr/__init__.py
@@ -1,3 +1,12 @@
+from importlib.util import find_spec
+
+if find_spec("pysr") is None:
+    raise ImportError(
+        "Symbolic regression requires the 'sr' optional dependency. "
+        "Install it with 'pip install SymbolicDSGE[sr]' or an equivalent "
+        "environment command before importing SymbolicDSGE.regression.sr."
+    )
+
 from .model_parametrizer import ModelParametrizer
 from .model_defaults import make_operator_general, CustomOp, PySRParams
 from .config import TemplateConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "numba>=0.62.1",
     "numpy>=2.3.5",
     "pandas>=2.3.3",
-    "pysr>=1.5.9",
     "pyyaml>=6.0.3",
     "scipy>=1.16.3",
     "statsmodels>=0.14.6",
@@ -34,6 +33,9 @@ Repository = "https://github.com/GongJr0/SymbolicDSGE"
 fred = [
     "fredapi>=0.5.2",
     "python-dotenv>=1.2.1",
+]
+sr = [
+    "pysr>=1.5.10",
 ]
 
 [dependency-groups]

--- a/tests/core/test_solved_model_fit_kf_contract.py
+++ b/tests/core/test_solved_model_fit_kf_contract.py
@@ -6,9 +6,6 @@ import pytest
 
 import SymbolicDSGE.core.solved_model as solved_model_module
 from SymbolicDSGE.core.solved_model import SolvedModel
-from SymbolicDSGE.regression.sr.config import TemplateConfig
-from SymbolicDSGE.regression.sr.model_defaults import PySRParams
-from SymbolicDSGE.regression.sr.model_parametrizer import ModelParametrizer
 
 
 def _make_solved_model() -> SolvedModel:
@@ -18,6 +15,21 @@ def _make_solved_model() -> SolvedModel:
         A=np.zeros((1, 1), dtype=np.float64),
         B=np.zeros((1, 1), dtype=np.float64),
     )
+
+
+class _FakeTemplateConfig:
+    pass
+
+
+class _FakePySRParams:
+    pass
+
+
+class _FakeParametrizer:
+    def __init__(self, variable_names, params=None, config=None):
+        self.variable_names = list(variable_names)
+        self.params = params
+        self.config = config
 
 
 def test_fit_kf_accepts_prebuilt_parametrizer(monkeypatch):
@@ -33,14 +45,14 @@ def test_fit_kf_accepts_prebuilt_parametrizer(monkeypatch):
             captured["y"] = y
             return "fit-result"
 
-    monkeypatch.setattr(solved_model_module, "SRInterface", _FakeSRInterface)
+    monkeypatch.setattr(
+        solved_model_module,
+        "_load_sr_fit_dependencies",
+        lambda: (_FakeParametrizer, _FakeSRInterface),
+    )
 
     solved = _make_solved_model()
-    parametrizer = ModelParametrizer(
-        ["x"],
-        PySRParams(precision=32),
-        TemplateConfig(),
-    )
+    parametrizer = _FakeParametrizer(["x"])
     y = np.zeros((4, 1), dtype=np.float64)
 
     out = solved.fit_kf(
@@ -58,11 +70,7 @@ def test_fit_kf_accepts_prebuilt_parametrizer(monkeypatch):
 
 def test_fit_kf_rejects_mismatched_variables_for_prebuilt_parametrizer():
     solved = _make_solved_model()
-    parametrizer = ModelParametrizer(
-        ["x"],
-        PySRParams(precision=32),
-        TemplateConfig(),
-    )
+    parametrizer = _FakeParametrizer(["x"])
 
     with pytest.raises(ValueError, match="do not match the parametrizer"):
         solved.fit_kf(
@@ -86,7 +94,7 @@ def test_fit_kf_requires_template_inputs_when_parametrizer_is_missing():
 def test_fit_kf_builds_parametrizer_when_not_provided(monkeypatch):
     captured = {}
 
-    class _FakeParametrizer:
+    class _CapturingParametrizer:
         def __init__(self, variable_names, params, config):
             captured["variable_names"] = variable_names
             captured["params"] = params
@@ -103,12 +111,15 @@ def test_fit_kf_builds_parametrizer_when_not_provided(monkeypatch):
             captured["y"] = y
             return "fit-result"
 
-    monkeypatch.setattr(solved_model_module, "ModelParametrizer", _FakeParametrizer)
-    monkeypatch.setattr(solved_model_module, "SRInterface", _FakeSRInterface)
+    monkeypatch.setattr(
+        solved_model_module,
+        "_load_sr_fit_dependencies",
+        lambda: (_CapturingParametrizer, _FakeSRInterface),
+    )
 
     solved = _make_solved_model()
-    template_config = TemplateConfig()
-    sr_params = PySRParams(precision=32)
+    template_config = _FakeTemplateConfig()
+    sr_params = _FakePySRParams()
     y = np.zeros((3, 1), dtype=np.float64)
 
     out = solved.fit_kf(

--- a/uv.lock
+++ b/uv.lock
@@ -2739,7 +2739,6 @@ dependencies = [
     { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pysr" },
     { name = "pyyaml" },
     { name = "scipy" },
     { name = "statsmodels" },
@@ -2750,6 +2749,9 @@ dependencies = [
 fred = [
     { name = "fredapi" },
     { name = "python-dotenv" },
+]
+sr = [
+    { name = "pysr" },
 ]
 
 [package.dev-dependencies]
@@ -2783,14 +2785,14 @@ requires-dist = [
     { name = "numba", specifier = ">=0.62.1" },
     { name = "numpy", specifier = ">=2.3.5" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "pysr", specifier = ">=1.5.9" },
+    { name = "pysr", marker = "extra == 'sr'", specifier = ">=1.5.10" },
     { name = "python-dotenv", marker = "extra == 'fred'", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "scipy", specifier = ">=1.16.3" },
     { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "sympy", specifier = ">=1.14.0" },
 ]
-provides-extras = ["fred"]
+provides-extras = ["fred", "sr"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request refactors how the symbolic regression (`sr`) dependency on `pysr` is handled, making it an optional dependency and improving import-time performance and error messaging. It also updates the public API and corresponding tests to avoid direct imports of `sr` types at the top level, and adjusts dependency management in `pyproject.toml`. 

**Optional symbolic regression dependency and dynamic imports:**

* The `SymbolicDSGE.regression.sr` module now checks for the `pysr` library on import and provides a clear error message if it's missing, making `pysr` an optional dependency instead of a core requirement.
* The main regression package (`SymbolicDSGE/regression/__init__.py`) uses a dynamic import for `sr`, so it is only loaded when accessed, and raises an appropriate error if unavailable. [[1]](diffhunk://#diff-0bfa12f83b99460f07a26927823d7d578a6f5b1722f42491f31a1593f0c21c3eL1-R4) [[2]](diffhunk://#diff-0bfa12f83b99460f07a26927823d7d578a6f5b1722f42491f31a1593f0c21c3eR18-R23)

**Type hinting and dependency loading improvements:**

* In `SymbolicDSGE/core/solved_model.py`, imports of `sr`-related types are moved inside a `TYPE_CHECKING` block and a new `_load_sr_fit_dependencies()` function is used to load them only when needed at runtime, reducing unnecessary imports and improving startup time. [[1]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL24-R51) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL608-R634) [[3]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadR646-R655)
* Type hints for parameters and return values in `fit_kf` are now quoted strings to avoid import-time errors if `pysr` is not installed.

**Dependency management:**

* The core `pyproject.toml` dependencies no longer require `pysr` by default; instead, an `[sr]` extra is added for optional installation (`pip install SymbolicDSGE[sr]`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R37-R39)

**Testing improvements:**

* Tests for `fit_kf` in `test_solved_model_fit_kf_contract.py` are updated to use fake classes and monkeypatching, so they do not require `pysr` or real `sr` types, ensuring tests can run without the optional dependency. [[1]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dL9-L11) [[2]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dR20-R34) [[3]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dL36-R55) [[4]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dL61-R73) [[5]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dL89-R97) [[6]](diffhunk://#diff-ce16b0a8d030c9f39bec07e686d055ab061abdaf6e4b9d99b53871938de6a40dL106-R122)

closes #107 