### PR TITLE
Add Chow structural break test and MC integration

### DIFF
--- a/SymbolicDSGE/_diag_tests/chow.py
+++ b/SymbolicDSGE/_diag_tests/chow.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy import float64
+from numpy.typing import NDArray
+from numba import njit
+
+from .status import TestStatus
+from .result import TestResult
+from .distributions import PvalMethod, ReferenceDistribution
+from ..regression.solvers import chol_solve, lstsq_solve
+
+NDF = NDArray[float64]
+
+OK = int(TestStatus.OK)
+LINALG = int(TestStatus.LINALG)
+BAD_SHAPE = int(TestStatus.BAD_SHAPE)
+INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
+BAD_PARAMETER = int(TestStatus.BAD_PARAMETER)
+
+
+@njit(cache=True)
+def _chow_stat(y: NDF, X: NDF, t_break: int) -> tuple[int, float64]:
+    if y.size != X.shape[0]:
+        return BAD_SHAPE, float64(np.nan)
+
+    T, p = X.shape
+
+    if T <= 2 * p:
+        return INSUFFICIENT_SAMPLES, float64(np.nan)
+
+    if t_break <= 0 or t_break >= T:
+        return BAD_PARAMETER, float64(np.nan)
+
+    X1 = np.ascontiguousarray(X[:t_break])
+    y1 = np.ascontiguousarray(y[:t_break])
+
+    X2 = np.ascontiguousarray(X[t_break:])
+    y2 = np.ascontiguousarray(y[t_break:])
+
+    statuses = np.empty(3, dtype=np.int32)
+    tss = np.empty(3, dtype=float64)
+
+    for i, (Xi, yi) in enumerate([(X, y), (X1, y1), (X2, y2)]):
+        try:
+            beta, _, status = chol_solve(Xi, yi)
+        except Exception:
+            beta, _, status = lstsq_solve(Xi, yi)
+
+        statuses[i] = status
+        tss_i = 0.0
+        for j in range(Xi.shape[0]):
+            resid = yi[j] - np.dot(Xi[j], beta)
+            tss_i += resid * resid
+        tss[i] = tss_i
+
+    tss_c, tss_1, tss_2 = tss
+
+    num = (tss_c - (tss_1 + tss_2)) / p
+    denom = (tss_1 + tss_2) / (T - 2 * p)
+    stat = num / denom
+
+    if np.any(statuses != OK):
+        return LINALG, stat
+    return OK, stat
+
+
+def chow(
+    y: NDF, X: NDF, t_break: int, alpha: float = 0.05, _auto_pval: bool = True
+) -> TestResult:
+    T, p = X.shape
+    df1 = p
+    df2 = T - 2 * p
+
+    status, stat = _chow_stat(y, X, t_break)
+    return TestResult(
+        test_name="chow",
+        statistic=stat,
+        df=(df1, df2),
+        status=TestStatus(status),
+        alpha=float64(alpha),
+        dist=ReferenceDistribution.F,
+        pval_method=PvalMethod.SF,
+        _auto_pval=_auto_pval,
+    )

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -1,6 +1,7 @@
 from .config import (
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    chow_test_step,
     cusum_test_step,
     cusumsq_test_step,
     jarque_bera_test_step,
@@ -31,6 +32,7 @@ from .mc_constructs import (
 )
 from .operations import (
     raw_data_datagen,
+    run_chow_test,
     run_cusum_test,
     run_cusumsq_test,
     run_breusch_godfrey_test,
@@ -61,6 +63,7 @@ __all__ = [
     "TestOp",
     "breusch_godfrey_test_step",
     "breusch_pagan_test_step",
+    "chow_test_step",
     "cusum_test_step",
     "cusumsq_test_step",
     "jarque_bera_test_step",
@@ -73,6 +76,7 @@ __all__ = [
     "regression_step",
     "run_breusch_godfrey_test",
     "run_breusch_pagan_test",
+    "run_chow_test",
     "run_cusum_test",
     "run_cusumsq_test",
     "run_reference_filter",

--- a/SymbolicDSGE/monte_carlo/config.py
+++ b/SymbolicDSGE/monte_carlo/config.py
@@ -14,6 +14,7 @@ from .operations import (
     run_breusch_godfrey_test as _run_breusch_godfrey_test,
     run_cusum_test as _run_cusum_test,
     run_cusumsq_test as _run_cusumsq_test,
+    run_chow_test as _run_chow_test,
     simulate_dgp as _simulate_dgp,
 )
 
@@ -84,6 +85,10 @@ def cusum_test_step(name: str, **kwargs: Any) -> MCStep:
 
 def cusumsq_test_step(name: str, **kwargs: Any) -> MCStep:
     return MCStep(name=name, op_type=OpType.TEST, func=_run_cusumsq_test, kwargs=kwargs)
+
+
+def chow_test_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(name=name, op_type=OpType.TEST, func=_run_chow_test, kwargs=kwargs)
 
 
 def regression_step(name: str, **kwargs: Any) -> MCStep:

--- a/SymbolicDSGE/monte_carlo/operations.py
+++ b/SymbolicDSGE/monte_carlo/operations.py
@@ -17,6 +17,7 @@ from .._diag_tests.breusch_pagan import breusch_pagan, robust_breusch_pagan
 from .._diag_tests.breusch_godfrey import breusch_godfrey
 from .._diag_tests.cusum import cusum
 from .._diag_tests.cusumsq import cusumsq_test
+from .._diag_tests.chow import chow
 
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterResult
@@ -543,6 +544,60 @@ def run_cusumsq_test(
             f"number of rows. Got y={y.shape[0]} and X={X.shape[0]}."
         )
     return cusumsq_test(y[:, 0], X, alpha=alpha, _auto_pval=False)
+
+
+def run_chow_test(
+    *,
+    context: MCContext,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    rep_idx: int,
+    x_source: InpSources,
+    y_source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    y_column: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    t_break: int = 10,
+    alpha: float = 0.05,
+) -> TestResult:
+    del reference, dgp, rep_idx
+    y_col_idx: Sequence[int] | None
+    if isinstance(y_column, int):
+        y_col_idx = [y_column]
+    else:
+        y_col_idx = y_column
+    y = _resolve_context_array(
+        context,
+        source=y_source,
+        filter_key=filter_key,
+        payload_key=payload_key,
+        columns=y_col_idx,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    X = _resolve_context_array(
+        context,
+        source=x_source,
+        filter_key=filter_key,
+        payload_key=payload_key,
+        columns=X_columns,
+        burn_in=burn_in,
+        drop_initial=drop_initial,
+    )
+    if y.shape[1] != 1:
+        raise ValueError(
+            "Chow test requires the dependent variable to resolve to exactly "
+            f"one column. Got shape {y.shape}."
+        )
+    if y.shape[0] != X.shape[0]:
+        raise ValueError(
+            "Chow test dependent variable and regressors must have the same "
+            f"number of rows. Got y={y.shape[0]} and X={X.shape[0]}."
+        )
+    return chow(y[:, 0], X, t_break=t_break, alpha=alpha, _auto_pval=False)
 
 
 def run_regression(

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -13,6 +13,7 @@ from SymbolicDSGE.monte_carlo import (
     MCPipelineResult,
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    chow_test_step,
     cusum_test_step,
     cusumsq_test_step,
     jarque_bera_test_step,
@@ -45,6 +46,7 @@ TERMINAL_STEP_TYPES = {
     "breusch_godfrey",
     "cusum",
     "cusumsq",
+    "chow",
     "regression",
 }
 
@@ -274,6 +276,42 @@ def mc_catalog() -> dict[str, Any]:
                     ),
                     _field("y_column", "Response column", "number_list", [0]),
                     _field("X_columns", "Regressor columns", "number_list", [1]),
+                    _field("burn_in", "Burn-in", "number", 0, minimum=0),
+                    _field("drop_initial", "Drop initial", "boolean", False),
+                    _field("alpha", "Alpha", "number", 0.05),
+                ],
+            ),
+            _step_catalog(
+                "chow",
+                "Chow Test",
+                "chow",
+                "Test for a structural break in regression coefficients at a "
+                "known break point.",
+                [
+                    _field(
+                        "y_source",
+                        "Response source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field(
+                        "x_source",
+                        "Regressor source",
+                        "select",
+                        "observables",
+                        options=INPUT_SOURCES,
+                    ),
+                    _field("y_column", "Response column", "number_list", [0]),
+                    _field("X_columns", "Regressor columns", "number_list", [1]),
+                    _field(
+                        "t_break",
+                        "Break point",
+                        "number",
+                        10,
+                        required=True,
+                        minimum=1,
+                    ),
                     _field("burn_in", "Burn-in", "number", 0, minimum=0),
                     _field("drop_initial", "Drop initial", "boolean", False),
                     _field("alpha", "Alpha", "number", 0.05),
@@ -510,6 +548,8 @@ def build_pipeline(
             steps.append(cusum_test_step(node.name, **params))
         elif node.step_type == "cusumsq":
             steps.append(cusumsq_test_step(node.name, **params))
+        elif node.step_type == "chow":
+            steps.append(chow_test_step(node.name, **params))
         elif node.step_type == "regression":
             steps.append(regression_step(node.name, **_regression_params(params)))
         else:

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -14,6 +14,7 @@ MCStepKind = Literal[
     "breusch_godfrey",
     "cusum",
     "cusumsq",
+    "chow",
     "regression",
 ]
 

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -191,6 +191,7 @@ function MCPipelineBuilder({ session }: { session: SessionSummary | null }) {
           "breusch_godfrey",
           "cusum",
           "cusumsq",
+          "chow",
           "regression",
         ].includes(source.data.stepType)
       ) {

--- a/sdsge-ui/frontend/src/mc/StepNode.tsx
+++ b/sdsge-ui/frontend/src/mc/StepNode.tsx
@@ -21,6 +21,7 @@ const ICONS: Record<MCStepType, LucideIcon> = {
   breusch_godfrey: Activity,
   cusum: Activity,
   cusumsq: Activity,
+  chow: Activity,
   regression: TestTubeDiagonal,
 };
 
@@ -35,6 +36,7 @@ export function StepNode({ data, selected }: NodeProps<MCFlowNode>) {
     "breusch_godfrey",
     "cusum",
     "cusumsq",
+    "chow",
     "regression",
   ].includes(data.stepType);
   return (

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1407,7 +1407,8 @@ button.mc-palette-step:hover {
 .mc-step-node.breusch_pagan,
 .mc-step-node.breusch_godfrey,
 .mc-step-node.cusum,
-.mc-step-node.cusumsq {
+.mc-step-node.cusumsq,
+.mc-step-node.chow {
   border-left-color: #9333ea;
 }
 

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -169,6 +169,7 @@ export type MCStepType =
   | "breusch_godfrey"
   | "cusum"
   | "cusumsq"
+  | "chow"
   | "regression";
 
 export type MCFieldType =

--- a/tests/diag_tests/test_chow.py
+++ b/tests/diag_tests/test_chow.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import f as f_dist
+
+from SymbolicDSGE._diag_tests.chow import _chow_stat, chow
+from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
+from SymbolicDSGE._diag_tests.status import TestStatus
+
+
+def _reference_chow(y: np.ndarray, X: np.ndarray, t_break: int) -> float:
+    """Textbook Chow F: pooled vs. split residual sums of squares."""
+
+    def rss(yy: np.ndarray, XX: np.ndarray) -> float:
+        beta, *_ = np.linalg.lstsq(XX, yy, rcond=None)
+        resid = yy - XX @ beta
+        return float(resid @ resid)
+
+    T, p = X.shape
+    rss_c = rss(y, X)
+    rss_1 = rss(y[:t_break], X[:t_break])
+    rss_2 = rss(y[t_break:], X[t_break:])
+    num = (rss_c - (rss_1 + rss_2)) / p
+    denom = (rss_1 + rss_2) / (T - 2 * p)
+    return num / denom
+
+
+def test_chow_matches_ols_partition() -> None:
+    rng = np.random.default_rng(11)
+    T, p = 120, 3
+    X = np.column_stack([np.ones(T), rng.normal(size=(T, p - 1))])
+    y = X @ np.array([1.0, 0.5, -0.25]) + rng.normal(size=T)
+    t_break = 50
+
+    status, stat = _chow_stat(y, X, t_break)
+    expected = _reference_chow(y, X, t_break)
+
+    assert status == int(TestStatus.OK)
+    assert float(stat) == pytest.approx(expected, rel=1e-9)
+
+    out = chow(y, X, t_break, alpha=0.1)
+    assert out.test_name == "chow"
+    assert out.status is TestStatus.OK
+    assert out.dist is ReferenceDistribution.F
+    assert out.pval_method is PvalMethod.SF
+    assert out.df == (p, T - 2 * p)
+    assert out.alpha == np.float64(0.1)
+    assert out.statistic == pytest.approx(expected, rel=1e-9)
+    assert out.pval == pytest.approx(f_dist.sf(expected, p, T - 2 * p))
+    assert 0.0 <= out.pval <= 1.0
+
+
+def test_chow_detects_coefficient_break() -> None:
+    rng = np.random.default_rng(0)
+    T, p = 200, 2
+    X = np.column_stack([np.ones(T), rng.normal(size=T)])
+    y = X @ np.array([1.0, 0.5]) + rng.normal(size=T)
+    t_break = T // 2
+
+    stable = chow(y, X, t_break, alpha=0.05)
+
+    broken_y = y.copy()
+    broken_y[t_break:] = X[t_break:] @ np.array([1.0, 3.0]) + rng.normal(
+        size=T - t_break
+    )
+    broken = chow(broken_y, X, t_break, alpha=0.05)
+
+    assert stable.status is TestStatus.OK
+    assert broken.status is TestStatus.OK
+    assert not stable.is_significant()
+    assert broken.statistic > stable.statistic
+    assert broken.pval < stable.pval
+    assert broken.is_significant()
+
+
+def test_chow_is_correctly_sized_under_stability() -> None:
+    rng = np.random.default_rng(5)
+    T = 200
+    t_break = T // 2
+    reps = 1000
+    rejections = 0
+    for _ in range(reps):
+        X = np.column_stack([np.ones(T), rng.normal(size=T)])
+        y = X @ np.array([1.0, 0.5]) + rng.normal(size=T)
+        rejections += chow(y, X, t_break, alpha=0.05).is_significant()
+    # Exact F reference distribution: empirical size should sit near nominal.
+    assert 0.02 < rejections / reps < 0.09
+
+
+def test_chow_reports_computation_statuses() -> None:
+    rng = np.random.default_rng(1)
+    T, p = 40, 2
+    X = np.column_stack([np.ones(T), rng.normal(size=T)])
+    y = X @ np.array([1.0, 0.5]) + rng.normal(size=T)
+
+    too_low = chow(y, X, 0)
+    too_high = chow(y, X, T)
+    bad_shape = chow(
+        np.zeros(5, dtype=np.float64), np.zeros((6, 2), dtype=np.float64), 3
+    )
+
+    assert too_low.status is TestStatus.BAD_PARAMETER
+    assert too_high.status is TestStatus.BAD_PARAMETER
+    assert bad_shape.status is TestStatus.BAD_SHAPE
+    assert np.isnan(too_low.statistic)
+    assert np.isnan(too_high.statistic)
+    assert np.isnan(bad_shape.statistic)

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -11,6 +11,7 @@ from SymbolicDSGE._diag_tests.breusch_pagan import (
     breusch_pagan,
     robust_breusch_pagan,
 )
+from SymbolicDSGE._diag_tests.chow import chow
 from SymbolicDSGE._diag_tests.cusum import cusum
 from SymbolicDSGE._diag_tests.cusumsq import cusumsq_test
 from SymbolicDSGE._diag_tests.jarque_bera import jarque_bera
@@ -28,6 +29,7 @@ from SymbolicDSGE.monte_carlo import (
     OpType,
     breusch_godfrey_test_step,
     breusch_pagan_test_step,
+    chow_test_step,
     cusum_test_step,
     cusumsq_test_step,
     jarque_bera_test_step,
@@ -717,6 +719,38 @@ def test_cusumsq_pipeline_aggregates_results() -> None:
     # is identical across equal-shape replications and survives aggregation as
     # the shared df.
     assert out.test_summaries["csq"].df == 60 - 2
+
+
+def test_chow_pipeline_aggregates_results() -> None:
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(2, 60, 2))
+    X[:, :, 0] = 1.0  # constant column for a well-posed partition
+    y = X @ np.array([0.5, -0.3]) + rng.normal(size=(2, 60))
+    observables = np.concatenate((y[:, :, None], X), axis=2)
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables),
+            chow_test_step(
+                "ch",
+                y_source="observables",
+                x_source="observables",
+                y_column=0,
+                X_columns=[1, 2],
+                t_break=30,
+            ),
+        ]
+    )
+
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, verbosity=0)
+
+    expected = np.asarray(
+        [chow(y[i], X[i], t_break=30).statistic for i in range(2)], dtype=np.float64
+    )
+    np.testing.assert_allclose(out.statistic_traces["ch"], expected)
+    assert out.test_status_traces["ch"] == (TestStatus.OK, TestStatus.OK)
+    # Chow uses an F reference with df = (p, T - 2p), identical across
+    # equal-shape replications and preserved through aggregation.
+    assert out.test_summaries["ch"].df == (2, 60 - 2 * 2)
 
 
 def test_raw_data_pipeline_rejects_empty_raw_data() -> None:

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -367,6 +367,7 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
         "breusch_godfrey",
         "cusum",
         "cusumsq",
+        "chow",
         "regression",
     }
 
@@ -768,6 +769,64 @@ def test_ui_backend_runs_cusumsq_monte_carlo_step() -> None:
     summary = body["test_summaries"]["variance_stability"]
     assert summary["test_name"] == "variance_stability"
     assert summary["distribution"] == "cusumsq"
+    assert summary["n"] == 2
+
+
+def test_ui_backend_runs_chow_monte_carlo_step() -> None:
+    client = TestClient(create_app())
+    for role in ("reference", "dgp"):
+        loaded = client.post(
+            "/api/model/load-yaml",
+            json={"role": role, "path": "MODELS/test.yaml"},
+        )
+        assert loaded.status_code == 200
+        solved = client.post(
+            "/api/model/solve",
+            json={"role": role, "compile_kwargs": {"n_state": 3, "n_exog": 2}},
+        )
+        assert solved.status_code == 200
+
+    pipeline = {
+        "nodes": [
+            {
+                "id": "sim",
+                "step_type": "simulation",
+                "name": "datagen",
+                "params": {"T": 30},
+            },
+            {
+                "id": "ch",
+                "step_type": "chow",
+                "name": "structural_break",
+                "params": {
+                    "y_source": "states",
+                    "x_source": "states",
+                    "y_column": [0],
+                    "X_columns": [1],
+                    "t_break": 10,
+                    "burn_in": 1,
+                    "alpha": 0.1,
+                },
+            },
+        ],
+        "edges": [{"source": "sim", "target": "ch"}],
+    }
+
+    validated = client.post("/api/mc/validate", json=pipeline)
+    assert validated.status_code == 200
+    assert validated.json()["order"] == ["sim", "ch"]
+
+    run = client.post(
+        "/api/run/mc",
+        json={"pipeline": pipeline, "n_rep": 2, "fail_fast": True},
+    )
+    assert run.status_code == 200
+    body = run.json()
+    assert body["succeeded"] is True
+    assert set(body["test_summaries"]) == {"structural_break"}
+    summary = body["test_summaries"]["structural_break"]
+    assert summary["test_name"] == "structural_break"
+    assert summary["distribution"] == "f"
     assert summary["n"] == 2
 
 


### PR DESCRIPTION
This pull request adds support for the Chow test for structural breaks in regression coefficients throughout the SymbolicDSGE codebase, including the core diagnostic test implementation, Monte Carlo pipeline integration, UI support, and comprehensive tests. The Chow test can now be configured, executed, and visualized just like other diagnostic tests.

**Chow Test Implementation and Integration:**

* Added a new implementation of the Chow test in `SymbolicDSGE/_diag_tests/chow.py`, including a Numba-accelerated statistic, flexible error handling, and a user-facing API.
* Integrated the Chow test into the Monte Carlo pipeline:
  - Registered `chow_test_step` and `run_chow_test` in `SymbolicDSGE/monte_carlo/__init__.py` and `config.py`. [[1]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R4) [[2]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R35) [[3]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R66) [[4]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R79) [[5]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaR17) [[6]](diffhunk://#diff-87393a87a870a214a9f90910227bffa6abbdebc4c4d512139da857ec9a4412eaR90-R93)
  - Implemented `run_chow_test` in `operations.py` to resolve pipeline inputs and invoke the test. [[1]](diffhunk://#diff-54f10bb36bf550c0f2cf685516b8b68f0d81f37853db3de5bad477449880ab37R20) [[2]](diffhunk://#diff-54f10bb36bf550c0f2cf685516b8b68f0d81f37853db3de5bad477449880ab37R549-R602)

**UI and Schema Updates:**

* Added Chow test configuration and display to the UI:
  - Registered the Chow test in the UI backend (`mc.py`) and schema (`mc_schemas.py`). [[1]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R16) [[2]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R49) [[3]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R284-R319) [[4]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R551-R552) [[5]](diffhunk://#diff-a0029617192ca36e8deb11bd497ed27865ff30d12894607e81db996c16022d2eR17)
  - Updated the frontend to recognize, display, and style Chow test steps (`MCPipelineView.tsx`, `StepNode.tsx`, `styles.css`, `types.ts`). [[1]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R194) [[2]](diffhunk://#diff-644536dc898c87b7a3bdbb777f6d40c077d4d7cde5f08876ad32576bc133abe2R24) [[3]](diffhunk://#diff-644536dc898c87b7a3bdbb777f6d40c077d4d7cde5f08876ad32576bc133abe2R39) [[4]](diffhunk://#diff-5c94fd357386aae761fb7bb77556efc19c869c2b4b74b285680a2fd85af64c1fL1410-R1411) [[5]](diffhunk://#diff-49a86825a2e5ce272e1f42186def5ef009ca6b11f92950714d8fbfcbe738c880R172)

**Testing:**

* Added a new test suite for the Chow test (`tests/diag_tests/test_chow.py`), covering correctness, statistical properties, and error handling.
* Added pipeline-level and UI/backend integration tests for the Chow test. [[1]](diffhunk://#diff-e20b5d7e65a9cdf9176b4b1187e48ec92693786daccf70617c36f981ba454838R14) [[2]](diffhunk://#diff-e20b5d7e65a9cdf9176b4b1187e48ec92693786daccf70617c36f981ba454838R32) [[3]](diffhunk://#diff-e20b5d7e65a9cdf9176b4b1187e48ec92693786daccf70617c36f981ba454838R724-R755) [[4]](diffhunk://#diff-beafed38f187bbe26161dbaab7acab3f78163c112dfcd53d6127a28e04a71689R370)

closes #124 