### PR TITLE
Add docs for Estimation and MC test steps

### DIFF
--- a/docs/documentation/monte_carlo/builtin/breusch_godfrey.md
+++ b/docs/documentation/monte_carlo/builtin/breusch_godfrey.md
@@ -1,0 +1,41 @@
+---
+tags:
+    - doc
+---
+
+# Breusch-Godfrey Tests
+
+```python
+breusch_godfrey_test_step(
+    name: str,
+    *,
+    residual_source: InpSources,
+    X_source: InpSources,
+    filter_key: str = "filter",
+    residual_payload_key: str | None = None,
+    x_payload_key: str | None = None,
+    residual_col: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    lags: int = 1,
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`breusch_godfrey_test_step` wraps `run_breusch_godfrey_test(...)`. It resolves a single residual column from `residual_source` and the original regressor matrix from `X_source`, then tests the residuals for serial correlation up to order `lags` via the auxiliary regression of the residuals on the regressors and their own lags.
+
+???+ info "Reference Distribution"
+    The Lagrange-multiplier statistic is compared against a $\chi^2(\text{lags})$ distribution.
+
+???+ warning "Residuals must be 1D"
+    `residual_source` must resolve to exactly one column, and the residual and regressor arrays must share the same number of rows.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/documentation/monte_carlo/builtin/breusch_pagan.md
+++ b/docs/documentation/monte_carlo/builtin/breusch_pagan.md
@@ -1,0 +1,41 @@
+---
+tags:
+    - doc
+---
+
+# Breusch-Pagan Tests
+
+```python
+breusch_pagan_test_step(
+    name: str,
+    *,
+    residual_source: InpSources,
+    X_source: InpSources,
+    filter_key: str = "filter",
+    residual_payload_key: str | None = None,
+    x_payload_key: str | None = None,
+    residual_col: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+    robust: bool = False,
+) -> MCStep
+```
+
+`breusch_pagan_test_step` wraps `run_breusch_pagan_test(...)`. It resolves a single residual column from `residual_source` and a regressor matrix from `X_source`, then tests the residuals for heteroskedasticity by regressing their squares on the regressors.
+
+???+ info "Reference Distribution"
+    The Lagrange-multiplier statistic is compared against a $\chi^2(p)$ distribution, where $p$ is the number of regressor columns. Set `robust=True` for Koenker's studentized variant, which is robust to non-normal residuals.
+
+???+ warning "Residuals must be 1D"
+    `residual_source` must resolve to exactly one column, and the residual and regressor arrays must share the same number of rows.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/documentation/monte_carlo/builtin/chow.md
+++ b/docs/documentation/monte_carlo/builtin/chow.md
@@ -1,0 +1,40 @@
+---
+tags:
+    - doc
+---
+
+# Chow Tests
+
+```python
+chow_test_step(
+    name: str,
+    *,
+    y_source: InpSources,
+    x_source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    y_column: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    t_break: int = 10,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`chow_test_step` wraps `run_chow_test(...)`. It resolves a single response column from `y_source` and a regressor matrix from `x_source`, then tests for a structural break in the regression coefficients at the known break point `t_break` by comparing the pooled residual sum of squares against the two sub-sample fits.
+
+???+ info "Reference Distribution"
+    The statistic is compared against an $F(p,\ T - 2p)$ distribution, where $p$ is the number of regressor columns and $T$ is the number of observations.
+
+???+ warning "Break point and sample size"
+    `t_break` must satisfy `0 < t_break < T`, and the sample must provide enough observations for two separate fits (`T > 2p`); otherwise the step reports a non-`OK` status. `y_source` must resolve to exactly one column, and the response and regressor arrays must share the same number of rows.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/documentation/monte_carlo/builtin/cusum.md
+++ b/docs/documentation/monte_carlo/builtin/cusum.md
@@ -1,0 +1,39 @@
+---
+tags:
+    - doc
+---
+
+# CUSUM Tests
+
+```python
+cusum_test_step(
+    name: str,
+    *,
+    y_source: InpSources,
+    x_source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    y_column: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`cusum_test_step` wraps `run_cusum_test(...)`. It resolves a single response column from `y_source` and a regressor matrix from `x_source`, then tests the regression coefficients for stability using the cumulative sum of standardized recursive (Brown-Durbin-Evans) residuals.
+
+???+ info "Reference Distribution"
+    The test is parameter-free: the boundary-crossing probability is Durbin's closed-form approximation evaluated directly on the statistic, so the reported degrees of freedom are not applicable (rendered as `N/A`).
+
+???+ warning "Response must be 1D"
+    `y_source` must resolve to exactly one column, and the response and regressor arrays must share the same number of rows.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/documentation/monte_carlo/builtin/cusumsq.md
+++ b/docs/documentation/monte_carlo/builtin/cusumsq.md
@@ -1,0 +1,39 @@
+---
+tags:
+    - doc
+---
+
+# CUSUM of Squares Tests
+
+```python
+cusumsq_test_step(
+    name: str,
+    *,
+    y_source: InpSources,
+    x_source: InpSources,
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    y_column: Sequence[int] | int | None = None,
+    X_columns: Sequence[int] | slice | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`cusumsq_test_step` wraps `run_cusumsq_test(...)`. It resolves a single response column from `y_source` and a regressor matrix from `x_source`, then tests the regression variance for stability using the cumulative sum of *squared* recursive (Brown-Durbin-Evans) residuals. Where the [CUSUM test](cusum.md) targets shifts in the coefficients, the CUSUM of squares targets shifts in the residual variance.
+
+???+ info "Reference Distribution"
+    The statistic is the maximum departure of the normalized squared-residual partial sums from their expected line, compared against a Kolmogorov-type survival function parameterized by the recursive-residual count $n = T - p$ (reported as the degrees of freedom).
+
+???+ warning "Response must be 1D"
+    `y_source` must resolve to exactly one column, and the response and regressor arrays must share the same number of rows.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/documentation/monte_carlo/builtin/jarque_bera.md
+++ b/docs/documentation/monte_carlo/builtin/jarque_bera.md
@@ -1,0 +1,44 @@
+---
+tags:
+    - doc
+---
+
+# Jarque-Bera Tests
+
+```python
+jarque_bera_test_step(
+    name: str,
+    *,
+    source: Literal[
+        "states",
+        "observables",
+        "x_pred",
+        "x_filt",
+        "y_pred",
+        "y_filt",
+        "innov",
+        "std_innov",
+        "payload",
+    ],
+    filter_key: str = "filter",
+    payload_key: str | None = None,
+    column: Sequence[int] | int | None = None,
+    burn_in: int = 0,
+    drop_initial: bool = False,
+    alpha: float = 0.05,
+) -> MCStep
+```
+
+`jarque_bera_test_step` wraps `run_jarque_bera_test(...)`. It selects a 1D array from generated data, a `FilterResult`, or a named payload, then runs the Jarque-Bera test for normality from the sample skewness and excess kurtosis.
+
+???+ info "Reference Distribution"
+    The statistic is compared against a $\chi^2(2)$ distribution asymptotically. For small samples the test uses a finite-sample critical-value lookup keyed on the sample size, so the reported degrees of freedom carry the sample size rather than a fixed value.
+
+__Sources:__
+
+| __Source__ | __Description__ |
+|:-----------|----------------:|
+| `states` | Use `context.data.states`. Set `drop_initial=True` to remove the initial state row. |
+| `observables` | Use `context.data.observables`. |
+| `x_pred`, `x_filt`, `y_pred`, `y_filt`, `innov`, `std_innov` | Read arrays from the `FilterResult` stored under `filter_key`. |
+| `payload` | Read an array-like object from `context.payloads[payload_key]`. |

--- a/docs/gui_usage/estimation.md
+++ b/docs/gui_usage/estimation.md
@@ -1,0 +1,47 @@
+---
+tags:
+    - guide
+---
+
+# Estimation Tab
+
+The Estimation tab fits the active model's parameters to observed data using maximum likelihood, maximum a posteriori, or Markov chain Monte Carlo.
+
+## Estimation Modes
+
+Select one of three methods:
+
+| Method | Description |
+| --- | --- |
+| MLE | Maximize the Kalman-filter log-likelihood. Priors are not required. |
+| MAP | Maximize the log-posterior. Each estimated parameter requires a prior. |
+| MCMC | Sample the posterior with a random-walk Metropolis sampler. Each estimated parameter requires a prior. |
+
+MLE and MAP expose a maximum-iteration control for the optimizer. MCMC exposes the draw count, burn-in, thinning, seed, proposal scale, proposal adaptation, and the posterior point summary (mean, MAP, or last draw).
+
+## Providing Data
+
+Enter the observable column names, then supply one column of observations per name. Values accept newline-, comma-, space-, or semicolon-separated entries. **Import CSV** fills the columns from a CSV whose headers match the observable names.
+
+## Configuring Parameters
+
+The Parameters panel lists every model parameter. Select a parameter to edit it in the Estimation Details panel:
+
+- **Estimate** toggles whether the parameter is included in the fit.
+- **Initial** sets the starting value; **Lower** and **Upper** set optional bounds.
+- **Prior** (MAP and MCMC only) selects a distribution, its parameters, and an optional transform.
+
+At least one parameter must be selected, and the estimated parameter names must be unique.
+
+## Running and Inspecting Results
+
+Select **Run Estimation** to fit the model, or **Estimate & Solve** to also write the fitted values back to the active model and solve it.
+
+The Latest Result section reports the method, success flag, and fitted values together with the log-likelihood, log-prior, and log-posterior. MCMC runs additionally display the acceptance rate, posterior summaries, the log-posterior trace, and per-parameter posterior distributions.
+
+## Persistence and Clearing
+
+The selected method, run settings, data columns, and parameter configuration persist across browser refreshes. **Clear** resets the workspace to its initial state.
+
+???+ note "Local Persistence"
+    Estimation workspace state is stored in the browser used to access the localhost GUI. It is not written into the model configuration.

--- a/docs/gui_usage/index.md
+++ b/docs/gui_usage/index.md
@@ -41,6 +41,7 @@ The sidebar controls the active model role and is available from every tab.
 - [Builder](builder.md): edit and load YAML model configurations.
 - [Spec](spec.md): inspect the model, configure shocks, and submit transforms or plots.
 - [Outputs](outputs.md): simulate the active model and inspect its generated series.
+- [Estimation](estimation.md): fit the active model's parameters to data with MLE, MAP, or MCMC.
 - [MC Pipeline](monte_carlo.md): visually construct and run repeated simulation experiments.
 
 Panels throughout the GUI can be resized, folded, and rearranged where drag controls are available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
       - Builder: gui_usage/builder.md
       - Spec: gui_usage/spec.md
       - Outputs: gui_usage/outputs.md
+      - Estimation: gui_usage/estimation.md
       - MC Pipeline: gui_usage/monte_carlo.md
   - Guides:
       - Model Configuration Guide: guides/model_config_guide.md
@@ -189,6 +190,12 @@ nav:
               - Reference Filtering: documentation/monte_carlo/builtin/filter.md
               - Wald Tests: documentation/monte_carlo/builtin/wald.md
               - Ljung-Box Tests: documentation/monte_carlo/builtin/ljung_box.md
+              - Jarque-Bera Tests: documentation/monte_carlo/builtin/jarque_bera.md
+              - Breusch-Pagan Tests: documentation/monte_carlo/builtin/breusch_pagan.md
+              - Breusch-Godfrey Tests: documentation/monte_carlo/builtin/breusch_godfrey.md
+              - CUSUM Tests: documentation/monte_carlo/builtin/cusum.md
+              - CUSUM of Squares Tests: documentation/monte_carlo/builtin/cusumsq.md
+              - Chow Tests: documentation/monte_carlo/builtin/chow.md
               - Regression Steps: documentation/monte_carlo/builtin/regression.md
               - Transform Steps: documentation/monte_carlo/builtin/transform.md
           - Result Access: documentation/monte_carlo/result_access.md


### PR DESCRIPTION
Add new documentation pages for the GUI Estimation tab and multiple Monte Carlo built-in statistical tests (Jarque-Bera, Breusch-Pagan, Breusch-Godfrey, CUSUM, CUSUM of Squares, Chow). Update gui_usage index to include the Estimation link and register the new test docs in mkdocs.yml navigation. Each new doc describes the step API, input sources, reference distributions, and usage/warning notes.

closes #135 