### PR TITLE
Add CUSUM diagnostic and distribution

### DIFF
--- a/SymbolicDSGE/_diag_tests/cusum.py
+++ b/SymbolicDSGE/_diag_tests/cusum.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeAlias, cast, overload
+
+import numpy as np
+from numpy import float64
+from numpy.typing import NDArray
+from numba import njit
+
+# Normal distribution with Numba JIT
+from math import sqrt, erf, erfc, exp, log
+
+from scipy.stats import norm
+from scipy.stats._distn_infrastructure import rv_frozen
+
+from .status import TestStatus
+from .result import TestResult
+from .distributions import PvalMethod, ReferenceDistribution
+
+from ..regression.solvers import chol_solve, lstsq_solve
+
+if TYPE_CHECKING:
+    import optype.numpy as onp
+
+NDF: TypeAlias = NDArray[float64]
+DistributionOutput: TypeAlias = float | float64 | NDF
+
+# Test Status
+OK = int(TestStatus.OK)
+BAD_SHAPE = int(TestStatus.BAD_SHAPE)
+INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
+
+# Newton Status
+CONVERGED = 0
+ITER_LIM = 1
+OOB = 2
+
+# Distribution Code
+
+SQRT_2 = sqrt(2.0)
+SQRT_2PI = sqrt(2.0 * np.pi)
+INV_SQRT_2PI = 1.0 / SQRT_2PI
+
+
+@njit(cache=True)
+def _pdf(x: float64) -> float64:
+    return float64(INV_SQRT_2PI * exp(-0.5 * x * x))
+
+
+@njit(cache=True)
+def _cdf(x: float64) -> float64:
+    return float64(0.5 * (1.0 + erf(x / SQRT_2)))
+
+
+@njit(cache=True)
+def _sf(x: float64) -> float64:
+    return float64(0.5 * erfc(x / SQRT_2))
+
+
+# Durbin's approximation
+@njit(cache=True)
+def _alpha_from_a(a: float64) -> float64:
+    return float64(2.0 * (_sf(float64(2.0 * a)) + exp(-4.0 * a * a) * _cdf(a)))
+
+
+@njit(cache=True)
+def _d_da(a: float64) -> float64:
+    e = exp(-4.0 * a * a)
+    return float64(
+        2.0 * (-2.0 * _pdf(float64(2.0 * a)) + e * _pdf(a) - 8.0 * a * e * _cdf(a))
+    )
+
+
+# Inverse for a = f(alpha) using Newton's method
+@njit(cache=True)
+def _a_from_alpha(
+    alpha: float64, tol: float = 1e-13, max_iter: int = 50
+) -> tuple[int, float64]:
+    if alpha <= 0.0 or alpha >= 1.0:
+        return OOB, float64(np.nan)
+
+    lo = 0.0
+
+    # approximate a:
+    hi = float64(max(1.0, -0.5 * sqrt(-0.5 * log(alpha / 2.0))))
+
+    while _alpha_from_a(hi) > alpha:
+        hi *= 2.0
+
+    a = hi
+
+    for _ in range(max_iter):
+        fa = _alpha_from_a(a) - alpha
+        if abs(fa) < tol:
+            return CONVERGED, a
+
+        if fa > 0.0:
+            lo = a
+        else:
+            hi = a
+
+        da = _d_da(a)
+        if da == 0.0:
+            cand = 0.5 * (lo + hi)
+        else:
+            cand = a - fa / da
+            # Reject Newton steps that leave the bracket; bisect instead so
+            # the iterate can never escape to a region where da underflows.
+            if cand <= lo or cand >= hi:
+                cand = 0.5 * (lo + hi)
+
+        if abs(cand - a) < tol * max(1.0, abs(a)):
+            return CONVERGED, cand
+        a = cand
+    return ITER_LIM, a
+
+
+# Reference distribution
+@njit(cache=True)
+def _alpha_from_a_array(a: NDF) -> NDF:
+    out = np.empty_like(a)
+    for i in range(a.size):
+        out[i] = _alpha_from_a(a[i])
+    return out
+
+
+@njit(cache=True)
+def _a_from_alpha_array(alpha: NDF) -> NDF:
+    out = np.empty_like(alpha)
+    for i in range(alpha.size):
+        out[i] = _a_from_alpha(alpha[i])[1]
+    return out
+
+
+def _isf_scalar(alpha: float64) -> float64:
+    return float64(_a_from_alpha(alpha)[1])
+
+
+def _dispatch(
+    x: Any,
+    scalar_fn: Callable[[float64], float64],
+    array_fn: Callable[[NDF], NDF],
+) -> DistributionOutput:
+    values = np.asarray(x, dtype=np.float64)
+    if values.ndim == 0:
+        return float64(scalar_fn(float64(values.item())))
+    flat = np.ascontiguousarray(values.reshape(-1))
+    return cast(NDF, array_fn(flat).reshape(values.shape))
+
+
+class CusumDist(rv_frozen):
+    """Durbin's (1969) approximation to the distribution of the recursive-
+    residual CUSUM statistic.
+
+    The test is parameter-free: the boundary-crossing probability is a closed
+    form of the statistic itself, so the survival function *is* ``_alpha_from_a``
+    and the inverse survival function *is* ``_a_from_alpha``. Exposing it as a
+    ``FrozenDistribution`` lets CUSUM reuse the standard ``TestResult`` p-value
+    machinery (``dist.freeze().sf(stat)`` via ``PvalMethod.SF``) instead of a
+    bespoke code path. It takes no distribution parameters; any ``df`` passed
+    through ``freeze`` is ignored.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(norm)  # placeholder base; all moments overridden
+
+    @overload
+    def sf(self, x: onp.ToFloat, /) -> DistributionOutput: ...
+    @overload
+    def sf(self, x: onp.ToFloatND, /) -> NDF: ...
+    def sf(self, x: Any, /) -> DistributionOutput:  # pyright: ignore
+        # Durbin's series can exceed 1 for small statistics; clamp so the
+        # survival function always returns a valid probability.
+        return np.minimum(1.0, _dispatch(x, _alpha_from_a, _alpha_from_a_array))
+
+    @overload
+    def cdf(self, x: onp.ToFloat, /) -> DistributionOutput: ...
+    @overload
+    def cdf(self, x: onp.ToFloatND, /) -> NDF: ...
+    def cdf(self, x: Any, /) -> DistributionOutput:  # pyright: ignore
+        return cast(DistributionOutput, 1.0 - self.sf(x))
+
+    @overload
+    def isf(self, q: onp.ToFloat, /) -> DistributionOutput: ...
+    @overload
+    def isf(self, q: onp.ToFloatND, /) -> NDF: ...
+    def isf(self, q: Any, /) -> DistributionOutput:  # pyright: ignore
+        return _dispatch(q, _isf_scalar, _a_from_alpha_array)
+
+    @overload
+    def ppf(self, q: onp.ToFloat, /) -> DistributionOutput: ...
+    @overload
+    def ppf(self, q: onp.ToFloatND, /) -> NDF: ...
+    def ppf(self, q: Any, /) -> DistributionOutput:  # pyright: ignore
+        return self.isf(1.0 - np.asarray(q, dtype=np.float64))
+
+
+# Test Code
+@njit(cache=True)
+def cusum_series(y: NDF, X: NDF) -> tuple[int, NDF]:
+    T, p = X.shape
+    if T == 0 or T <= p:
+        return INSUFFICIENT_SAMPLES, np.empty(0, dtype=float64)
+    if y.size != T:
+        return BAD_SHAPE, np.empty(0, dtype=float64)
+
+    try:
+        bhat, _, _ = chol_solve(X, y)
+    except Exception:
+        bhat, _, _ = lstsq_solve(X, y)
+
+    resid = y - X @ bhat
+    sigma_hat = sqrt(np.sum(resid**2) / (T - p))  # DoF correction
+
+    # Seed the recursion from the first p observations: P = (X_p' X_p)^-1 and
+    # beta = P X_p' y_p. The Gram matrix and X_p' y_p are accumulated by direct
+    # indexing (no slice views), leaving only a single small p x p inverse.
+    G = np.zeros((p, p), dtype=float64)
+    Xty = np.zeros(p, dtype=float64)
+    for r in range(p):
+        yr = y[r]
+        for a in range(p):
+            xra = X[r, a]
+            Xty[a] += xra * yr
+            for b in range(p):
+                G[a, b] += xra * X[r, b]
+    P = np.linalg.inv(G)
+
+    beta = np.zeros(p, dtype=float64)
+    for a in range(p):
+        s = 0.0
+        for b in range(p):
+            s += P[a, b] * Xty[b]
+        beta[a] = s
+
+    # Recursive residuals. P stays symmetric (a symmetric rank-1 downdate of a
+    # symmetric matrix), so Px == P @ x_t == x_t @ P is computed once per step
+    # and reused for the quadratic form, the downdate, and the beta update.
+    # Manual loops avoid per-iteration BLAS dispatch, which dominates at the
+    # small p typical of CUSUM regressions.
+    rec_resid = np.empty(T - p, dtype=float64)
+    Px = np.empty(p, dtype=float64)
+    for i in range(T - p):
+        xt = X[p + i]
+
+        e = y[p + i]
+        for a in range(p):
+            e -= xt[a] * beta[a]
+
+        quad = 0.0
+        for a in range(p):
+            s = 0.0
+            for b in range(p):
+                s += P[a, b] * xt[b]
+            Px[a] = s
+            quad += xt[a] * s
+
+        ft = 1.0 + quad
+        rec_resid[i] = e / sqrt(ft)
+
+        inv_ft = 1.0 / ft
+        coef = e * inv_ft
+        for a in range(p):
+            pa = Px[a]
+            beta[a] += pa * coef
+            for b in range(p):
+                P[a, b] -= pa * Px[b] * inv_ft
+
+    std_cusum = np.cumsum(rec_resid) / sigma_hat
+    return OK, std_cusum
+
+
+@njit(cache=True)
+def cusum_stat(y: NDF, X: NDF) -> tuple[int, float64]:
+    T, p = X.shape
+    status, cusum = cusum_series(y, X)
+    if status != OK:
+        return status, float64(np.nan)
+
+    scaled = np.empty(T - p, dtype=float64)
+    sqrt_Tp = sqrt(T - p)
+    abs_cusum = np.abs(cusum)
+    for i, t in enumerate(range(p, T)):
+        denom = sqrt_Tp + (2 * (t - p) / sqrt_Tp)
+        scaled[i] = abs_cusum[i] / denom
+    return status, np.max(scaled)
+
+
+def cusum(y: NDF, X: NDF, alpha: float = 0.05, _auto_pval: bool = True) -> TestResult:
+    test_status, stat = cusum_stat(y, X)
+    # _a_from_alpha is only used to validate alpha (in-bounds + convergent);
+    # the p-value itself comes from sf(stat) inside TestResult.
+    newton_status, _ = _a_from_alpha(alpha)
+
+    test_ok = test_status == OK
+    nwt_ok = newton_status == CONVERGED
+
+    if test_ok and nwt_ok:
+        status = TestStatus.OK
+    elif not test_ok:
+        status = TestStatus(test_status)
+    else:
+        if newton_status == ITER_LIM:
+            status = TestStatus.ITERATIVE_ALG_NONCONVERGENCE
+        else:
+            status = TestStatus.BAD_PARAMETER
+
+    return TestResult(
+        test_name="cusum",
+        statistic=stat,
+        df=float64(np.nan),
+        dist=ReferenceDistribution.CUSUM,
+        pval_method=PvalMethod.SF,
+        alpha=float64(alpha),
+        status=status,
+        _auto_pval=_auto_pval,
+    )

--- a/SymbolicDSGE/_diag_tests/distributions.py
+++ b/SymbolicDSGE/_diag_tests/distributions.py
@@ -49,6 +49,7 @@ class ReferenceDistribution(Enum):
     F = "f"
     t = "t"
     JB_LOOKUP = "jb_lookup"
+    CUSUM = "cusum"
 
     def freeze(self, *df: DistributionParameter) -> FrozenDistribution:
         match self:
@@ -75,5 +76,11 @@ class ReferenceDistribution(Enum):
                 if isinstance(n, bool | np.bool_) or not isinstance(n, int | integer):
                     raise TypeError("JB_LOOKUP sample size must be an integer")
                 return JarqueBeraDist(n)
+            case ReferenceDistribution.CUSUM:
+                from .cusum import CusumDist
+
+                # CUSUM is parameter-free; any df forwarded by TestResult
+                # (a NaN placeholder) is ignored.
+                return CusumDist()
             case _:
                 raise ValueError(f"Unsupported reference distribution: {self}")

--- a/SymbolicDSGE/_diag_tests/status.py
+++ b/SymbolicDSGE/_diag_tests/status.py
@@ -10,3 +10,5 @@ class TestStatus(IntEnum):
     UDEF_VARIANCE = -3
     BAD_LAG = -4
     INSUFFICIENT_SAMPLES = -5
+    ITERATIVE_ALG_NONCONVERGENCE = -6
+    BAD_PARAMETER = -7

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -1,6 +1,7 @@
 from .config import (
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    cusum_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     raw_data_step,
@@ -29,6 +30,7 @@ from .mc_constructs import (
 )
 from .operations import (
     raw_data_datagen,
+    run_cusum_test,
     run_breusch_godfrey_test,
     run_breusch_pagan_test,
     run_jarque_bera_test,
@@ -57,6 +59,7 @@ __all__ = [
     "TestOp",
     "breusch_godfrey_test_step",
     "breusch_pagan_test_step",
+    "cusum_test_step",
     "jarque_bera_test_step",
     "ljung_box_test_step",
     "raw_data_datagen",
@@ -67,6 +70,7 @@ __all__ = [
     "regression_step",
     "run_breusch_godfrey_test",
     "run_breusch_pagan_test",
+    "run_cusum_test",
     "run_reference_filter",
     "run_regression",
     "run_jarque_bera_test",

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -12,6 +12,7 @@ from .operations import (
     run_jarque_bera_test as _run_jarque_bera_test,
     run_breusch_pagan_test as _run_breusch_pagan_test,
     run_breusch_godfrey_test as _run_breusch_godfrey_test,
+    run_cusum_test as _run_cusum_test,
     simulate_dgp as _simulate_dgp,
 )
 
@@ -74,6 +75,10 @@ def breusch_godfrey_test_step(name: str, **kwargs: Any) -> MCStep:
     return MCStep(
         name=name, op_type=OpType.TEST, func=_run_breusch_godfrey_test, kwargs=kwargs
     )
+
+
+def cusum_test_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(name=name, op_type=OpType.TEST, func=_run_cusum_test, kwargs=kwargs)
 
 
 def regression_step(name: str, **kwargs: Any) -> MCStep:

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -183,6 +183,28 @@ class MCPipeline:
         context.payloads[step.output_key] = out
 
 
+def _df_metadata_matches(a: object, b: object) -> bool:
+    """Compare normalized df metadata across replications, treating NaN == NaN
+    as a match. Parameter-free reference distributions (CUSUM) carry a NaN df
+    placeholder, which a plain ``!=`` would otherwise flag as incompatible."""
+    at = a if isinstance(a, tuple) else (a,)
+    bt = b if isinstance(b, tuple) else (b,)
+    if len(at) != len(bt):
+        return False
+    for x, y in zip(at, bt):
+        if x == y:
+            continue
+        if (
+            isinstance(x, float | np.floating)
+            and isinstance(y, float | np.floating)
+            and np.isnan(x)
+            and np.isnan(y)
+        ):
+            continue
+        return False
+    return True
+
+
 def _summarize_tests(
     results_by_step: Mapping[str, list[TestResult]],
 ) -> dict[str, MCResult]:
@@ -196,7 +218,7 @@ def _summarize_tests(
             if (
                 result.dist is not first.dist
                 or result.pval_method is not first.pval_method
-                or result.df != first.df
+                or not _df_metadata_matches(result.df, first.df)
                 or result.alpha != first.alpha
             ):
                 raise ValueError(

--- a/SymbolicDSGE/monte_carlo/operations.py
+++ b/SymbolicDSGE/monte_carlo/operations.py
@@ -15,6 +15,7 @@ from .._diag_tests.ljung_box import ljung_box
 from .._diag_tests.jarque_bera import jarque_bera
 from .._diag_tests.breusch_pagan import breusch_pagan, robust_breusch_pagan
 from .._diag_tests.breusch_godfrey import breusch_godfrey
+from .._diag_tests.cusum import cusum
 
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
@@ -435,6 +436,59 @@ def run_breusch_godfrey_test(
 
     residual_vec = np.ascontiguousarray(residuals[:, 0], dtype=np.float64)
     return breusch_godfrey(residual_vec, X, lags=lags, alpha=alpha, _auto_pval=False)
+
+
+def run_cusum_test(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    x_source: InpSources,
+    y_source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    y_column: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+) -> TestResult:
+    del reference, dgp, rep_idx
+    y_col_idx: Sequence[int] | None
+    if isinstance(y_column, int):
+        y_col_idx = [y_column]
+    else:
+        y_col_idx = y_column
+    y = _resolve_context_array(
+        context,
+        source=y_source,
+        filter_key=filter_key,
+        payload_key=payload_key,
+        columns=y_col_idx,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    X = _resolve_context_array(
+        context,
+        source=x_source,
+        filter_key=filter_key,
+        payload_key=payload_key,
+        columns=X_columns,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    if y.shape[1] != 1:
+        raise ValueError(
+            "CUSUM test requires the dependent variable to resolve to exactly "
+            f"one column. Got shape {y.shape}."
+        )
+    if y.shape[0] != X.shape[0]:
+        raise ValueError(
+            "CUSUM test dependent variable and regressors must have the same "
+            f"number of rows. Got y={y.shape[0]} and X={X.shape[0]}."
+        )
+    return cusum(y[:, 0], X, alpha=alpha, _auto_pval=False)
 
 
 def run_regression(

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -13,6 +13,7 @@ from SymbolicDSGE.monte_carlo import (
     MCPipelineResult,
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    cusum_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     reference_filter_step,
@@ -41,6 +42,7 @@ TERMINAL_STEP_TYPES = {
     "jarque_bera",
     "breusch_pagan",
     "breusch_godfrey",
+    "cusum",
     "regression",
 }
 
@@ -218,6 +220,33 @@ def mc_catalog() -> dict[str, Any]:
                     _field("burn_in", "Burn-in", "number", 0, minimum=0),
                     _field("drop_initial", "Drop initial", "boolean", False),
                     _field("lags", "Lags", "number", 1, minimum=1),
+                    _field("alpha", "Alpha", "number", 0.05),
+                ],
+            ),
+            _step_catalog(
+                "cusum",
+                "CUSUM Test",
+                "cusum",
+                "Test regression coefficients for stability via recursive residuals.",
+                [
+                    _field(
+                        "y_source",
+                        "Response source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field(
+                        "x_source",
+                        "Regressor source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field("y_column", "Response column", "number_list", [0]),
+                    _field("X_columns", "Regressor columns", "number_list", [1]),
+                    _field("burn_in", "Burn-in", "number", 0, minimum=0),
+                    _field("drop_initial", "Drop initial", "boolean", False),
                     _field("alpha", "Alpha", "number", 0.05),
                 ],
             ),
@@ -448,6 +477,8 @@ def build_pipeline(
             steps.append(breusch_pagan_test_step(node.name, **params))
         elif node.step_type == "breusch_godfrey":
             steps.append(breusch_godfrey_test_step(node.name, **params))
+        elif node.step_type == "cusum":
+            steps.append(cusum_test_step(node.name, **params))
         elif node.step_type == "regression":
             steps.append(regression_step(node.name, **_regression_params(params)))
         else:
@@ -584,7 +615,7 @@ def _validate_dependency(node: MCNodeSpec, prior_names: set[str]) -> None:
         return
     sources = [
         params.get(key)
-        for key in ("source", "residual_source", "y_source", "X_source")
+        for key in ("source", "residual_source", "y_source", "X_source", "x_source")
         if params.get(key) is not None
     ]
     if any(source in FILTER_SOURCES for source in sources):
@@ -622,7 +653,7 @@ def _bind_graph_dependency(
     elif node.step_type in TERMINAL_STEP_TYPES:
         sources = [
             params.get(key)
-            for key in ("source", "residual_source", "y_source", "X_source")
+            for key in ("source", "residual_source", "y_source", "X_source", "x_source")
             if params.get(key) is not None
         ]
         if any(source == "payload" for source in sources):

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -12,6 +12,7 @@ MCStepKind = Literal[
     "jarque_bera",
     "breusch_pagan",
     "breusch_godfrey",
+    "cusum",
     "regression",
 ]
 

--- a/evaluation.html
+++ b/evaluation.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SymbolicDSGE — Evaluation Report</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --surface2: #22263a;
+    --border: #2e3250;
+    --accent: #f97316;
+    --accent2: #6366f1;
+    --accent3: #10b981;
+    --text: #e2e8f0;
+    --muted: #8892a4;
+    --warn: #f59e0b;
+    --good: #22c55e;
+    --bad: #ef4444;
+    --bar-bg: #2e3250;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem 1rem 4rem;
+  }
+  .container { max-width: 960px; margin: 0 auto; }
+
+  /* HEADER */
+  .header {
+    display: flex; flex-direction: column; gap: 0.5rem;
+    border-bottom: 1px solid var(--border); padding-bottom: 1.5rem; margin-bottom: 2rem;
+  }
+  .header-top { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .logo { font-size: 1.6rem; font-weight: 800; letter-spacing: -0.5px; }
+  .logo span { color: var(--accent); }
+  .badge {
+    font-size: 0.7rem; font-weight: 600; padding: 2px 8px; border-radius: 999px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+  }
+  .badge-orange { background: rgba(249,115,22,0.15); color: var(--accent); border: 1px solid rgba(249,115,22,0.3); }
+  .badge-blue { background: rgba(99,102,241,0.15); color: #818cf8; border: 1px solid rgba(99,102,241,0.3); }
+  .badge-green { background: rgba(16,185,129,0.15); color: var(--accent3); border: 1px solid rgba(16,185,129,0.3); }
+  .subtitle { color: var(--muted); font-size: 0.9rem; line-height: 1.6; max-width: 700px; }
+  .meta { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-top: 0.25rem; }
+  .meta-item { font-size: 0.75rem; color: var(--muted); display: flex; gap: 0.3rem; align-items: center; }
+  .meta-item a { color: var(--accent2); text-decoration: none; }
+  .meta-item a:hover { text-decoration: underline; }
+
+  /* SECTION TITLES */
+  .section-title {
+    font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em;
+    color: var(--muted); margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem;
+  }
+  .section-title::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+
+  /* OVERALL SCORE CARD */
+  .overall-card {
+    background: linear-gradient(135deg, #1e2140 0%, #1a1d27 100%);
+    border: 1px solid var(--border); border-radius: 12px;
+    padding: 1.5rem 2rem; margin-bottom: 2rem;
+    display: grid; grid-template-columns: auto 1fr; gap: 2rem; align-items: center;
+  }
+  .big-score {
+    font-size: 5rem; font-weight: 900; line-height: 1; letter-spacing: -2px;
+    background: linear-gradient(135deg, var(--accent), #fbbf24);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  }
+  .big-score sub { font-size: 1.5rem; opacity: 0.5; vertical-align: super; }
+  .overall-text h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 0.4rem; }
+  .overall-text p { font-size: 0.85rem; color: var(--muted); line-height: 1.7; }
+
+  /* SCORES GRID */
+  .scores-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .score-card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    padding: 1.1rem 1.2rem;
+  }
+  .score-card-header {
+    display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.6rem;
+  }
+  .score-card-title { font-size: 0.82rem; font-weight: 600; color: var(--text); line-height: 1.3; }
+  .score-num {
+    font-size: 1.4rem; font-weight: 800; min-width: 2.2rem; text-align: right; line-height: 1;
+  }
+  .score-bar { height: 4px; background: var(--bar-bg); border-radius: 2px; overflow: hidden; margin-bottom: 0.6rem; }
+  .score-bar-fill { height: 100%; border-radius: 2px; transition: width 0.6s ease; }
+  .score-note { font-size: 0.73rem; color: var(--muted); line-height: 1.5; }
+  /* color tiers */
+  .s-high .score-num { color: var(--good); }
+  .s-high .score-bar-fill { background: var(--good); }
+  .s-mid .score-num { color: var(--warn); }
+  .s-mid .score-bar-fill { background: var(--warn); }
+  .s-low .score-num { color: var(--bad); }
+  .s-low .score-bar-fill { background: var(--bad); }
+  .s-accent .score-num { color: var(--accent); }
+  .s-accent .score-bar-fill { background: var(--accent); }
+
+  /* COMPETITIVE TABLE */
+  .comp-table-wrap {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    overflow-x: auto; margin-bottom: 2rem;
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+  thead tr { border-bottom: 1px solid var(--border); }
+  thead th {
+    padding: 0.75rem 1rem; text-align: left; font-size: 0.68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted);
+  }
+  thead th:first-child { min-width: 130px; }
+  tbody tr { border-bottom: 1px solid rgba(46,50,80,0.5); }
+  tbody tr:last-child { border-bottom: none; }
+  tbody td { padding: 0.7rem 1rem; vertical-align: middle; }
+  tbody td:first-child { font-weight: 600; }
+  .highlight-row td { background: rgba(99,102,241,0.06); }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+  .dot-green { background: var(--good); }
+  .dot-yellow { background: var(--warn); }
+  .dot-red { background: var(--bad); }
+  .cell-score { font-weight: 700; }
+  .cell-yes { color: var(--good); font-size: 0.85rem; }
+  .cell-partial { color: var(--warn); font-size: 0.85rem; }
+  .cell-no { color: var(--muted); font-size: 0.85rem; }
+
+  /* STRENGTHS / WEAKNESSES */
+  .sw-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem; }
+  @media (max-width: 600px) { .sw-grid { grid-template-columns: 1fr; } .overall-card { grid-template-columns: 1fr; } .big-score { font-size: 3.5rem; } }
+  .sw-card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    padding: 1.1rem 1.2rem;
+  }
+  .sw-card h4 { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.8rem; }
+  .sw-card.strengths h4 { color: var(--good); }
+  .sw-card.weaknesses h4 { color: var(--bad); }
+  .sw-item {
+    display: flex; gap: 0.5rem; font-size: 0.78rem; color: var(--text); line-height: 1.5;
+    margin-bottom: 0.5rem; align-items: flex-start;
+  }
+  .sw-icon { flex-shrink: 0; margin-top: 0.1rem; }
+
+  /* NOTES / COMMENTARY */
+  .note-block {
+    background: var(--surface2); border-left: 3px solid var(--accent2); border-radius: 0 8px 8px 0;
+    padding: 0.9rem 1.1rem; margin-bottom: 2rem; font-size: 0.82rem; line-height: 1.7; color: var(--text);
+  }
+  .note-block strong { color: var(--accent2); }
+
+  /* FOOTER */
+  .footer { font-size: 0.72rem; color: var(--muted); text-align: center; padding-top: 2rem; border-top: 1px solid var(--border); line-height: 1.8; }
+</style>
+</head>
+<body>
+<div class="container">
+
+  <!-- HEADER -->
+  <div class="header">
+    <div class="header-top">
+      <div class="logo">Symbolic<span>DSGE</span></div>
+      <span class="badge badge-orange">v1.4.0</span>
+      <span class="badge badge-green">95% Coverage</span>
+      <span class="badge badge-blue">MIT</span>
+    </div>
+    <p class="subtitle">
+      A Python DSGE engine with a SymPy symbolic backend, Numba-JIT compiled numerics,
+      and an integrated suite for Monte Carlo experiments, estimation (MLE/MAP/MCMC),
+      Kalman filtering, symbolic regression augmentation, and a web GUI.
+    </p>
+    <div class="meta">
+      <span class="meta-item">🐍 Python ≥ 3.13</span>
+      <span class="meta-item">📦 <a href="https://pypi.org/project/SymbolicDSGE/" target="_blank">PyPI</a></span>
+      <span class="meta-item">📖 <a href="https://gongjr0.github.io/SymbolicDSGE/latest/" target="_blank">Docs</a></span>
+      <span class="meta-item">🔗 <a href="https://github.com/GongJr0/SymbolicDSGE" target="_blank">GitHub</a></span>
+      <span class="meta-item">🎓 DOI: 10.5281/zenodo.20115401</span>
+      <span class="meta-item">📅 Evaluated: June 2026</span>
+    </div>
+  </div>
+
+  <!-- OVERALL -->
+  <div class="overall-card">
+    <div>
+      <div class="big-score">6.9<sub>/10</sub></div>
+    </div>
+    <div class="overall-text">
+      <h3>Overall Assessment</h3>
+      <p>
+        SymbolicDSGE is a technically impressive solo project that punches well above its weight class.
+        Its clearest competitive edge is the <em>config → MC experiment</em> pipeline: the composable step system,
+        tight Kalman integration, and symbolic regression augmentation represent a genuinely novel workflow
+        that no other Python DSGE tool offers. The main drags on the score are the Python 3.13+ constraint
+        (a significant adoption barrier), the linear-only solver, and single-maintainer risk.
+        Appropriately scoped — not competing with Dynare's breadth, winning on friction-free Python experimentation.
+      </p>
+    </div>
+  </div>
+
+  <!-- SCORES GRID -->
+  <div class="section-title">Category Scores</div>
+  <div class="scores-grid">
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Code &amp; Distribution Quality</div>
+        <div class="score-num">7</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:70%"></div></div>
+      <div class="score-note">95% test coverage, mypy + black + pre-commit, CI/CD, DOI, PyPI extras, CITATION.cff.
+      Deducted for Python 3.13+ only (most research is on 3.10–3.12), <code>assert</code> in production paths
+      (<code>_shock_unpack</code>), and <code>exec()+njit</code> in the solver compile path which is opaque to debug.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Performance Optimizations</div>
+        <div class="score-num">7</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:70%"></div></div>
+      <div class="score-note">Numba JIT on all scalar objective and observable functions; affine
+      measurement fast path bypasses per-step function calls; code-gen'd Jacobian pre-compiled at solver
+      startup. MCPipeline runs sequentially — no parallel MC sweeps despite the embarrassingly-parallel
+      structure being trivial to exploit. SymPy <code>simplify()</code> in compile paths is one-time cost, acceptable.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Position vs. Competitors</div>
+        <div class="score-num">6</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:60%"></div></div>
+      <div class="score-note">Outclassed by Dynare (breadth, community, institutional) and DSGE.jl (Julia speed, SMC).
+      Comparable to pydsge but lacks OBC/ZLB; compensates with richer MC pipeline and SR augmentation.
+      Clear win: Python-native with zero MATLAB dependency, composable MC workflow, GUI for non-programmers.
+      Linear-only is the central gap against serious academic alternatives.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Usability — Experienced Programmer, Less DSGE</div>
+        <div class="score-num">7</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:70%"></div></div>
+      <div class="score-note">Pure Python, pip-install, type-hinted API, Pythonic return types (dataclasses, dicts).
+      Workflow is linear and reasonably discoverable. <code>compile()</code> requiring <code>n_state/n_exog</code>
+      is a friction point — these are inferred correctly in most cases but must be confirmed by the user.
+      Error messages are good; could use more guided "what to do next" messaging.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Usability — DSGE Academic, Less Programming</div>
+        <div class="score-num">6</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:60%"></div></div>
+      <div class="score-note">YAML config lets equations be written near paper-form, and guides cover end-to-end workflow.
+      Python 3.13 env setup is a real hurdle for researchers with locked environments. No publication-ready
+      table output from estimation (Dynare's TeX tables are a gold standard here). The MC pipeline is powerful
+      but verbose for someone writing their first Python script.</div>
+    </div>
+
+    <div class="score-card s-low">
+      <div class="score-card-header">
+        <div class="score-card-title">Usability — Non-Technical Macro/Policy</div>
+        <div class="score-num">5</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:50%"></div></div>
+      <div class="score-note">The web GUI covers core use-cases (simulate, IRF, MC, transforms, figures) and can be
+      pre-loaded from a <code>SolvedModel</code> — a well-designed handoff. But estimation is absent from the GUI,
+      setup still requires a technical owner, and there is no hosted/cloud version. Score reflects honest current
+      state rather than potential; the GUI roadmap is promising.</div>
+    </div>
+
+    <div class="score-card s-high">
+      <div class="score-card-header">
+        <div class="score-card-title">Documentation &amp; Guide Quality</div>
+        <div class="score-num">8</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:80%"></div></div>
+      <div class="score-note">Versioned MkDocs Material site, full API reference, five topic guides, GUI docs,
+      contributing guide, demo notebooks, CITATION.cff. The "AI parsability" callout is a thoughtful touch.
+      Deducted for thin SR augmentation docs, no tutorial video, and a few edge-case gaps (when to prefer
+      extended vs linear KF, prior transform interaction subtleties).</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Extensibility</div>
+        <div class="score-num">7</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:70%"></div></div>
+      <div class="score-note">MC pipeline was explicitly designed for user-defined steps; <code>MCStep</code>
+      protocol with <code>OpType</code> enum is clean and composable. Custom shock distributions, user-supplied
+      Kalman R matrices, and in-place <code>ModelConfig</code> modification are all supported.
+      Extending the solver core (e.g., adding nonlinear methods) would require replacing linearsolve —
+      no plugin point at that level. No abstract base classes for alternative backends.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Ease of Contributing</div>
+        <div class="score-num">7</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:70%"></div></div>
+      <div class="score-note">Thorough CONTRIBUTING.md, uv-based one-command setup, pre-commit automation,
+      four issue templates, dependabot. The test suite is well-structured with pytest fixtures and module-scope
+      caching. Main barrier: single-maintainer review bottleneck. The MCStep protocol and some implicit contracts
+      (DATAGEN must be first, step names must be unique) are underdocumented for contributors adding built-in steps.</div>
+    </div>
+
+    <div class="score-card s-high">
+      <div class="score-card-header">
+        <div class="score-card-title">Feature Set</div>
+        <div class="score-num">8</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:80%"></div></div>
+      <div class="score-note">MLE/MAP/MCMC · Linear+Extended Kalman · SR measurement augmentation · Composable
+      MC pipeline · 5 statistical tests · OLS/Ridge/Lasso/ElasticNet in MC context · FRED integration · Web UI ·
+      Symbolic in-place manipulation · LKJ correlation priors · Custom shock distributions · Log/Taylor linearization.
+      Gap: no global (nonlinear) solution, no OBC/ZLB, no heterogeneous agents, no identification/sensitivity analysis.</div>
+    </div>
+
+    <div class="score-card s-mid">
+      <div class="score-card-header">
+        <div class="score-card-title">Research Institute Adoption Potential</div>
+        <div class="score-num">6</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:60%"></div></div>
+      <div class="score-note">Real advantages: Python-native, no MATLAB license, fast MC experimentation, SR novelty
+      publishable as methodology, GUI for policy collaborators. Barriers: Python 3.13 requirement (most lab stacks
+      are 3.10–3.11), single-maintainer continuity risk, no institution backing, linear-only. Best fit as a
+      <em>companion tool</em> to Dynare — the "quick model testing ground" use-case is well-served.</div>
+    </div>
+
+    <div class="score-card s-accent">
+      <div class="score-card-header">
+        <div class="score-card-title">Innovation &amp; Novelty ✦</div>
+        <div class="score-num">8</div>
+      </div>
+      <div class="score-bar"><div class="score-bar-fill" style="width:80%"></div></div>
+      <div class="score-note">SR-based measurement equation discovery is a genuine research contribution not seen in
+      any comparable Python DSGE tool. The typed, composable MC pipeline with Kalman-integration and statistical
+      test steps is an original design. Serving a solved model into a web GUI is practically unique.
+      Symbolic in-place modification + recompile workflow offers iteration speed unavailable in config-only tools.</div>
+    </div>
+
+  </div>
+
+  <!-- COMPETITIVE COMPARISON -->
+  <div class="section-title">Competitive Landscape</div>
+  <div class="comp-table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Tool</th>
+          <th>Language</th>
+          <th>Linear DSGE</th>
+          <th>Nonlinear</th>
+          <th>OBC/ZLB</th>
+          <th>Estimation</th>
+          <th>MC Pipeline</th>
+          <th>GUI</th>
+          <th>SR Augment</th>
+          <th>Community</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="highlight-row">
+          <td><span class="dot dot-green"></span><strong>SymbolicDSGE</strong></td>
+          <td>Python</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-yes">MLE/MAP/MCMC</td>
+          <td class="cell-yes">✓ Composable</td>
+          <td class="cell-yes">✓ Web</td>
+          <td class="cell-yes">✓ PySR</td>
+          <td class="cell-partial">Solo</td>
+        </tr>
+        <tr>
+          <td><span class="dot dot-red"></span><strong>Dynare</strong></td>
+          <td>MATLAB/Julia</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-yes">✓ Full</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-yes">Bayesian/MLE</td>
+          <td class="cell-partial">Manual</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-yes">Institutional</td>
+        </tr>
+        <tr>
+          <td><span class="dot dot-yellow"></span><strong>DSGE.jl (FRBNY)</strong></td>
+          <td>Julia</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-partial">Partial</td>
+          <td class="cell-no">—</td>
+          <td class="cell-yes">SMC/MH</td>
+          <td class="cell-partial">Manual</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-yes">NY Fed</td>
+        </tr>
+        <tr>
+          <td><span class="dot dot-yellow"></span><strong>pydsge</strong></td>
+          <td>Python</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-no">—</td>
+          <td class="cell-yes">✓ ZLB</td>
+          <td class="cell-yes">MLE/MCMC</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-partial">Solo</td>
+        </tr>
+        <tr>
+          <td><span class="dot dot-yellow"></span><strong>gEcon (R)</strong></td>
+          <td>R</td>
+          <td class="cell-yes">✓</td>
+          <td class="cell-partial">Symbolic</td>
+          <td class="cell-no">—</td>
+          <td class="cell-partial">MLE</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-no">—</td>
+          <td class="cell-partial">Academic</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- STRENGTHS & WEAKNESSES -->
+  <div class="section-title">Strengths &amp; Weaknesses</div>
+  <div class="sw-grid">
+    <div class="sw-card strengths">
+      <h4>✦ Strengths</h4>
+      <div class="sw-item"><span class="sw-icon">🔬</span><span>SR-based measurement augmentation — novel, publishable, unavailable elsewhere in Python DSGE tooling</span></div>
+      <div class="sw-item"><span class="sw-icon">⚡</span><span>Lowest friction config→MC pipeline in the Python DSGE space; composable step protocol is clean and extensible</span></div>
+      <div class="sw-item"><span class="sw-icon">🧮</span><span>Symbolic manipulation post-parse: modify equations, recompile, re-solve without touching YAML</span></div>
+      <div class="sw-item"><span class="sw-icon">🌐</span><span>Web GUI served directly from <code>SolvedModel.serve()</code> — practical for non-programmer collaborators</span></div>
+      <div class="sw-item"><span class="sw-icon">📊</span><span>95% test coverage with well-structured fixtures; CI badges, DOI, CITATION.cff show academic seriousness</span></div>
+      <div class="sw-item"><span class="sw-icon">🔗</span><span>FRED data integration + SciPy shock distributions + LKJ priors cover a realistic empirical workflow</span></div>
+      <div class="sw-item"><span class="sw-icon">🚀</span><span>Numba JIT + pre-compiled Jacobian gives competitive runtime after warmup; affine measurement fast path is smart</span></div>
+    </div>
+    <div class="sw-card weaknesses">
+      <h4>✗ Weaknesses</h4>
+      <div class="sw-item"><span class="sw-icon">🐍</span><span><strong>Python ≥ 3.13 requirement</strong> is the single biggest adoption barrier — most research environments pin 3.10 or 3.11</span></div>
+      <div class="sw-item"><span class="sw-icon">🔧</span><span>Linear-only solver (no perturbation beyond first order, no global methods) limits applicability to DSGE research requiring nonlinear dynamics</span></div>
+      <div class="sw-item"><span class="sw-icon">👤</span><span>Single-maintainer continuity risk; no institutional backing makes long-term support uncertain for labs</span></div>
+      <div class="sw-item"><span class="sw-icon">🔄</span><span>MC pipeline runs sequentially — obvious parallelism opportunity left on the table</span></div>
+      <div class="sw-item"><span class="sw-icon">⚠️</span><span><code>assert</code> used in production paths (<code>_shock_unpack</code>) — fails silently under <code>-O</code> optimized mode</span></div>
+      <div class="sw-item"><span class="sw-icon">📋</span><span>No publication-ready estimation output (TeX tables, parameter significance, convergence diagnostics) — Dynare's reporting is the benchmark</span></div>
+      <div class="sw-item"><span class="sw-icon">🏘️</span><span>No community forum, no mailing list; low discoverability outside the SR/symbolic niche</span></div>
+    </div>
+  </div>
+
+  <!-- COMMENTARY NOTE -->
+  <div class="section-title">Evaluator Note</div>
+  <div class="note-block">
+    <strong>On the "quick testing ground" use-case:</strong> This is where SymbolicDSGE is most convincing.
+    The workflow from <code>ModelParser → compile → solve → .sim() → MCPipeline.run()</code> with typed steps,
+    built-in Kalman integration, and result containers is genuinely faster to iterate on than anything Dynare or
+    DSGE.jl offer. The SR augmentation pipeline (<code>fit_kf</code>) for discovering measurement equations from
+    Kalman innovations is a research contribution in its own right. For a lab that already has Dynare for production
+    models and wants a Python-native scratchpad with MC and estimation built in, this fills a real gap.
+    <br><br>
+    <strong>On the Python 3.13 constraint:</strong> This should be treated as the highest-priority actionable item.
+    Dropping it to ≥3.10 (or ≥3.11 at most) would unlock the vast majority of existing research environments
+    and CI runners. The only likely blocker is a dependency, not the library code itself — worth investigating.
+    <br><br>
+    <strong>On the scores relative to Dynare/DSGE.jl:</strong> These are not the right comparators for an absolute
+    score — they represent 30 years of institutional investment vs. a solo project. On the specific axes where
+    SymbolicDSGE competes (Python ergonomics, MC pipeline, symbolic manipulation, SR augmentation), it scores 8–9
+    against anything available in the Python ecosystem.
+  </div>
+
+  <div class="footer">
+    Evaluation based on source code review (v1.4.0, branch: CUSUM), documentation at gongjr0.github.io/SymbolicDSGE/latest,
+    and comparison with Dynare 7.x, DSGE.jl (FRBNY), pydsge, and gEcon. · June 2026
+  </div>
+
+</div>
+</body>
+</html>

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -189,6 +189,7 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
           "jarque_bera",
           "breusch_pagan",
           "breusch_godfrey",
+          "cusum",
           "regression",
         ].includes(source.data.stepType)
       ) {

--- a/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
+++ b/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
@@ -373,5 +373,12 @@ function formatInterval(values: Array<number | null>): string {
 }
 
 function formatDf(value: number | Array<number | null> | null): string {
-  return Array.isArray(value) ? value.map(format).join(", ") : format(value);
+  // Parameter-free reference distributions (e.g. CUSUM) carry no df; the
+  // backend sends null. Render "N/A" so it reads as "not applicable" rather
+  // than a missing/failed value.
+  if (value == null) return "N/A";
+  if (Array.isArray(value)) {
+    return value.length === 0 ? "N/A" : value.map(format).join(", ");
+  }
+  return format(value);
 }

--- a/sdsge-ui/frontend/src/mc/StepNode.tsx
+++ b/sdsge-ui/frontend/src/mc/StepNode.tsx
@@ -19,6 +19,7 @@ const ICONS: Record<MCStepType, LucideIcon> = {
   jarque_bera: Activity,
   breusch_pagan: Activity,
   breusch_godfrey: Activity,
+  cusum: Activity,
   regression: TestTubeDiagonal,
 };
 
@@ -31,6 +32,7 @@ export function StepNode({ data, selected }: NodeProps<MCFlowNode>) {
     "jarque_bera",
     "breusch_pagan",
     "breusch_godfrey",
+    "cusum",
     "regression",
   ].includes(data.stepType);
   return (

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1405,7 +1405,8 @@ button.mc-palette-step:hover {
 .mc-step-node.ljung_box,
 .mc-step-node.jarque_bera,
 .mc-step-node.breusch_pagan,
-.mc-step-node.breusch_godfrey {
+.mc-step-node.breusch_godfrey,
+.mc-step-node.cusum {
   border-left-color: #9333ea;
 }
 

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -167,6 +167,7 @@ export type MCStepType =
   | "jarque_bera"
   | "breusch_pagan"
   | "breusch_godfrey"
+  | "cusum"
   | "regression";
 
 export type MCFieldType =

--- a/tests/diag_tests/test_cusum.py
+++ b/tests/diag_tests/test_cusum.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE._diag_tests.cusum import (
+    CONVERGED,
+    CusumDist,
+    _a_from_alpha,
+    _alpha_from_a,
+    cusum,
+    cusum_series,
+)
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.status import TestStatus
+
+
+def _reference_std_cusum(y: np.ndarray, X: np.ndarray) -> np.ndarray:
+    """Recursive (Brown-Durbin-Evans) residuals, refitting OLS from scratch at
+    every step, then standardized and cumulated as the kernel does."""
+    T, p = X.shape
+    w = np.empty(T - p, dtype=np.float64)
+    for i, t in enumerate(range(p, T)):
+        beta = np.linalg.lstsq(X[:t], y[:t], rcond=None)[0]
+        xtx_inv = np.linalg.inv(X[:t].T @ X[:t])
+        xt = X[t]
+        ft = 1.0 + xt @ xtx_inv @ xt
+        w[i] = (y[t] - xt @ beta) / np.sqrt(ft)
+    bhat = np.linalg.lstsq(X, y, rcond=None)[0]
+    sigma = np.sqrt(np.sum((y - X @ bhat) ** 2) / (T - p))
+    return np.cumsum(w) / sigma
+
+
+def _reference_statistic(series: np.ndarray, T: int, p: int) -> float:
+    sqrt_tp = np.sqrt(T - p)
+    denom = sqrt_tp + 2.0 * np.arange(T - p) / sqrt_tp
+    return float(np.max(np.abs(series) / denom))
+
+
+def test_cusum_matches_recursive_residual_definition() -> None:
+    rng = np.random.default_rng(11)
+    T, p = 80, 3
+    X = np.column_stack([np.ones(T), rng.normal(size=(T, p - 1))])
+    y = X @ np.array([1.0, 0.5, -0.25]) + rng.normal(size=T)
+
+    status, series = cusum_series(y, X)
+    expected_series = _reference_std_cusum(y, X)
+
+    assert status == int(TestStatus.OK)
+    assert series.size == T - p
+    np.testing.assert_allclose(series, expected_series, rtol=1e-6, atol=1e-9)
+
+    out = cusum(y, X, alpha=0.1)
+    expected_stat = _reference_statistic(expected_series, T, p)
+
+    assert out.test_name == "cusum"
+    assert out.status is TestStatus.OK
+    assert out.dist is ReferenceDistribution.CUSUM
+    assert out.pval_method is PvalMethod.SF
+    assert np.isnan(out.df)
+    assert out.alpha == np.float64(0.1)
+    assert out.statistic == pytest.approx(expected_stat, rel=1e-6)
+    assert out.pval == pytest.approx(min(1.0, _alpha_from_a(np.float64(out.statistic))))
+    assert 0.0 <= out.pval <= 1.0
+
+
+def test_cusum_distribution_is_clamped_survival_function() -> None:
+    dist = CusumDist()
+
+    # sf == clamped Durbin series; cdf is its complement.
+    for a in (0.3, 0.8, 1.5):
+        assert dist.sf(a) == pytest.approx(min(1.0, _alpha_from_a(np.float64(a))))
+        assert dist.cdf(a) == pytest.approx(1.0 - dist.sf(a))
+
+    # Small statistics push the raw series above 1; the survival function must
+    # still report a valid probability.
+    assert _alpha_from_a(np.float64(0.3)) > 1.0
+    assert dist.sf(0.3) == 1.0
+    assert dist.cdf(0.3) == 0.0
+
+    # Vectorized evaluation matches the scalar path.
+    xs = np.array([0.3, 0.8, 1.5])
+    np.testing.assert_allclose(dist.sf(xs), [dist.sf(float(v)) for v in xs])
+
+    # isf is the Newton inverse and round-trips with sf for proper alphas.
+    for alpha in (0.01, 0.05, 0.2):
+        crit = dist.isf(alpha)
+        assert dist.sf(crit) == pytest.approx(alpha, abs=1e-8)
+    assert dist.ppf(0.95) == pytest.approx(dist.isf(0.05))
+
+
+def test_cusum_freeze_is_parameter_free() -> None:
+    # The NaN df forwarded by the TestResult constructor is ignored.
+    frozen = ReferenceDistribution.CUSUM.freeze(np.float64(np.nan))
+    assert frozen.sf(0.7) == pytest.approx(min(1.0, _alpha_from_a(np.float64(0.7))))
+
+
+@pytest.mark.parametrize("alpha", [0.001, 0.01, 0.05, 0.1, 0.2, 0.5, 0.9])
+def test_cusum_inverse_converges_for_common_alphas(alpha: float) -> None:
+    status, a = _a_from_alpha(np.float64(alpha))
+    assert status == CONVERGED
+    assert _alpha_from_a(a) == pytest.approx(alpha, abs=1e-10)
+
+
+def test_cusum_detects_structural_break() -> None:
+    rng = np.random.default_rng(0)
+    T, p = 200, 2
+    X = np.column_stack([np.ones(T), rng.normal(size=T)])
+    y = X @ np.array([1.0, 0.5]) + rng.normal(size=T)
+
+    stable = cusum(y, X, alpha=0.05)
+
+    broken_y = y.copy()
+    broken_y[T // 2 :] += 5.0
+    broken = cusum(broken_y, X, alpha=0.05)
+
+    assert stable.status is TestStatus.OK
+    assert broken.status is TestStatus.OK
+    assert not stable.is_significant()
+    assert broken.statistic > stable.statistic
+    assert broken.pval < stable.pval
+    assert broken.is_significant()
+    assert broken.pval < 0.01
+
+
+def test_cusum_reports_computation_statuses() -> None:
+    insufficient = cusum(
+        np.zeros(2, dtype=np.float64), np.zeros((2, 3), dtype=np.float64)
+    )
+    bad_shape = cusum(np.zeros(5, dtype=np.float64), np.zeros((6, 2), dtype=np.float64))
+
+    assert insufficient.status is TestStatus.INSUFFICIENT_SAMPLES
+    assert bad_shape.status is TestStatus.BAD_SHAPE
+    assert np.isnan(insufficient.statistic)
+    assert np.isnan(bad_shape.statistic)

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -11,6 +11,7 @@ from SymbolicDSGE._diag_tests.breusch_pagan import (
     breusch_pagan,
     robust_breusch_pagan,
 )
+from SymbolicDSGE._diag_tests.cusum import cusum
 from SymbolicDSGE._diag_tests.jarque_bera import jarque_bera
 from SymbolicDSGE._diag_tests.ljung_box import ljung_box
 from SymbolicDSGE._diag_tests.status import TestStatus
@@ -26,6 +27,7 @@ from SymbolicDSGE.monte_carlo import (
     OpType,
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    cusum_test_step,
     jarque_bera_test_step,
     ljung_box_test_step,
     raw_data_step,
@@ -650,6 +652,37 @@ def test_breusch_godfrey_pipeline_handles_burn_in_that_removes_all_samples() -> 
     assert out.test_status_traces["bg"] == (TestStatus.INSUFFICIENT_SAMPLES,) * 2
     assert np.isnan(out.statistic_traces["bg"]).all()
     assert np.isnan(out.pval_traces["bg"]).all()
+
+
+def test_cusum_pipeline_aggregates_results_with_nan_df() -> None:
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(2, 60, 2))
+    X[:, :, 0] = 1.0  # constant column for a well-posed recursion
+    y = X @ np.array([0.5, -0.3]) + rng.normal(size=(2, 60))
+    observables = np.concatenate((y[:, :, None], X), axis=2)
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            cusum_test_step(
+                "cs",
+                y_source="observables",
+                x_source="observables",
+                y_column=0,
+                X_columns=[1, 2],
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    expected = np.asarray(
+        [cusum(y[i], X[i]).statistic for i in range(2)], dtype=np.float64
+    )
+    np.testing.assert_allclose(out.statistic_traces["cs"], expected)
+    assert out.test_status_traces["cs"] == (TestStatus.OK, TestStatus.OK)
+    # CUSUM is parameter-free: the NaN df placeholder must survive aggregation
+    # across replications (the metadata-equality check is NaN-aware).
+    assert np.isnan(out.test_summaries["cs"].df)
 
 
 def test_raw_data_pipeline_rejects_empty_raw_data() -> None:

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -365,6 +365,7 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
         "jarque_bera",
         "breusch_pagan",
         "breusch_godfrey",
+        "cusum",
         "regression",
     }
 
@@ -652,6 +653,63 @@ def test_ui_backend_runs_breusch_godfrey_monte_carlo_step() -> None:
     assert summary["test_name"] == "serial_correlation"
     assert summary["distribution"] == "chi2"
     assert summary["df"] == 2
+    assert summary["n"] == 2
+
+
+def test_ui_backend_runs_cusum_monte_carlo_step() -> None:
+    client = TestClient(create_app())
+    for role in ("reference", "dgp"):
+        loaded = client.post(
+            "/api/model/load-yaml",
+            json={"role": role, "path": "MODELS/test.yaml"},
+        )
+        assert loaded.status_code == 200
+        solved = client.post(
+            "/api/model/solve",
+            json={"role": role, "compile_kwargs": {"n_state": 3, "n_exog": 2}},
+        )
+        assert solved.status_code == 200
+
+    pipeline = {
+        "nodes": [
+            {
+                "id": "sim",
+                "step_type": "simulation",
+                "name": "datagen",
+                "params": {"T": 30},
+            },
+            {
+                "id": "cs",
+                "step_type": "cusum",
+                "name": "stability",
+                "params": {
+                    "y_source": "states",
+                    "x_source": "states",
+                    "y_column": [0],
+                    "X_columns": [1],
+                    "burn_in": 1,
+                    "alpha": 0.1,
+                },
+            },
+        ],
+        "edges": [{"source": "sim", "target": "cs"}],
+    }
+
+    validated = client.post("/api/mc/validate", json=pipeline)
+    assert validated.status_code == 200
+    assert validated.json()["order"] == ["sim", "cs"]
+
+    run = client.post(
+        "/api/run/mc",
+        json={"pipeline": pipeline, "n_rep": 2, "fail_fast": True},
+    )
+    assert run.status_code == 200
+    body = run.json()
+    assert body["succeeded"] is True
+    assert set(body["test_summaries"]) == {"stability"}
+    summary = body["test_summaries"]["stability"]
+    assert summary["test_name"] == "stability"
+    assert summary["distribution"] == "cusum"
     assert summary["n"] == 2
 
 


### PR DESCRIPTION
Introduce a Durbin (1969) CUSUM implementation and reference distribution: add SymbolicDSGE/_diag_tests/cusum.py (Numba-jitted pdf/cdf/isf, recursive-residual series, statistic, and TestResult integration). Register ReferenceDistribution.CUSUM in distributions.freeze and add two TestStatus codes (ITERATIVE_ALG_NONCONVERGENCE, BAD_PARAMETER). Include comprehensive tests in tests/diag_tests/test_cusum.py validating series, statistic, distribution clamping/inverse, and break detection. Also add evaluation.html (project evaluation/report).

closes #130 