### PR TITLE
Include test status traces in MC results

### DIFF
--- a/SymbolicDSGE/_diag_tests/result.py
+++ b/SymbolicDSGE/_diag_tests/result.py
@@ -169,6 +169,7 @@ class MCResult:
     pval_method: PvalMethod
     alpha: float64
     statistic_trace: NDArray[float64]
+    status_trace: tuple[TestStatus, ...]
 
     frozen_dist: FrozenDistribution = field(init=False, repr=False)
     pval_trace: NDArray[float64] = field(init=False)
@@ -188,6 +189,12 @@ class MCResult:
         if n == 0:
             raise ValueError("statistic_trace must be non-empty")
 
+        status_trace = tuple(TestStatus(status) for status in self.status_trace)
+        if len(status_trace) != n:
+            raise ValueError(
+                "status_trace and statistic_trace must have the same length"
+            )
+
         df = _normalize_df(self.df)
         object.__setattr__(self, "df", df)
         frozen_dist, pval_trace = _compute_pvalues(
@@ -203,6 +210,11 @@ class MCResult:
             self,
             "statistic_trace",
             statistic_trace,
+        )
+        object.__setattr__(
+            self,
+            "status_trace",
+            status_trace,
         )
         object.__setattr__(
             self,

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -212,6 +212,7 @@ def _summarize_tests(
             pval_method=first.pval_method,
             alpha=first.alpha,
             statistic_trace=stat_trace,
+            status_trace=tuple(result.status for result in results),
         )
         test_summaries[step_name] = summary
 

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -9,6 +9,7 @@ from numpy import float64
 from numpy.typing import NDArray
 
 from .._diag_tests.result import MCResult, TestResult
+from .._diag_tests.status import TestStatus
 from ..core.shock_generators import Shock
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
@@ -219,6 +220,12 @@ class MCPipelineResult:
     def pval_traces(self) -> Mapping[str, NDF]:
         return {
             name: summary.pval_trace for name, summary in self.test_summaries.items()
+        }
+
+    @property
+    def test_status_traces(self) -> Mapping[str, tuple[TestStatus, ...]]:
+        return {
+            name: summary.status_trace for name, summary in self.test_summaries.items()
         }
 
     @property

--- a/SymbolicDSGE/regression/ols/ols_result.py
+++ b/SymbolicDSGE/regression/ols/ols_result.py
@@ -333,6 +333,10 @@ class MCRegressionResult:
             pval_method=PvalMethod.SF,
             alpha=float64(alpha),
             statistic_trace=self.F_stat_trace,
+            status_trace=tuple(
+                TestStatus.OK if status is RegressionStatus.OK else TestStatus.LINALG
+                for status in self.status_trace
+            ),
         )
 
     def to_dict(self) -> dict:

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -455,6 +455,8 @@ def serialize_pipeline_result(
                 "rejection_ci": _json_value(summary.pval_confidence_interval()),
                 "statistic_trace": _json_value(summary.statistic_trace),
                 "pval_trace": _json_value(summary.pval_trace),
+                "status_trace": [int(status) for status in summary.status_trace],
+                "status_counts": _status_counts(summary.status_trace),
                 "statistic_summary": _trace_summary(summary.statistic_trace),
                 "pval_summary": _trace_summary(summary.pval_trace),
             }
@@ -675,9 +677,6 @@ def _regression_params(params: dict[str, Any]) -> dict[str, Any]:
 
 
 def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
-    status_counts: dict[str, int] = {}
-    for status in summary.status_trace:
-        status_counts[status.name] = status_counts.get(status.name, 0) + 1
     coefficient_summaries = [
         {
             "variable": variable,
@@ -700,7 +699,7 @@ def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
         "coef_trace": _json_value(summary.coef_trace),
         "r2_trace": _json_value(summary.r2_trace),
         "status_trace": [int(status) for status in summary.status_trace],
-        "status_counts": status_counts,
+        "status_counts": _status_counts(summary.status_trace),
         "coefficient_summaries": coefficient_summaries,
         "metrics": metrics,
         "ols": None,
@@ -715,6 +714,13 @@ def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
             "f_pvalue": _trace_summary(summary.F_pval_trace),
         }
     return out
+
+
+def _status_counts(status_trace: Sequence[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for status in status_trace:
+        counts[status.name] = counts.get(status.name, 0) + 1
+    return counts
 
 
 def _summarize_context_data(contexts: Sequence[MCContext]) -> dict[str, Any]:

--- a/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
+++ b/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
@@ -164,6 +164,7 @@ function TestSummary({ result }: { result: MCPipelineResult }) {
               <th>Step</th>
               <th>Reference</th>
               <th>N</th>
+              <th>Status</th>
               <th>Mean statistic</th>
               <th>Statistic 95% CI</th>
               <th>Statistic SE</th>
@@ -179,6 +180,7 @@ function TestSummary({ result }: { result: MCPipelineResult }) {
                 <td>{name}</td>
                 <td>{summary.distribution}({formatDf(summary.df)})</td>
                 <td>{summary.n}</td>
+                <td>{formatStatusCounts(summary.status_counts)}</td>
                 <td>{format(summary.mean_statistic)}</td>
                 <td>{formatInterval(summary.statistic_ci)}</td>
                 <td>{format(summary.statistic_se)}</td>
@@ -217,6 +219,12 @@ function TestSummary({ result }: { result: MCPipelineResult }) {
       </div>
     </div>
   );
+}
+
+function formatStatusCounts(counts: Record<string, number>): string {
+  return Object.entries(counts)
+    .map(([status, count]) => `${status}: ${count}`)
+    .join(", ");
 }
 
 function RegressionSummary({ result }: { result: MCPipelineResult }) {

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -254,6 +254,8 @@ export interface MCTestSummary {
   rejection_ci: Array<number | null>;
   statistic_trace: Array<number | null>;
   pval_trace: Array<number | null>;
+  status_trace: number[];
+  status_counts: Record<string, number>;
   statistic_summary: MCTraceSummary;
   pval_summary: MCTraceSummary;
 }

--- a/tests/diag_tests/test_result.py
+++ b/tests/diag_tests/test_result.py
@@ -95,11 +95,13 @@ def test_mc_result_derives_n_from_trace_length() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic_trace=statistic_trace,
+        status_trace=(TestStatus.OK,) * statistic_trace.size,
     )
 
     assert out.n == 3
     np.testing.assert_allclose(out.pval_trace, chi2(df=2).sf(statistic_trace))
     assert out.rejection_rate == pytest.approx(2.0 / 3.0)
+    assert out.status_trace == (TestStatus.OK,) * 3
 
 
 def test_mc_result_supports_multi_df_reference_distribution() -> None:
@@ -111,6 +113,7 @@ def test_mc_result_supports_multi_df_reference_distribution() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic_trace=statistic_trace,
+        status_trace=(TestStatus.OK,) * statistic_trace.size,
     )
 
     assert out.df == (np.float64(2.0), np.float64(10.0))
@@ -162,6 +165,7 @@ def test_test_and_mc_results_preserve_integer_jb_sample_size() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic_trace=np.array([1.0, 5.0], dtype=np.float64),
+        status_trace=(TestStatus.OK, TestStatus.INSUFFICIENT_SAMPLES),
     )
 
     assert test_result.df == 100
@@ -182,6 +186,7 @@ def test_mc_result_raises_on_empty_traces() -> None:
             pval_method=PvalMethod.SF,
             alpha=np.float64(0.05),
             statistic_trace=np.array([], dtype=np.float64),
+            status_trace=(),
         )
 
 
@@ -194,6 +199,7 @@ def test_mc_result_raises_on_non_1d_statistic_trace() -> None:
             pval_method=PvalMethod.SF,
             alpha=np.float64(0.05),
             statistic_trace=np.ones((2, 2), dtype=np.float64),
+            status_trace=(TestStatus.OK,) * 4,
         )
 
 
@@ -206,6 +212,20 @@ def test_mc_result_raises_on_unsupported_reference_distribution() -> None:
             pval_method=PvalMethod.SF,
             alpha=np.float64(0.05),
             statistic_trace=np.array([1.0], dtype=np.float64),
+            status_trace=(TestStatus.OK,),
+        )
+
+
+def test_mc_result_rejects_mismatched_status_trace() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        MCResult(
+            test_name="demo",
+            dist=ReferenceDistribution.CHI2,
+            df=np.float64(2.0),
+            pval_method=PvalMethod.SF,
+            alpha=np.float64(0.05),
+            statistic_trace=np.array([1.0, 2.0], dtype=np.float64),
+            status_trace=(TestStatus.OK,),
         )
 
 
@@ -251,6 +271,7 @@ def test_mc_result_confidence_intervals_cover_wilson_normal_and_t_paths() -> Non
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.5),
         statistic_trace=np.array([0.1, 1.0, 3.0, 5.0], dtype=np.float64),
+        status_trace=(TestStatus.OK,) * 4,
     )
 
     wilson = out.pval_confidence_interval(wilson=True)

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -366,6 +366,10 @@ def test_jarque_bera_pipeline_handles_burn_in_that_removes_all_samples() -> None
         result.status is TestStatus.INSUFFICIENT_SAMPLES
         for result in out.test_results["jb"]
     )
+    assert out.test_status_traces["jb"] == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
+    assert (
+        out.test_summaries["jb"].status_trace == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
+    )
     assert np.isnan(out.statistic_traces["jb"]).all()
     assert np.isnan(out.pval_traces["jb"]).all()
 

--- a/tests/regression/test_ols_solvers.py
+++ b/tests/regression/test_ols_solvers.py
@@ -5,6 +5,7 @@ import pytest
 from scipy.stats import t
 
 from SymbolicDSGE._diag_tests.distributions import ReferenceDistribution
+from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE.regression.ols import MCRegressionResult as ExportedMCRegressionResult
 from SymbolicDSGE.regression.ols import OLSResult as ExportedOLSResult
 from SymbolicDSGE.regression.ols import RegressionStatus as ExportedRegressionStatus
@@ -364,6 +365,7 @@ def test_mc_regression_result_computes_vectorized_diagnostics() -> None:
     assert f_test.dist is ReferenceDistribution.F
     assert f_test.df == (np.float64(out.k), np.float64(out.n - out.k - 1))
     np.testing.assert_allclose(f_test.statistic_trace, out.F_stat_trace)
+    assert f_test.status_trace == (TestStatus.OK, TestStatus.OK)
 
     as_dict = out.to_dict()
     assert as_dict["variables"] == ["const", "trend"]

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -22,6 +22,7 @@ from SymbolicDSGE.ui.serializers import decode_array, encode_array
 
 from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
 from SymbolicDSGE._diag_tests.result import MCResult
+from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE.monte_carlo import MCContext, MCData, MCPipelineResult
 from SymbolicDSGE.regression.ols import MCRegressionResult, ols
 
@@ -593,6 +594,7 @@ def test_ui_backend_serializes_detailed_mc_summaries() -> None:
         pval_method=PvalMethod.SF,
         alpha=np.float64(0.05),
         statistic_trace=np.array([0.5, 1.5], dtype=np.float64),
+        status_trace=(TestStatus.OK, TestStatus.BAD_SHAPE),
     )
     context = MCContext(
         rep_idx=0,
@@ -617,6 +619,11 @@ def test_ui_backend_serializes_detailed_mc_summaries() -> None:
 
     assert payload["test_summaries"]["diagnostic"]["statistic_ci"][0] is not None
     assert payload["test_summaries"]["diagnostic"]["rejection_ci"][0] is not None
+    assert payload["test_summaries"]["diagnostic"]["status_trace"] == [0, -1]
+    assert payload["test_summaries"]["diagnostic"]["status_counts"] == {
+        "OK": 1,
+        "BAD_SHAPE": 1,
+    }
     assert payload["regression_summaries"]["ols"]["ols"] is not None
     assert (
         payload["regression_summaries"]["ols"]["coefficient_summaries"][0]["variable"]


### PR DESCRIPTION
Store and propagate per-run TestStatus values through Monte Carlo results and UI. MCResult now accepts and validates a status_trace (ensuring it matches statistic_trace length) and exposes it; monte_carlo exposes test_status_traces; OLS F_test maps regression statuses into TestStatus for its MCResult. UI/backend serialization sends status_trace (as ints) and status_counts, with a helper to compute counts. Frontend types and MCResultPanel render status counts. Tests updated to cover the new status_trace behavior and serialization.

closes #125 