### PR TITLE
Add Breusch-Pagan test and MC integration

### DIFF
--- a/SymbolicDSGE/_diag_tests/breusch_pagan.py
+++ b/SymbolicDSGE/_diag_tests/breusch_pagan.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import njit
+from numpy import float64
+from numpy.typing import NDArray
+
+from ..regression.enums import RegressionStatus
+from ..regression.solvers import chol_solve, lstsq_solve
+from .distributions import PvalMethod, ReferenceDistribution
+from .result import TestResult
+from .status import TestStatus
+
+OK = int(TestStatus.OK)
+LINALG = int(TestStatus.LINALG)
+UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
+INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
+REGRESSION_OK = int(RegressionStatus.OK)
+
+NDF = NDArray[float64]
+
+
+@njit(cache=True)
+def bp_aux(eps: NDF, X: NDF) -> tuple[int, float64, float64]:
+    """Fit the auxiliary regression and return its RSS and centered TSS."""
+    n = X.shape[0]
+    if n == 0:
+        return INSUFFICIENT_SAMPLES, float64(np.nan), float64(np.nan)
+
+    eps_sq = eps**2
+    sigma2 = np.sum(eps_sq) / n
+    if not np.isfinite(sigma2) or sigma2 <= 0.0:
+        return UDEF_VARIANCE, float64(np.nan), float64(np.nan)
+    g = eps_sq / sigma2
+
+    try:
+        bhat, _, regression_status = chol_solve(X, g)
+    except Exception:
+        bhat, _, regression_status = lstsq_solve(X, g)
+    if regression_status != REGRESSION_OK:
+        return LINALG, float64(np.nan), float64(np.nan)
+
+    residuals = g - X @ bhat
+    rss = np.sum(residuals**2)
+    g_mean = np.sum(g) / n
+    tss = np.sum((g - g_mean) ** 2)
+    return OK, rss, tss
+
+
+@njit(cache=True)
+def bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+    status, rss, tss = bp_aux(eps, X)
+    if status != OK:
+        return status, float64(np.nan)
+
+    return OK, max(float64(0.0), (tss - rss) * 0.5)
+
+
+@njit(cache=True)
+def robust_bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+    status, rss, tss = bp_aux(eps, X)
+    if status != OK:
+        return status, float64(np.nan)
+    if tss <= 0.0:
+        return OK, float64(0.0)
+
+    r2 = min(float64(1.0), max(float64(0.0), float64(1.0 - rss / tss)))
+    return OK, r2 * len(eps)
+
+
+def _prepare_bp_inputs(eps: NDF, X: NDF) -> tuple[NDF, NDF]:
+    residuals = np.ascontiguousarray(eps, dtype=np.float64)
+    regressors = np.ascontiguousarray(X, dtype=np.float64)
+
+    if residuals.ndim != 1:
+        raise ValueError("Breusch-Pagan residuals must be a 1D array.")
+    if regressors.ndim != 2:
+        raise ValueError("Breusch-Pagan regressors must be a 2D array.")
+    if residuals.shape[0] != regressors.shape[0]:
+        raise ValueError("Breusch-Pagan residual and regressor row counts differ.")
+    if regressors.shape[1] == 0:
+        raise ValueError("Breusch-Pagan requires at least one variance regressor.")
+    if not np.isfinite(residuals).all() or not np.isfinite(regressors).all():
+        raise ValueError("Breusch-Pagan inputs must contain only finite values.")
+    if regressors.shape[0] > 0 and np.any(np.all(regressors == regressors[0], axis=0)):
+        raise ValueError(
+            "Breusch-Pagan regressors must not contain a constant column; "
+            "an intercept is added automatically."
+        )
+
+    augmented = np.empty(
+        (regressors.shape[0], regressors.shape[1] + 1), dtype=np.float64
+    )
+    augmented[:, 0] = 1.0
+    augmented[:, 1:] = regressors
+    return residuals, augmented
+
+
+def breusch_pagan(
+    eps: NDF, X: NDF, alpha: float = 0.05, _auto_pval: bool = True
+) -> TestResult:
+    residuals, regressors = _prepare_bp_inputs(eps, X)
+    status, stat = bp_stat(residuals, regressors)
+    return TestResult(
+        test_name="breusch_pagan",
+        status=TestStatus(status),
+        statistic=stat,
+        pval_method=PvalMethod.SF,
+        dist=ReferenceDistribution.CHI2,
+        df=regressors.shape[1] - 1,
+        alpha=float64(alpha),
+        _auto_pval=_auto_pval,
+    )
+
+
+def robust_breusch_pagan(
+    eps: NDF, X: NDF, alpha: float = 0.05, _auto_pval: bool = True
+) -> TestResult:
+    residuals, regressors = _prepare_bp_inputs(eps, X)
+    status, stat = robust_bp_stat(residuals, regressors)
+    return TestResult(
+        test_name="robust_breusch_pagan",
+        status=TestStatus(status),
+        statistic=stat,
+        pval_method=PvalMethod.SF,
+        dist=ReferenceDistribution.CHI2,
+        df=regressors.shape[1] - 1,
+        alpha=float64(alpha),
+        _auto_pval=_auto_pval,
+    )

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -7,6 +7,7 @@ from .config import (
     simulation_step,
     transform_step,
     wald_test_step,
+    breusch_pagan_test_step,
 )
 from .core import MCPipeline
 from .mc_constructs import (
@@ -32,6 +33,7 @@ from .operations import (
     run_reference_filter,
     run_regression,
     run_wald_test,
+    run_breusch_pagan_test,
     simulate_dgp,
 )
 from .reference_constructs import MCReferenceConstruct
@@ -64,8 +66,10 @@ __all__ = [
     "run_jarque_bera_test",
     "run_ljung_box_test",
     "run_wald_test",
+    "run_breusch_pagan_test",
     "simulate_dgp",
     "simulation_step",
     "transform_step",
     "wald_test_step",
+    "breusch_pagan_test_step",
 ]

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -10,6 +10,7 @@ from .operations import (
     run_regression as _run_regression,
     run_wald_test as _run_wald_test,
     run_jarque_bera_test as _run_jarque_bera_test,
+    run_breusch_pagan_test as _run_breusch_pagan_test,
     simulate_dgp as _simulate_dgp,
 )
 
@@ -59,6 +60,12 @@ def ljung_box_test_step(name: str, **kwargs: Any) -> MCStep:
 def jarque_bera_test_step(name: str, **kwargs: Any) -> MCStep:
     return MCStep(
         name=name, op_type=OpType.TEST, func=_run_jarque_bera_test, kwargs=kwargs
+    )
+
+
+def breusch_pagan_test_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(
+        name=name, op_type=OpType.TEST, func=_run_breusch_pagan_test, kwargs=kwargs
     )
 
 

--- a/SymbolicDSGE/monte_carlo/operations.py
+++ b/SymbolicDSGE/monte_carlo/operations.py
@@ -5,14 +5,16 @@ from typing import Literal, Mapping, Sequence, Any, Callable
 import numpy as np
 from numpy import float64, ndarray
 
-from .._diag_tests.ljung_box import ljung_box
 from .._diag_tests.result import TestResult
 from .._diag_tests.wald_test import (
     wald_covariance_hac,
     wald_mean_hac,
     wald_second_moment_hac,
 )
+from .._diag_tests.ljung_box import ljung_box
 from .._diag_tests.jarque_bera import jarque_bera
+from .._diag_tests.breusch_pagan import breusch_pagan, robust_breusch_pagan
+
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
 from ..regression.enums import RegressionKind
@@ -310,6 +312,68 @@ def run_jarque_bera_test(
         raise ValueError("Jarque-Bera test requires a single column of data.")
 
     return jarque_bera(arr[:, 0], alpha=alpha, _auto_pval=False)
+
+
+def run_breusch_pagan_test(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    residual_source: InpSources,
+    X_source: InpSources,
+    filter_key: str = "filter",
+    residual_payload_key: str | None = None,
+    x_payload_key: str | None = None,
+    residual_col: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+    robust: bool = False,
+) -> TestResult:
+    del reference, dgp, rep_idx
+
+    residual_col_idx: Sequence[int] | None
+    if isinstance(residual_col, int):
+        residual_col_idx = [residual_col]
+    else:
+        residual_col_idx = residual_col
+
+    residuals = _resolve_context_array(
+        context,
+        source=residual_source,
+        filter_key=filter_key,
+        payload_key=residual_payload_key,
+        columns=residual_col_idx,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    X = _resolve_context_array(
+        context,
+        source=X_source,
+        filter_key=filter_key,
+        payload_key=x_payload_key,
+        columns=X_columns,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+
+    if residuals.shape[1] != 1:
+        raise ValueError(
+            "Breusch-Pagan residuals must resolve to exactly one column. "
+            f"Got shape {residuals.shape}."
+        )
+    if residuals.shape[0] != X.shape[0]:
+        raise ValueError(
+            "Breusch-Pagan residuals and regressors must have the same number "
+            f"of rows. Got residuals={residuals.shape[0]} and X={X.shape[0]}."
+        )
+
+    residual_vec = np.ascontiguousarray(residuals[:, 0], dtype=np.float64)
+    if robust:
+        return robust_breusch_pagan(residual_vec, X, alpha=alpha, _auto_pval=False)
+    return breusch_pagan(residual_vec, X, alpha=alpha, _auto_pval=False)
 
 
 def run_regression(

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -11,6 +11,7 @@ from SymbolicDSGE.monte_carlo import (
     MCContext,
     MCPipeline,
     MCPipelineResult,
+    breusch_pagan_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     reference_filter_step,
@@ -33,7 +34,13 @@ INPUT_SOURCES = [
     "std_innov",
 ]
 FILTER_SOURCES = {"x_pred", "x_filt", "y_pred", "y_filt", "innov", "std_innov"}
-TERMINAL_STEP_TYPES = {"wald", "ljung_box", "jarque_bera", "regression"}
+TERMINAL_STEP_TYPES = {
+    "wald",
+    "ljung_box",
+    "jarque_bera",
+    "breusch_pagan",
+    "regression",
+}
 
 
 def mc_catalog() -> dict[str, Any]:
@@ -153,6 +160,34 @@ def mc_catalog() -> dict[str, Any]:
                     _field("column", "Column", "number_list", []),
                     _field("burn_in", "Burn-in", "number", 0, minimum=0),
                     _field("drop_initial", "Drop initial", "boolean", False),
+                    _field("alpha", "Alpha", "number", 0.05),
+                ],
+            ),
+            _step_catalog(
+                "breusch_pagan",
+                "Breusch-Pagan Test",
+                "breusch_pagan",
+                "Test residual variance against selected regressors.",
+                [
+                    _field(
+                        "residual_source",
+                        "Residual source",
+                        "select",
+                        "std_innov",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field(
+                        "X_source",
+                        "Regressor source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field("residual_col", "Residual column", "number_list", [0]),
+                    _field("X_columns", "Regressor columns", "number_list", [0]),
+                    _field("burn_in", "Burn-in", "number", 0, minimum=0),
+                    _field("drop_initial", "Drop initial", "boolean", False),
+                    _field("robust", "Robust (Koenker)", "boolean", False),
                     _field("alpha", "Alpha", "number", 0.05),
                 ],
             ),
@@ -379,6 +414,8 @@ def build_pipeline(
             steps.append(ljung_box_test_step(node.name, **params))
         elif node.step_type == "jarque_bera":
             steps.append(jarque_bera_test_step(node.name, **params))
+        elif node.step_type == "breusch_pagan":
+            steps.append(breusch_pagan_test_step(node.name, **params))
         elif node.step_type == "regression":
             steps.append(regression_step(node.name, **_regression_params(params)))
         else:
@@ -515,7 +552,7 @@ def _validate_dependency(node: MCNodeSpec, prior_names: set[str]) -> None:
         return
     sources = [
         params.get(key)
-        for key in ("source", "y_source", "X_source")
+        for key in ("source", "residual_source", "y_source", "X_source")
         if params.get(key) is not None
     ]
     if any(source in FILTER_SOURCES for source in sources):
@@ -526,7 +563,12 @@ def _validate_dependency(node: MCNodeSpec, prior_names: set[str]) -> None:
             )
     payload_keys = [
         params.get(key)
-        for key in ("payload_key", "y_payload_key", "x_payload_key")
+        for key in (
+            "payload_key",
+            "residual_payload_key",
+            "y_payload_key",
+            "x_payload_key",
+        )
         if params.get(key)
     ]
     for payload_key in payload_keys:
@@ -548,7 +590,7 @@ def _bind_graph_dependency(
     elif node.step_type in TERMINAL_STEP_TYPES:
         sources = [
             params.get(key)
-            for key in ("source", "y_source", "X_source")
+            for key in ("source", "residual_source", "y_source", "X_source")
             if params.get(key) is not None
         ]
         if any(source == "payload" for source in sources):

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -5,7 +5,13 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 MCStepKind = Literal[
-    "simulation", "filter", "wald", "ljung_box", "jarque_bera", "regression"
+    "simulation",
+    "filter",
+    "wald",
+    "ljung_box",
+    "jarque_bera",
+    "breusch_pagan",
+    "regression",
 ]
 
 

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -183,9 +183,13 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
       const target = nodes.find((node) => node.id === connection.target);
       if (source === undefined || target === undefined) return false;
       if (
-        ["wald", "ljung_box", "jarque_bera", "regression"].includes(
-          source.data.stepType,
-        )
+        [
+          "wald",
+          "ljung_box",
+          "jarque_bera",
+          "breusch_pagan",
+          "regression",
+        ].includes(source.data.stepType)
       ) {
         return false;
       }

--- a/sdsge-ui/frontend/src/mc/StepNode.tsx
+++ b/sdsge-ui/frontend/src/mc/StepNode.tsx
@@ -7,23 +7,30 @@ import {
   Sigma,
   TestTubeDiagonal,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { MCStepType } from "../types";
 import type { MCFlowNode } from "./types";
 
-const ICONS = {
+const ICONS: Record<MCStepType, LucideIcon> = {
   simulation: DatabaseZap,
   filter: Filter,
   wald: Sigma,
   ljung_box: Activity,
   jarque_bera: Activity,
+  breusch_pagan: Activity,
   regression: TestTubeDiagonal,
 };
 
 export function StepNode({ data, selected }: NodeProps<MCFlowNode>) {
-  const Icon = ICONS[data.stepType];
+  const Icon = ICONS[data.stepType] ?? Activity;
   const summary = summarizeParams(data.params);
-  const terminal = ["wald", "ljung_box", "jarque_bera", "regression"].includes(
-    data.stepType,
-  );
+  const terminal = [
+    "wald",
+    "ljung_box",
+    "jarque_bera",
+    "breusch_pagan",
+    "regression",
+  ].includes(data.stepType);
   return (
     <div className={`mc-step-node ${data.stepType}${selected ? " selected" : ""}`}>
       {data.stepType !== "simulation" && (

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1418,7 +1418,8 @@ button.mc-palette-step:hover {
 
 .mc-step-node.wald,
 .mc-step-node.ljung_box,
-.mc-step-node.jarque_bera {
+.mc-step-node.jarque_bera,
+.mc-step-node.breusch_pagan {
   border-left-color: #9333ea;
 }
 

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -165,6 +165,7 @@ export type MCStepType =
   | "wald"
   | "ljung_box"
   | "jarque_bera"
+  | "breusch_pagan"
   | "regression";
 
 export type MCFieldType =

--- a/tests/diag_tests/test_breusch_pagan.py
+++ b/tests/diag_tests/test_breusch_pagan.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import chi2
+
+from SymbolicDSGE._diag_tests.breusch_pagan import (
+    breusch_pagan,
+    robust_breusch_pagan,
+)
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.status import TestStatus
+
+
+def _manual_bp_stat(eps: np.ndarray, X: np.ndarray, *, robust: bool) -> float:
+    augmented = np.column_stack((np.ones(eps.size, dtype=np.float64), X))
+    g = eps**2 / np.mean(eps**2)
+    coefficients = np.linalg.lstsq(augmented, g, rcond=None)[0]
+    rss = np.sum((g - augmented @ coefficients) ** 2)
+    tss = np.sum((g - g.mean()) ** 2)
+    if robust:
+        return float(eps.size * (1.0 - rss / tss))
+    return float((tss - rss) * 0.5)
+
+
+@pytest.mark.parametrize("robust", [False, True])
+def test_breusch_pagan_matches_auxiliary_regression_definition(robust: bool) -> None:
+    rng = np.random.default_rng(1024)
+    X = rng.normal(size=(200, 2))
+    eps = rng.normal(scale=np.exp(0.4 * X[:, 0]), size=200)
+    func = robust_breusch_pagan if robust else breusch_pagan
+
+    out = func(eps, X, alpha=0.1)
+    expected = _manual_bp_stat(eps, X, robust=robust)
+
+    assert out.test_name == ("robust_breusch_pagan" if robust else "breusch_pagan")
+    assert out.status is TestStatus.OK
+    assert out.dist is ReferenceDistribution.CHI2
+    assert out.pval_method is PvalMethod.SF
+    assert out.df == X.shape[1]
+    assert out.alpha == np.float64(0.1)
+    assert out.statistic == pytest.approx(expected)
+    assert out.pval == pytest.approx(chi2(df=X.shape[1]).sf(expected))
+
+
+def test_breusch_pagan_reports_computation_statuses() -> None:
+    empty_X = np.empty((0, 1), dtype=np.float64)
+    empty = breusch_pagan(np.empty(0, dtype=np.float64), empty_X)
+    undefined = breusch_pagan(np.zeros(5, dtype=np.float64), np.arange(5.0)[:, None])
+    robust_constant = robust_breusch_pagan(
+        np.ones(5, dtype=np.float64), np.arange(5.0)[:, None]
+    )
+    x = np.arange(10.0)
+    rank_deficient = breusch_pagan(
+        np.linspace(-1.0, 1.0, 10),
+        np.column_stack((x, x * 2.0)),
+    )
+
+    assert empty.status is TestStatus.INSUFFICIENT_SAMPLES
+    assert undefined.status is TestStatus.UDEF_VARIANCE
+    assert robust_constant.status is TestStatus.OK
+    assert robust_constant.statistic == 0.0
+    assert robust_constant.pval == 1.0
+    assert rank_deficient.status is TestStatus.LINALG
+    assert np.isnan(empty.statistic)
+    assert np.isnan(undefined.statistic)
+    assert np.isnan(rank_deficient.statistic)
+
+
+@pytest.mark.parametrize(
+    ("eps", "X", "message"),
+    [
+        (np.ones((3, 1)), np.ones((3, 1)), "residuals must be a 1D"),
+        (np.ones(3), np.ones(3), "regressors must be a 2D"),
+        (np.ones(3), np.ones((2, 1)), "row counts differ"),
+        (np.ones(3), np.empty((3, 0)), "at least one variance regressor"),
+        (np.array([1.0, np.nan]), np.arange(2.0)[:, None], "finite values"),
+        (np.ones(3), np.ones((3, 1)), "must not contain a constant column"),
+    ],
+)
+def test_breusch_pagan_validates_inputs(
+    eps: np.ndarray, X: np.ndarray, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        breusch_pagan(eps, X)

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -6,6 +6,10 @@ import numpy as np
 import pytest
 
 from SymbolicDSGE import Shock
+from SymbolicDSGE._diag_tests.breusch_pagan import (
+    breusch_pagan,
+    robust_breusch_pagan,
+)
 from SymbolicDSGE._diag_tests.jarque_bera import jarque_bera
 from SymbolicDSGE._diag_tests.ljung_box import ljung_box
 from SymbolicDSGE._diag_tests.status import TestStatus
@@ -19,6 +23,7 @@ from SymbolicDSGE.monte_carlo import (
     MCReferenceConstruct,
     MCStep,
     OpType,
+    breusch_pagan_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     raw_data_step,
@@ -372,6 +377,187 @@ def test_jarque_bera_pipeline_handles_burn_in_that_removes_all_samples() -> None
     )
     assert np.isnan(out.statistic_traces["jb"]).all()
     assert np.isnan(out.pval_traces["jb"]).all()
+
+
+def test_breusch_pagan_pipeline_selects_columns_and_aggregates_results() -> None:
+    rng = np.random.default_rng(512)
+    X = rng.normal(size=(2, 40, 2))
+    eps = rng.normal(scale=np.exp(0.4 * X[:, :, 0]))
+    observables = np.concatenate((eps[:, :, None], X), axis=2)
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            breusch_pagan_test_step(
+                "bp",
+                residual_source="observables",
+                X_source="observables",
+                residual_col=0,
+                X_columns=[1, 2],
+            ),
+            breusch_pagan_test_step(
+                "robust_bp",
+                residual_source="observables",
+                X_source="observables",
+                residual_col=0,
+                X_columns=[1, 2],
+                robust=True,
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    expected = np.asarray(
+        [breusch_pagan(eps[i], X[i]).statistic for i in range(2)],
+        dtype=np.float64,
+    )
+    robust_expected = np.asarray(
+        [robust_breusch_pagan(eps[i], X[i]).statistic for i in range(2)],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(out.statistic_traces["bp"], expected)
+    np.testing.assert_allclose(out.statistic_traces["robust_bp"], robust_expected)
+    assert out.test_summaries["bp"].df == 2
+    assert out.test_summaries["robust_bp"].df == 2
+    assert out.test_status_traces["bp"] == (TestStatus.OK, TestStatus.OK)
+    assert out.test_status_traces["robust_bp"] == (TestStatus.OK, TestStatus.OK)
+
+
+def test_breusch_pagan_pipeline_supports_separate_residual_and_regressor_sources() -> (
+    None
+):
+    rng = np.random.default_rng(128)
+    states = rng.normal(size=(2, 30, 2))
+    residuals = rng.normal(scale=np.exp(0.4 * states[:, :, 0]))
+    observables = residuals[:, :, None]
+    pipeline = MCPipeline(
+        [
+            raw_data_step(states=states, observables=observables),
+            breusch_pagan_test_step(
+                "bp",
+                residual_source="observables",
+                X_source="states",
+                residual_col=0,
+                X_columns=[0, 1],
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    expected = np.asarray(
+        [breusch_pagan(residuals[i], states[i]).statistic for i in range(2)],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(out.statistic_traces["bp"], expected)
+
+
+def test_breusch_pagan_pipeline_supports_separate_payload_sources() -> None:
+    rng = np.random.default_rng(256)
+    X = rng.normal(size=(30, 2))
+    residuals = rng.normal(scale=np.exp(0.4 * X[:, 0]), size=30)
+
+    def residual_payload(**_: object) -> np.ndarray:
+        return residuals
+
+    def regressor_payload(**_: object) -> np.ndarray:
+        return X
+
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=residuals[:, None]),
+            transform_step("residual_payload", residual_payload),
+            transform_step("regressor_payload", regressor_payload),
+            breusch_pagan_test_step(
+                "bp",
+                residual_source="payload",
+                X_source="payload",
+                residual_payload_key="residual_payload",
+                x_payload_key="regressor_payload",
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    np.testing.assert_allclose(
+        out.statistic_traces["bp"],
+        np.full(2, breusch_pagan(residuals, X).statistic, dtype=np.float64),
+    )
+
+
+def test_breusch_pagan_pipeline_validates_residual_and_regressor_inputs() -> None:
+    observables = np.arange(30.0, dtype=np.float64).reshape(10, 3)
+    reference = _FakeSolvedModel()
+
+    with pytest.raises(ValueError, match="exactly one column"):
+        MCPipeline(
+            [
+                raw_data_step(observables=observables),
+                breusch_pagan_test_step(
+                    "bp",
+                    residual_source="observables",
+                    X_source="observables",
+                    X_columns=[1, 2],
+                ),
+            ]
+        ).run(reference=reference, n_rep=1, verbosity=0)
+
+    with pytest.raises(ValueError, match="at least one variance regressor"):
+        MCPipeline(
+            [
+                raw_data_step(observables=observables),
+                breusch_pagan_test_step(
+                    "bp",
+                    residual_source="observables",
+                    X_source="observables",
+                    residual_col=0,
+                    X_columns=[],
+                ),
+            ]
+        ).run(reference=reference, n_rep=1, verbosity=0)
+
+    with pytest.raises(ValueError, match="same number of rows"):
+        MCPipeline(
+            [
+                raw_data_step(
+                    states=np.arange(33.0, dtype=np.float64).reshape(11, 3),
+                    observables=observables,
+                ),
+                breusch_pagan_test_step(
+                    "bp",
+                    residual_source="observables",
+                    X_source="states",
+                    residual_col=0,
+                    X_columns=[0, 1],
+                ),
+            ]
+        ).run(reference=reference, n_rep=1, verbosity=0)
+
+
+def test_breusch_pagan_pipeline_handles_burn_in_that_removes_all_samples() -> None:
+    base = np.arange(30.0, dtype=np.float64).reshape(10, 3)
+    observables = np.stack((base, base + 0.5))
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            breusch_pagan_test_step(
+                "bp",
+                residual_source="observables",
+                X_source="observables",
+                residual_col=0,
+                X_columns=[1, 2],
+                burn_in=observables.shape[1],
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    assert out.succeeded
+    assert out.test_status_traces["bp"] == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
+    assert np.isnan(out.statistic_traces["bp"]).all()
+    assert np.isnan(out.pval_traces["bp"]).all()
 
 
 def test_raw_data_pipeline_rejects_empty_raw_data() -> None:

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -363,6 +363,7 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
         "wald",
         "ljung_box",
         "jarque_bera",
+        "breusch_pagan",
         "regression",
     }
 
@@ -535,6 +536,65 @@ def test_ui_backend_runs_jarque_bera_monte_carlo_step() -> None:
     assert summary["n"] == 2
 
 
+def test_ui_backend_runs_breusch_pagan_monte_carlo_step() -> None:
+    client = TestClient(create_app())
+    for role in ("reference", "dgp"):
+        loaded = client.post(
+            "/api/model/load-yaml",
+            json={"role": role, "path": "MODELS/test.yaml"},
+        )
+        assert loaded.status_code == 200
+        solved = client.post(
+            "/api/model/solve",
+            json={"role": role, "compile_kwargs": {"n_state": 3, "n_exog": 2}},
+        )
+        assert solved.status_code == 200
+
+    pipeline = {
+        "nodes": [
+            {
+                "id": "sim",
+                "step_type": "simulation",
+                "name": "datagen",
+                "params": {"T": 20},
+            },
+            {
+                "id": "bp",
+                "step_type": "breusch_pagan",
+                "name": "heteroskedasticity",
+                "params": {
+                    "residual_source": "states",
+                    "X_source": "states",
+                    "residual_col": [0],
+                    "X_columns": [1],
+                    "burn_in": 1,
+                    "robust": True,
+                    "alpha": 0.1,
+                },
+            },
+        ],
+        "edges": [{"source": "sim", "target": "bp"}],
+    }
+
+    validated = client.post("/api/mc/validate", json=pipeline)
+    assert validated.status_code == 200
+    assert validated.json()["order"] == ["sim", "bp"]
+
+    run = client.post(
+        "/api/run/mc",
+        json={"pipeline": pipeline, "n_rep": 2, "fail_fast": True},
+    )
+    assert run.status_code == 200
+    body = run.json()
+    assert body["succeeded"] is True
+    assert set(body["test_summaries"]) == {"heteroskedasticity"}
+    summary = body["test_summaries"]["heteroskedasticity"]
+    assert summary["test_name"] == "heteroskedasticity"
+    assert summary["distribution"] == "chi2"
+    assert summary["df"] == 1
+    assert summary["n"] == 2
+
+
 def test_ui_backend_normalizes_integer_or_keyword_mc_fields() -> None:
     client = TestClient(create_app())
     for role in ("reference", "dgp"):
@@ -646,9 +706,14 @@ def test_ui_backend_binds_filter_dependencies_from_graph_edges() -> None:
                 {"id": "filter", "step_type": "filter", "name": "renamed_filter"},
                 {
                     "id": "test",
-                    "step_type": "wald",
+                    "step_type": "breusch_pagan",
                     "name": "diagnostic",
-                    "params": {"source": "std_innov", "target_vector": [0.0]},
+                    "params": {
+                        "residual_source": "std_innov",
+                        "X_source": "observables",
+                        "residual_col": [0],
+                        "X_columns": [0],
+                    },
                 },
             ],
             "edges": [


### PR DESCRIPTION
Implement Breusch-Pagan and robust Breusch-Pagan diagnostics and integrate them into the Monte Carlo pipeline and UI. Adds SymbolicDSGE/_diag_tests/breusch_pagan.py with numba-optimized stat computation, input validation, and TestResult wiring (chi2 reference, SF p-value). Wire new test step through monte_carlo package (config, operations, __init__) and add comprehensive unit tests for diagnostics and pipeline behavior. Update UI schemas, backend mc wiring, frontend node/types/styles to support the new "breusch_pagan" step and ensure graph validation, payload handling, and MC run endpoints work with the new test.

closes #122 