### PR TITLE
Add Breusch-Godfrey test and MC UI integration

### DIFF
--- a/SymbolicDSGE/_diag_tests/breusch_godfrey.py
+++ b/SymbolicDSGE/_diag_tests/breusch_godfrey.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy import float64
+from numpy.typing import NDArray
+from numba import njit
+
+from ..regression.solvers import chol_solve, lstsq_solve
+
+from .status import TestStatus
+from .result import TestResult
+from .distributions import PvalMethod, ReferenceDistribution
+
+NDF = NDArray[float64]
+
+OK = int(TestStatus.OK)
+UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
+BAD_SHAPE = int(TestStatus.BAD_SHAPE)
+INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
+
+
+@njit(cache=True)
+def build_design_matrix(X: NDF, eps: NDF, lags: int) -> NDF:
+    N, K = X.shape
+    out = np.empty((N, K + lags + 1), dtype=float64)
+
+    out[:, 0] = 1.0  # Intercept
+    out[:, 1 : K + 1] = X
+
+    for lag in range(1, lags + 1):
+        col = K + lag
+        out[:lag, col] = 0.0
+        out[lag:, col] = eps[:-lag]
+
+    return out
+
+
+@njit(cache=True)
+def bg_stat(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
+    n = eps.size
+    if n <= lags:
+        return INSUFFICIENT_SAMPLES, float64(np.nan)
+    if X.shape[0] != n:
+        return BAD_SHAPE, float64(np.nan)
+
+    design = build_design_matrix(X, eps, lags)
+
+    try:
+        bhat, _, _ = chol_solve(design, eps)
+    except Exception:
+        bhat, _, _ = lstsq_solve(design, eps)
+
+    resid = eps - design @ bhat
+    tss = np.sum(eps**2)
+    stat = n * (1.0 - np.sum(resid**2) / tss) if tss > 0.0 else 0.0
+
+    return OK, float64(stat)
+
+
+def breusch_godfrey(
+    eps: NDF,
+    X: NDF,
+    lags: int,
+    alpha: float = 0.05,
+    _auto_pval: bool = True,
+) -> TestResult:
+    status, stat = bg_stat(eps, X, lags)
+    return TestResult(
+        test_name="breusch_godfrey",
+        statistic=stat,
+        status=TestStatus(status),
+        df=lags,
+        dist=ReferenceDistribution.CHI2,
+        pval_method=PvalMethod.SF,
+        alpha=float64(alpha),
+        _auto_pval=_auto_pval,
+    )

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -1,4 +1,6 @@
 from .config import (
+    breusch_godfrey_test_step,
+    breusch_pagan_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     raw_data_step,
@@ -7,7 +9,6 @@ from .config import (
     simulation_step,
     transform_step,
     wald_test_step,
-    breusch_pagan_test_step,
 )
 from .core import MCPipeline
 from .mc_constructs import (
@@ -28,12 +29,13 @@ from .mc_constructs import (
 )
 from .operations import (
     raw_data_datagen,
+    run_breusch_godfrey_test,
+    run_breusch_pagan_test,
     run_jarque_bera_test,
     run_ljung_box_test,
     run_reference_filter,
     run_regression,
     run_wald_test,
-    run_breusch_pagan_test,
     simulate_dgp,
 )
 from .reference_constructs import MCReferenceConstruct
@@ -53,6 +55,8 @@ __all__ = [
     "OpType",
     "RegressionOp",
     "TestOp",
+    "breusch_godfrey_test_step",
+    "breusch_pagan_test_step",
     "jarque_bera_test_step",
     "ljung_box_test_step",
     "raw_data_datagen",
@@ -61,15 +65,15 @@ __all__ = [
     "report_mc_performance",
     "report_mc_step_performance",
     "regression_step",
+    "run_breusch_godfrey_test",
+    "run_breusch_pagan_test",
     "run_reference_filter",
     "run_regression",
     "run_jarque_bera_test",
     "run_ljung_box_test",
     "run_wald_test",
-    "run_breusch_pagan_test",
     "simulate_dgp",
     "simulation_step",
     "transform_step",
     "wald_test_step",
-    "breusch_pagan_test_step",
 ]

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -11,6 +11,7 @@ from .operations import (
     run_wald_test as _run_wald_test,
     run_jarque_bera_test as _run_jarque_bera_test,
     run_breusch_pagan_test as _run_breusch_pagan_test,
+    run_breusch_godfrey_test as _run_breusch_godfrey_test,
     simulate_dgp as _simulate_dgp,
 )
 
@@ -66,6 +67,12 @@ def jarque_bera_test_step(name: str, **kwargs: Any) -> MCStep:
 def breusch_pagan_test_step(name: str, **kwargs: Any) -> MCStep:
     return MCStep(
         name=name, op_type=OpType.TEST, func=_run_breusch_pagan_test, kwargs=kwargs
+    )
+
+
+def breusch_godfrey_test_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(
+        name=name, op_type=OpType.TEST, func=_run_breusch_godfrey_test, kwargs=kwargs
     )
 
 

--- a/SymbolicDSGE/monte_carlo/operations.py
+++ b/SymbolicDSGE/monte_carlo/operations.py
@@ -14,6 +14,7 @@ from .._diag_tests.wald_test import (
 from .._diag_tests.ljung_box import ljung_box
 from .._diag_tests.jarque_bera import jarque_bera
 from .._diag_tests.breusch_pagan import breusch_pagan, robust_breusch_pagan
+from .._diag_tests.breusch_godfrey import breusch_godfrey
 
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
@@ -374,6 +375,66 @@ def run_breusch_pagan_test(
     if robust:
         return robust_breusch_pagan(residual_vec, X, alpha=alpha, _auto_pval=False)
     return breusch_pagan(residual_vec, X, alpha=alpha, _auto_pval=False)
+
+
+def run_breusch_godfrey_test(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    residual_source: InpSources,
+    X_source: InpSources,
+    filter_key: str = "filter",
+    residual_payload_key: str | None = None,
+    x_payload_key: str | None = None,
+    residual_col: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    lags: int = 1,
+    alpha: float = 0.05,
+) -> TestResult:
+    del reference, dgp, rep_idx
+
+    residual_col_idx: Sequence[int] | None
+    if isinstance(residual_col, int):
+        residual_col_idx = [residual_col]
+    else:
+        residual_col_idx = residual_col
+
+    residuals = _resolve_context_array(
+        context,
+        source=residual_source,
+        filter_key=filter_key,
+        payload_key=residual_payload_key,
+        columns=residual_col_idx,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    X = _resolve_context_array(
+        context,
+        source=X_source,
+        filter_key=filter_key,
+        payload_key=x_payload_key,
+        columns=X_columns,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+
+    if residuals.shape[1] != 1:
+        raise ValueError(
+            "Breusch-Godfrey residuals must resolve to exactly one column. "
+            f"Got shape {residuals.shape}."
+        )
+    if residuals.shape[0] != X.shape[0]:
+        raise ValueError(
+            "Breusch-Godfrey residuals and regressors must have the same number "
+            f"of rows. Got residuals={residuals.shape[0]} and X={X.shape[0]}."
+        )
+
+    residual_vec = np.ascontiguousarray(residuals[:, 0], dtype=np.float64)
+    return breusch_godfrey(residual_vec, X, lags=lags, alpha=alpha, _auto_pval=False)
 
 
 def run_regression(

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -11,6 +11,7 @@ from SymbolicDSGE.monte_carlo import (
     MCContext,
     MCPipeline,
     MCPipelineResult,
+    breusch_godfrey_test_step,
     breusch_pagan_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
@@ -39,6 +40,7 @@ TERMINAL_STEP_TYPES = {
     "ljung_box",
     "jarque_bera",
     "breusch_pagan",
+    "breusch_godfrey",
     "regression",
 }
 
@@ -188,6 +190,34 @@ def mc_catalog() -> dict[str, Any]:
                     _field("burn_in", "Burn-in", "number", 0, minimum=0),
                     _field("drop_initial", "Drop initial", "boolean", False),
                     _field("robust", "Robust (Koenker)", "boolean", False),
+                    _field("alpha", "Alpha", "number", 0.05),
+                ],
+            ),
+            _step_catalog(
+                "breusch_godfrey",
+                "Breusch-Godfrey Test",
+                "breusch_godfrey",
+                "Test residuals for serial correlation up to a given lag order.",
+                [
+                    _field(
+                        "residual_source",
+                        "Residual source",
+                        "select",
+                        "std_innov",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field(
+                        "X_source",
+                        "Regressor source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field("residual_col", "Residual column", "number_list", [0]),
+                    _field("X_columns", "Regressor columns", "number_list", [0]),
+                    _field("burn_in", "Burn-in", "number", 0, minimum=0),
+                    _field("drop_initial", "Drop initial", "boolean", False),
+                    _field("lags", "Lags", "number", 1, minimum=1),
                     _field("alpha", "Alpha", "number", 0.05),
                 ],
             ),
@@ -416,6 +446,8 @@ def build_pipeline(
             steps.append(jarque_bera_test_step(node.name, **params))
         elif node.step_type == "breusch_pagan":
             steps.append(breusch_pagan_test_step(node.name, **params))
+        elif node.step_type == "breusch_godfrey":
+            steps.append(breusch_godfrey_test_step(node.name, **params))
         elif node.step_type == "regression":
             steps.append(regression_step(node.name, **_regression_params(params)))
         else:

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -11,6 +11,7 @@ MCStepKind = Literal[
     "ljung_box",
     "jarque_bera",
     "breusch_pagan",
+    "breusch_godfrey",
     "regression",
 ]
 

--- a/sdsge-ui/frontend/src/PanelWorkspace.tsx
+++ b/sdsge-ui/frontend/src/PanelWorkspace.tsx
@@ -20,6 +20,7 @@ export function PanelWorkspace({
   panels,
   defaultLayout = "vertical",
   defaultSplit = 50,
+  defaultSizes,
   fillHeight = false,
   initialFolded,
   onFoldChange,
@@ -27,6 +28,7 @@ export function PanelWorkspace({
   panels: PanelDef[];
   defaultLayout?: LayoutDirection;
   defaultSplit?: number;
+  defaultSizes?: number[];
   fillHeight?: boolean;
   initialFolded?: Record<string, boolean>;
   onFoldChange?: (folded: Record<string, boolean>) => void;
@@ -38,7 +40,11 @@ export function PanelWorkspace({
   const [panelHeights, setPanelHeights] = useState<Record<string, number>>(() =>
     Object.fromEntries(panels.map((p) => [p.id, p.defaultHeight ?? 470])),
   );
-  const [split, setSplit] = useState(defaultSplit);
+  const [sizes, setSizes] = useState<number[]>(() => {
+    if (defaultSizes && defaultSizes.length === panels.length) return [...defaultSizes];
+    if (panels.length === 2) return [defaultSplit, 100 - defaultSplit];
+    return Array.from({ length: panels.length }, () => 100 / panels.length);
+  });
   const [layout, setLayout] = useState<LayoutDirection>(defaultLayout);
   const [dragged, setDragged] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<{
@@ -83,13 +89,13 @@ export function PanelWorkspace({
     setOrder(without);
     if (newLayout !== layout) {
       setLayout(newLayout);
-      setSplit(50);
+      setSizes(Array.from({ length: order.length }, () => 100 / order.length));
     }
     setDragged(null);
     setDropTarget(null);
   }
 
-  function startSplitResize(event: PointerEvent<HTMLDivElement>) {
+  function startSplitResize(boundary: number, event: PointerEvent<HTMLDivElement>) {
     const ws = (event.currentTarget as HTMLElement).closest<HTMLElement>(
       ".output-workspace",
     );
@@ -97,14 +103,32 @@ export function PanelWorkspace({
     const rect = ws.getBoundingClientRect();
     const sx = event.clientX;
     const sy = event.clientY;
-    const s0 = split;
+    const base = [...sizes];
+    const left = boundary - 1;
+    const right = boundary;
+    const total = (base[left] ?? 0) + (base[right] ?? 0);
+    const min = 10;
 
     function move(e: globalThis.PointerEvent) {
-      if (layout === "horizontal") {
-        setSplit(Math.min(75, Math.max(25, s0 + ((e.clientX - sx) / rect.width) * 100)));
-      } else {
-        setSplit(Math.min(80, Math.max(20, s0 + ((e.clientY - sy) / rect.height) * 100)));
+      const deltaPct =
+        layout === "horizontal"
+          ? ((e.clientX - sx) / rect.width) * 100
+          : ((e.clientY - sy) / rect.height) * 100;
+      let l = (base[left] ?? 0) + deltaPct;
+      let r = (base[right] ?? 0) - deltaPct;
+      if (l < min) {
+        l = min;
+        r = total - min;
+      } else if (r < min) {
+        r = min;
+        l = total - min;
       }
+      setSizes((cur) => {
+        const next = [...cur];
+        next[left] = l;
+        next[right] = r;
+        return next;
+      });
     }
     function stop() {
       window.removeEventListener("pointermove", move);
@@ -129,14 +153,12 @@ export function PanelWorkspace({
   }
 
   function slotStyle(id: string, index: number): CSSProperties | undefined {
-    if (layout !== "vertical") return undefined;
-    const others = order.filter((oid) => oid !== id);
-    if (folded[id]) return { flex: "0 0 auto" };
-    if (others.some((oid) => folded[oid])) return { flex: 1, minHeight: 0 };
-    if (order.length === 2) {
-      return { flex: index === 0 ? split : 100 - split, minHeight: 0 };
+    if (layout === "horizontal") {
+      return { gridColumn: String(2 * index + 1) };
     }
-    return { flex: 1, minHeight: 0 };
+    if (folded[id]) return { flex: "0 0 auto" };
+    if (order.some((oid) => folded[oid])) return { flex: 1, minHeight: 0 };
+    return { flex: `${sizes[index] ?? 1} 1 0`, minHeight: 0 };
   }
 
   function panelStyle(id: string): CSSProperties | undefined {
@@ -156,15 +178,12 @@ export function PanelWorkspace({
 
   function horizontalTemplate(): CSSProperties | undefined {
     if (layout !== "horizontal" || !multi) return undefined;
-    if (order.length === 2) {
-      if (folded[order[0]]) {
-        return { gridTemplateColumns: "42px 6px minmax(0, 1fr)" };
-      }
-      if (folded[order[1]]) {
-        return { gridTemplateColumns: "minmax(0, 1fr) 6px 42px" };
-      }
-    }
-    return { gridTemplateColumns: `${split}fr 6px ${100 - split}fr` };
+    const cols: string[] = [];
+    order.forEach((id, i) => {
+      if (i > 0) cols.push("6px");
+      cols.push(folded[id] ? "42px" : `${sizes[i] ?? 1}fr`);
+    });
+    return { gridTemplateColumns: cols.join(" ") };
   }
 
   function bodyClass(def: PanelDef) {
@@ -198,9 +217,8 @@ export function PanelWorkspace({
             {showSplitter && (
               <div
                 className="output-splitter"
-                onPointerDown={order.length === 2 ? startSplitResize : undefined}
-                style={order.length !== 2 ? { cursor: "default" } : undefined}
-                title={order.length === 2 ? "Resize panels" : undefined}
+                onPointerDown={(e) => startSplitResize(index, e)}
+                title="Resize panels"
               />
             )}
             <section

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -188,6 +188,7 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
           "ljung_box",
           "jarque_bera",
           "breusch_pagan",
+          "breusch_godfrey",
           "regression",
         ].includes(source.data.stepType)
       ) {
@@ -317,6 +318,13 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
 
   const canvasPanels: PanelDef[] = [
     {
+      id: "steps",
+      title: "Steps",
+      badge: catalog ? `${catalog.steps.length}` : undefined,
+      scrollable: true,
+      content: <StepPalette catalog={catalog} onAdd={addStep} />,
+    },
+    {
       id: "pipeline",
       title: "Pipeline",
       badge: `${nodes.length} steps`,
@@ -332,7 +340,6 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
           onDragOver={(event) => event.preventDefault()}
           onDrop={onDrop}
         >
-          <StepPalette catalog={catalog} onAdd={addStep} />
           <ReactFlow
             nodes={nodes}
             edges={edges}
@@ -447,7 +454,7 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
           <PanelWorkspace
             panels={canvasPanels}
             defaultLayout="horizontal"
-            defaultSplit={72}
+            defaultSizes={[18, 54, 28]}
             fillHeight
           />
         </div>
@@ -483,7 +490,6 @@ function StepPalette({
 }) {
   return (
     <div className="mc-palette">
-      <strong>Steps</strong>
       {catalog?.steps.map((item) => (
         <button
           key={item.step_type}

--- a/sdsge-ui/frontend/src/mc/StepNode.tsx
+++ b/sdsge-ui/frontend/src/mc/StepNode.tsx
@@ -18,6 +18,7 @@ const ICONS: Record<MCStepType, LucideIcon> = {
   ljung_box: Activity,
   jarque_bera: Activity,
   breusch_pagan: Activity,
+  breusch_godfrey: Activity,
   regression: TestTubeDiagonal,
 };
 
@@ -29,6 +30,7 @@ export function StepNode({ data, selected }: NodeProps<MCFlowNode>) {
     "ljung_box",
     "jarque_bera",
     "breusch_pagan",
+    "breusch_godfrey",
     "regression",
   ].includes(data.stepType);
   return (

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1352,27 +1352,12 @@ button.estimation-parameter-card.selected {
 }
 
 .mc-palette {
-  background: rgb(255 255 255 / 94%);
-  border: 1px solid #cbd5e1;
-  border-radius: 7px;
-  box-shadow: 0 3px 12px rgb(15 23 42 / 10%);
   display: flex;
   flex-direction: column;
   gap: 5px;
-  left: 10px;
   padding: 8px;
-  position: absolute;
-  top: 10px;
-  width: 150px;
-  z-index: 5;
 }
 
-.mc-palette > strong {
-  color: #475569;
-  font-size: 11px;
-  padding: 2px 3px;
-  text-transform: uppercase;
-}
 
 button.mc-palette-step {
   background: #f8fafc;
@@ -1419,7 +1404,8 @@ button.mc-palette-step:hover {
 .mc-step-node.wald,
 .mc-step-node.ljung_box,
 .mc-step-node.jarque_bera,
-.mc-step-node.breusch_pagan {
+.mc-step-node.breusch_pagan,
+.mc-step-node.breusch_godfrey {
   border-left-color: #9333ea;
 }
 
@@ -2191,7 +2177,6 @@ button.mc-palette-step:hover {
 }
 
 .theme-dark .mc-runbar,
-.theme-dark .mc-palette,
 .theme-dark .mc-step-node,
 .theme-dark .mc-metric {
   background: #1e293b;
@@ -2199,9 +2184,6 @@ button.mc-palette-step:hover {
   box-shadow: none;
 }
 
-.theme-dark .mc-palette {
-  background: rgb(30 41 59 / 94%);
-}
 
 .theme-dark button.mc-palette-step {
   background: #152032;
@@ -2214,7 +2196,6 @@ button.mc-palette-step:hover {
   color: #c7d2fe;
 }
 
-.theme-dark .mc-palette > strong,
 .theme-dark .mc-step-node-heading,
 .theme-dark .mc-step-node-summary,
 .theme-dark .mc-inspector-title span,

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -166,6 +166,7 @@ export type MCStepType =
   | "ljung_box"
   | "jarque_bera"
   | "breusch_pagan"
+  | "breusch_godfrey"
   | "regression";
 
 export type MCFieldType =

--- a/tests/diag_tests/test_breusch_godfrey.py
+++ b/tests/diag_tests/test_breusch_godfrey.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import chi2
+
+from SymbolicDSGE._diag_tests.breusch_godfrey import breusch_godfrey
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.status import TestStatus
+
+
+def _manual_bg_stat(eps: np.ndarray, X: np.ndarray, lags: int) -> float:
+    n = eps.size
+    k = X.shape[1]
+    design = np.empty((n, k + lags + 1), dtype=np.float64)
+    design[:, 0] = 1.0
+    design[:, 1 : k + 1] = X
+    for lag in range(1, lags + 1):
+        col = k + lag
+        design[:lag, col] = 0.0
+        design[lag:, col] = eps[:-lag]
+    bhat = np.linalg.lstsq(design, eps, rcond=None)[0]
+    rss = np.sum((eps - design @ bhat) ** 2)
+    tss = np.sum(eps**2)
+    return float(n * (1.0 - rss / tss))
+
+
+@pytest.mark.parametrize("lags", [1, 3])
+def test_breusch_godfrey_matches_lm_definition(lags: int) -> None:
+    rng = np.random.default_rng(2024)
+    X = rng.normal(size=(150, 2))
+    eps = rng.normal(size=150)
+
+    out = breusch_godfrey(eps, X, lags=lags, alpha=0.1)
+    expected = _manual_bg_stat(eps, X, lags)
+
+    assert out.test_name == "breusch_godfrey"
+    assert out.status is TestStatus.OK
+    assert out.dist is ReferenceDistribution.CHI2
+    assert out.pval_method is PvalMethod.SF
+    assert out.df == lags
+    assert out.alpha == np.float64(0.1)
+    assert out.statistic == pytest.approx(expected)
+    assert out.pval == pytest.approx(chi2(df=lags).sf(expected))
+
+
+def test_breusch_godfrey_detects_serial_correlation() -> None:
+    rng = np.random.default_rng(7)
+    n = 400
+    noise = rng.normal(size=n)
+    correlated = np.empty(n, dtype=np.float64)
+    correlated[0] = noise[0]
+    for t in range(1, n):
+        correlated[t] = 0.8 * correlated[t - 1] + noise[t]
+    X = rng.normal(size=(n, 1))
+
+    serial = breusch_godfrey(correlated, X, lags=1)
+    white = breusch_godfrey(noise, X, lags=1)
+
+    assert serial.status is TestStatus.OK
+    assert white.status is TestStatus.OK
+    # Strongly autocorrelated residuals yield a large LM statistic and a
+    # rejection, while white noise does not.
+    assert serial.statistic > white.statistic
+    assert serial.pval < 0.01
+    assert white.pval > serial.pval
+
+
+def test_breusch_godfrey_reports_computation_statuses() -> None:
+    insufficient = breusch_godfrey(
+        np.zeros(2, dtype=np.float64), np.zeros((2, 1), dtype=np.float64), lags=3
+    )
+    bad_shape = breusch_godfrey(
+        np.zeros(5, dtype=np.float64), np.zeros((4, 1), dtype=np.float64), lags=1
+    )
+
+    assert insufficient.status is TestStatus.INSUFFICIENT_SAMPLES
+    assert bad_shape.status is TestStatus.BAD_SHAPE
+    assert insufficient.df == 3
+    assert np.isnan(insufficient.statistic)
+    assert np.isnan(bad_shape.statistic)

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from SymbolicDSGE import Shock
+from SymbolicDSGE._diag_tests.breusch_godfrey import breusch_godfrey
 from SymbolicDSGE._diag_tests.breusch_pagan import (
     breusch_pagan,
     robust_breusch_pagan,
@@ -23,6 +24,7 @@ from SymbolicDSGE.monte_carlo import (
     MCReferenceConstruct,
     MCStep,
     OpType,
+    breusch_godfrey_test_step,
     breusch_pagan_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
@@ -558,6 +560,96 @@ def test_breusch_pagan_pipeline_handles_burn_in_that_removes_all_samples() -> No
     assert out.test_status_traces["bp"] == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
     assert np.isnan(out.statistic_traces["bp"]).all()
     assert np.isnan(out.pval_traces["bp"]).all()
+
+
+def test_breusch_godfrey_pipeline_selects_columns_and_aggregates_results() -> None:
+    rng = np.random.default_rng(512)
+    X = rng.normal(size=(2, 40, 2))
+    eps = rng.normal(size=(2, 40))
+    observables = np.concatenate((eps[:, :, None], X), axis=2)
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            breusch_godfrey_test_step(
+                "bg",
+                residual_source="observables",
+                X_source="observables",
+                residual_col=0,
+                X_columns=[1, 2],
+                lags=2,
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    expected = np.asarray(
+        [breusch_godfrey(eps[i], X[i], lags=2).statistic for i in range(2)],
+        dtype=np.float64,
+    )
+    np.testing.assert_allclose(out.statistic_traces["bg"], expected)
+    assert out.test_summaries["bg"].df == 2
+    assert out.test_status_traces["bg"] == (TestStatus.OK, TestStatus.OK)
+
+
+def test_breusch_godfrey_pipeline_validates_residual_and_regressor_inputs() -> None:
+    observables = np.arange(30.0, dtype=np.float64).reshape(10, 3)
+    reference = _FakeSolvedModel()
+
+    with pytest.raises(ValueError, match="exactly one column"):
+        MCPipeline(
+            [
+                raw_data_step(observables=observables),
+                breusch_godfrey_test_step(
+                    "bg",
+                    residual_source="observables",
+                    X_source="observables",
+                    X_columns=[1, 2],
+                ),
+            ]
+        ).run(reference=reference, n_rep=1, verbosity=0)
+
+    with pytest.raises(ValueError, match="same number of rows"):
+        MCPipeline(
+            [
+                raw_data_step(
+                    states=np.arange(33.0, dtype=np.float64).reshape(11, 3),
+                    observables=observables,
+                ),
+                breusch_godfrey_test_step(
+                    "bg",
+                    residual_source="observables",
+                    X_source="states",
+                    residual_col=0,
+                    X_columns=[0, 1],
+                ),
+            ]
+        ).run(reference=reference, n_rep=1, verbosity=0)
+
+
+def test_breusch_godfrey_pipeline_handles_burn_in_that_removes_all_samples() -> None:
+    base = np.arange(30.0, dtype=np.float64).reshape(10, 3)
+    observables = np.stack((base, base + 0.5))
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            breusch_godfrey_test_step(
+                "bg",
+                residual_source="observables",
+                X_source="observables",
+                residual_col=0,
+                X_columns=[1, 2],
+                burn_in=observables.shape[1],
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    assert out.succeeded
+    assert out.test_status_traces["bg"] == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
+    assert np.isnan(out.statistic_traces["bg"]).all()
+    assert np.isnan(out.pval_traces["bg"]).all()
 
 
 def test_raw_data_pipeline_rejects_empty_raw_data() -> None:

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -364,6 +364,7 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
         "ljung_box",
         "jarque_bera",
         "breusch_pagan",
+        "breusch_godfrey",
         "regression",
     }
 
@@ -592,6 +593,65 @@ def test_ui_backend_runs_breusch_pagan_monte_carlo_step() -> None:
     assert summary["test_name"] == "heteroskedasticity"
     assert summary["distribution"] == "chi2"
     assert summary["df"] == 1
+    assert summary["n"] == 2
+
+
+def test_ui_backend_runs_breusch_godfrey_monte_carlo_step() -> None:
+    client = TestClient(create_app())
+    for role in ("reference", "dgp"):
+        loaded = client.post(
+            "/api/model/load-yaml",
+            json={"role": role, "path": "MODELS/test.yaml"},
+        )
+        assert loaded.status_code == 200
+        solved = client.post(
+            "/api/model/solve",
+            json={"role": role, "compile_kwargs": {"n_state": 3, "n_exog": 2}},
+        )
+        assert solved.status_code == 200
+
+    pipeline = {
+        "nodes": [
+            {
+                "id": "sim",
+                "step_type": "simulation",
+                "name": "datagen",
+                "params": {"T": 20},
+            },
+            {
+                "id": "bg",
+                "step_type": "breusch_godfrey",
+                "name": "serial_correlation",
+                "params": {
+                    "residual_source": "states",
+                    "X_source": "states",
+                    "residual_col": [0],
+                    "X_columns": [1],
+                    "burn_in": 1,
+                    "lags": 2,
+                    "alpha": 0.1,
+                },
+            },
+        ],
+        "edges": [{"source": "sim", "target": "bg"}],
+    }
+
+    validated = client.post("/api/mc/validate", json=pipeline)
+    assert validated.status_code == 200
+    assert validated.json()["order"] == ["sim", "bg"]
+
+    run = client.post(
+        "/api/run/mc",
+        json={"pipeline": pipeline, "n_rep": 2, "fail_fast": True},
+    )
+    assert run.status_code == 200
+    body = run.json()
+    assert body["succeeded"] is True
+    assert set(body["test_summaries"]) == {"serial_correlation"}
+    summary = body["test_summaries"]["serial_correlation"]
+    assert summary["test_name"] == "serial_correlation"
+    assert summary["distribution"] == "chi2"
+    assert summary["df"] == 2
     assert summary["n"] == 2
 
 


### PR DESCRIPTION
Introduce a Breusch-Godfrey diagnostic and wire it into the Monte Carlo pipeline and UI. Added SymbolicDSGE/_diag_tests/breusch_godfrey.py (Numba-jitted BG statistic, design matrix builder, solver fallback and TestResult creation). Exposed a breusch_godfrey_test_step in monte_carlo.config and added run_breusch_godfrey_test in monte_carlo.operations (resolves residuals/X from MCContext, validates shapes, calls the test). Updated monte_carlo package exports. UI changes: register the step type in mc schemas and UI catalog, add step palette entry and node/icon support (MCPipelineView, StepNode, types), and include the step when building pipelines in SymbolicDSGE/ui/mc.py. PanelWorkspace changes: add defaultSizes prop, support multi-panel split resizing, compute per-panel sizes, and set new default sizes in MCPipelineView. CSS updates: remove absolute positioning and heading from .mc-palette, add styling for breusch_godfrey node, and tidy theme-dark palette rules. These changes enable serial-correlation testing in MC workflows and improve the workspace panel resizing behavior.

closes #123 