### PR TITLE
Add Monte Carlo serialization and PipelineSpec

### DIFF
--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -45,11 +45,19 @@ from .operations import (
     simulate_dgp,
 )
 from .reference_constructs import MCReferenceConstruct
+from .serialize import (
+    pipeline_result_wire,
+    result_document,
+    result_traces,
+    serialize_pipeline_result,
+)
+from .spec import EdgeSpec, MCStepKind, NodeSpec, PipelineSpec
 
 __all__ = [
     "ContextOp",
     "DataGenOp",
     "DataGenReturn",
+    "EdgeSpec",
     "FilterOp",
     "MCContext",
     "MCData",
@@ -58,7 +66,10 @@ __all__ = [
     "MCPipelineResult",
     "MCReferenceConstruct",
     "MCStep",
+    "MCStepKind",
+    "NodeSpec",
     "OpType",
+    "PipelineSpec",
     "RegressionOp",
     "TestOp",
     "breusch_godfrey_test_step",
@@ -88,4 +99,8 @@ __all__ = [
     "simulation_step",
     "transform_step",
     "wald_test_step",
+    "pipeline_result_wire",
+    "result_document",
+    "result_traces",
+    "serialize_pipeline_result",
 ]

--- a/SymbolicDSGE/monte_carlo/serialize.py
+++ b/SymbolicDSGE/monte_carlo/serialize.py
@@ -1,0 +1,293 @@
+"""Serialization for Monte Carlo pipeline results.
+
+Lifted out of ``SymbolicDSGE.ui.mc`` so the result wire format is reusable by the
+``.sdsge`` bundle without depending on the HTTP layer. ``serialize_pipeline_result``
+remains the canonical (unchanged) wire shape consumed by the UI; the bundle path uses
+the parquet-friendly split below:
+
+- ``result_document`` -> JSON-safe metadata + summaries (no bulk trace arrays),
+- ``result_traces`` -> the bulk numeric trace columns as ndarrays (no I/O here),
+- ``pipeline_result_wire`` -> re-merges the two back into the UI wire shape (hydration).
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..regression.ols import OLSResult
+from .mc_constructs import MCContext, MCPipelineResult
+
+
+def serialize_pipeline_result(
+    result: MCPipelineResult, *, run_id: str
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "kind": "mc",
+        "n_rep": result.n_rep,
+        "n_successful": result.n_successful,
+        "succeeded": result.succeeded,
+        "elapsed_s": result.elapsed_s,
+        "it_s": result.it_s,
+        "step_elapsed_s": dict(result.step_elapsed_s),
+        "step_it_s": dict(result.step_it_s),
+        "step_counts": dict(result.step_counts),
+        "step_failures": dict(result.step_failures),
+        "failures": [
+            {
+                "rep_idx": failure.rep_idx,
+                "step_name": failure.step_name,
+                "error_type": failure.error_type,
+                "message": failure.message,
+            }
+            for failure in result.failures
+        ],
+        "test_summaries": {
+            name: {
+                "test_name": summary.test_name,
+                "n": summary.n,
+                "alpha": float(summary.alpha),
+                "distribution": summary.dist.value,
+                "df": _json_value(summary.df),
+                "pval_method": summary.pval_method.value,
+                "mean_statistic": float(summary.mean_statistic),
+                "mean_pval": float(summary.mean_pval),
+                "rejection_rate": float(summary.rejection_rate),
+                "statistic_se": _json_float(summary.statistic_se),
+                "pval_se": _json_float(summary.pval_se),
+                "statistic_ci": _json_value(summary.statistic_confidence_interval()),
+                "rejection_ci": _json_value(summary.pval_confidence_interval()),
+                "statistic_trace": _json_value(summary.statistic_trace),
+                "pval_trace": _json_value(summary.pval_trace),
+                "status_trace": [int(status) for status in summary.status_trace],
+                "status_counts": _status_counts(summary.status_trace),
+                "statistic_summary": _trace_summary(summary.statistic_trace),
+                "pval_summary": _trace_summary(summary.pval_trace),
+            }
+            for name, summary in result.test_summaries.items()
+        },
+        "regression_summaries": {
+            name: _serialize_regression_summary(summary)
+            for name, summary in result.regression_summaries.items()
+        },
+        "data_summaries": _summarize_context_data(result.contexts or ()),
+    }
+
+
+# Bulk trace keys stripped from the JSON document and carried as ndarray columns.
+_TEST_TRACE_KEYS = ("statistic_trace", "pval_trace", "status_trace")
+_REGRESSION_TRACE_KEYS = ("coef_trace", "r2_trace", "status_trace")
+
+
+def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
+    """Bulk numeric trace columns, keyed for a later parquet writer (no I/O).
+
+    Keys: per test ``"test.<name>.{statistic,pval,status}"``; per regression
+    ``"regression.<name>.{coef,r2,status}"`` (``coef`` is 2D ``n_rep x k``).
+    """
+    traces: dict[str, NDArray[Any]] = {}
+    for name, test_summary in result.test_summaries.items():
+        traces[f"test.{name}.statistic"] = np.asarray(
+            test_summary.statistic_trace, dtype=np.float64
+        )
+        traces[f"test.{name}.pval"] = np.asarray(
+            test_summary.pval_trace, dtype=np.float64
+        )
+        traces[f"test.{name}.status"] = np.asarray(
+            [int(status) for status in test_summary.status_trace], dtype=np.int64
+        )
+    for name, reg_summary in result.regression_summaries.items():
+        traces[f"regression.{name}.coef"] = np.asarray(
+            reg_summary.coef_trace, dtype=np.float64
+        )
+        traces[f"regression.{name}.r2"] = np.asarray(
+            reg_summary.r2_trace, dtype=np.float64
+        )
+        traces[f"regression.{name}.status"] = np.asarray(
+            [int(status) for status in reg_summary.status_trace], dtype=np.int64
+        )
+    return traces
+
+
+def result_document(result: MCPipelineResult, *, run_id: str = "") -> dict[str, Any]:
+    """JSON-safe metadata + summaries with the bulk trace arrays removed.
+
+    Pairs with :func:`result_traces`; recombine via :func:`pipeline_result_wire`.
+    """
+    document = serialize_pipeline_result(result, run_id=run_id)
+    for entry in document["test_summaries"].values():
+        for key in _TEST_TRACE_KEYS:
+            entry.pop(key, None)
+    for entry in document["regression_summaries"].values():
+        for key in _REGRESSION_TRACE_KEYS:
+            entry.pop(key, None)
+    return document
+
+
+def pipeline_result_wire(
+    document: dict[str, Any], traces: dict[str, NDArray[Any]]
+) -> dict[str, Any]:
+    """Re-merge a trace-free :func:`result_document` with :func:`result_traces`
+    into the canonical UI wire shape (used for hydration)."""
+    wire = copy.deepcopy(document)
+    for name, entry in wire["test_summaries"].items():
+        entry["statistic_trace"] = _json_value(traces[f"test.{name}.statistic"])
+        entry["pval_trace"] = _json_value(traces[f"test.{name}.pval"])
+        entry["status_trace"] = [int(x) for x in traces[f"test.{name}.status"]]
+    for name, entry in wire["regression_summaries"].items():
+        entry["coef_trace"] = _json_value(traces[f"regression.{name}.coef"])
+        entry["r2_trace"] = _json_value(traces[f"regression.{name}.r2"])
+        entry["status_trace"] = [int(x) for x in traces[f"regression.{name}.status"]]
+    return wire
+
+
+def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
+    coefficient_summaries = [
+        {
+            "variable": variable,
+            **_trace_summary(summary.coef_trace[:, index]),
+        }
+        for index, variable in enumerate(summary.variables)
+    ]
+    metrics = {
+        "r2": _trace_summary(summary.r2_trace),
+        "adjusted_r2": _trace_summary(summary.r2_adj_trace),
+        "rmse": _trace_summary(summary.rmse_trace),
+        "mse": _trace_summary(summary.mse_trace),
+        "ssr": _trace_summary(summary.ssr_trace),
+    }
+    out = {
+        "variables": summary.variables,
+        "n_rep": summary.n_rep,
+        "n": summary.n,
+        "k": summary.k,
+        "coef_trace": _json_value(summary.coef_trace),
+        "r2_trace": _json_value(summary.r2_trace),
+        "status_trace": [int(status) for status in summary.status_trace],
+        "status_counts": _status_counts(summary.status_trace),
+        "coefficient_summaries": coefficient_summaries,
+        "metrics": metrics,
+        "ols": None,
+    }
+    if all(isinstance(item, OLSResult) for item in summary.results):
+        out["ols"] = {
+            "mean_standard_errors": _json_value(np.mean(summary.se_trace, axis=0)),
+            "mean_t_statistics": _json_value(np.mean(summary.t_stat_trace, axis=0)),
+            "mean_pvalues": _json_value(np.mean(summary.pval_trace, axis=0)),
+            "mean_partial_r2": _json_value(np.mean(summary.partial_r2_trace, axis=0)),
+            "f_statistic": _trace_summary(summary.F_stat_trace),
+            "f_pvalue": _trace_summary(summary.F_pval_trace),
+        }
+    return out
+
+
+def _status_counts(status_trace: Sequence[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for status in status_trace:
+        counts[status.name] = counts.get(status.name, 0) + 1
+    return counts
+
+
+def _summarize_context_data(contexts: Sequence[MCContext]) -> dict[str, Any]:
+    arrays: dict[str, list[np.ndarray]] = {}
+    for context in contexts:
+        if context.data is None:
+            continue
+        data = context.data
+        if data.states is not None:
+            arrays.setdefault("states", []).append(np.asarray(data.states))
+        if data.observables is not None:
+            arrays.setdefault("observables", []).append(np.asarray(data.observables))
+        for name, value in data.raw.items():
+            if name != "_X":
+                arrays.setdefault(f"raw:{name}", []).append(np.asarray(value))
+    return {name: _array_collection_summary(values) for name, values in arrays.items()}
+
+
+def _array_collection_summary(values: Sequence[np.ndarray]) -> dict[str, Any]:
+    n_total = sum(int(arr.size) for arr in values)
+    n_finite = 0
+    value_sum = 0.0
+    square_sum = 0.0
+    minimum = np.inf
+    maximum = -np.inf
+    for arr in values:
+        finite = arr[np.isfinite(arr)]
+        if finite.size == 0:
+            continue
+        n_finite += int(finite.size)
+        value_sum += float(finite.sum())
+        square_sum += float(np.square(finite).sum())
+        minimum = min(minimum, float(finite.min()))
+        maximum = max(maximum, float(finite.max()))
+    if n_finite == 0:
+        return {
+            "n_rep": len(values),
+            "shape": list(values[0].shape),
+            "n_values": n_total,
+            "n_finite": 0,
+            "mean": None,
+            "std": None,
+            "min": None,
+            "max": None,
+        }
+    mean = value_sum / n_finite
+    variance = max(0.0, square_sum / n_finite - mean**2)
+    return {
+        "n_rep": len(values),
+        "shape": list(values[0].shape),
+        "n_values": n_total,
+        "n_finite": n_finite,
+        "mean": _json_float(mean),
+        "std": _json_float(variance**0.5),
+        "min": _json_float(minimum),
+        "max": _json_float(maximum),
+    }
+
+
+def _trace_summary(values: Any) -> dict[str, Any]:
+    arr = np.asarray(values, dtype=np.float64).reshape(-1)
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        return {
+            "n": int(arr.size),
+            "n_finite": 0,
+            "mean": None,
+            "std": None,
+            "min": None,
+            "max": None,
+            "q025": None,
+            "q975": None,
+        }
+    return {
+        "n": int(arr.size),
+        "n_finite": int(finite.size),
+        "mean": _json_float(finite.mean()),
+        "std": _json_float(finite.std()),
+        "min": _json_float(finite.min()),
+        "max": _json_float(finite.max()),
+        "q025": _json_float(np.quantile(finite, 0.025)),
+        "q975": _json_float(np.quantile(finite, 0.975)),
+    }
+
+
+def _json_float(value: Any) -> float | None:
+    scalar = float(value)
+    return scalar if np.isfinite(scalar) else None
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return _json_value(value.tolist())
+    if isinstance(value, tuple | list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, float | np.floating):
+        return _json_float(value)
+    return value

--- a/SymbolicDSGE/monte_carlo/spec.py
+++ b/SymbolicDSGE/monte_carlo/spec.py
@@ -1,0 +1,97 @@
+"""Serializable Monte Carlo pipeline specification (graph form).
+
+Stdlib dataclasses — the core ``monte_carlo`` module must stay pydantic-free
+(pydantic is only present transitively under the ``[ui]`` extra). The UI keeps its
+pydantic request models and converts via :meth:`PipelineSpec.from_dict`. This is the
+text representation a ``.sdsge`` bundle stores for the MC pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, get_args
+
+MCStepKind = Literal[
+    "simulation",
+    "filter",
+    "wald",
+    "ljung_box",
+    "jarque_bera",
+    "breusch_pagan",
+    "breusch_godfrey",
+    "cusum",
+    "cusumsq",
+    "chow",
+    "regression",
+]
+
+STEP_KINDS: frozenset[str] = frozenset(get_args(MCStepKind))
+
+
+@dataclass
+class NodeSpec:
+    id: str
+    step_type: str
+    name: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "step_type": self.step_type,
+            "name": self.name,
+            "params": dict(self.params),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> NodeSpec:
+        step_type = str(data["step_type"])
+        if step_type not in STEP_KINDS:
+            raise ValueError(f"Unknown MC step type: {step_type!r}")
+        return cls(
+            id=str(data["id"]),
+            step_type=step_type,
+            name=str(data["name"]),
+            params=dict(data.get("params", {})),
+        )
+
+
+@dataclass
+class EdgeSpec:
+    source: str
+    target: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"source": self.source, "target": self.target}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> EdgeSpec:
+        return cls(source=str(data["source"]), target=str(data["target"]))
+
+
+@dataclass
+class PipelineSpec:
+    nodes: list[NodeSpec]
+    edges: list[EdgeSpec] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodes": [node.to_dict() for node in self.nodes],
+            "edges": [edge.to_dict() for edge in self.edges],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> PipelineSpec:
+        return cls(
+            nodes=[NodeSpec.from_dict(node) for node in data.get("nodes", [])],
+            edges=[EdgeSpec.from_dict(edge) for edge in data.get("edges", [])],
+        )
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, text: str) -> PipelineSpec:
+        return cls.from_dict(json.loads(text))

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -8,7 +8,6 @@ import numpy as np
 from SymbolicDSGE.core.shock_generators import Shock
 from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.monte_carlo import (
-    MCContext,
     MCPipeline,
     MCPipelineResult,
     breusch_godfrey_test_step,
@@ -23,7 +22,9 @@ from SymbolicDSGE.monte_carlo import (
     simulation_step,
     wald_test_step,
 )
-from SymbolicDSGE.regression.ols import OLSResult
+from SymbolicDSGE.monte_carlo.serialize import (
+    serialize_pipeline_result as serialize_pipeline_result,
+)
 
 from .mc_schemas import MCNodeSpec, MCPipelineSpec
 
@@ -585,62 +586,6 @@ def run_pipeline(
     )
 
 
-def serialize_pipeline_result(
-    result: MCPipelineResult, *, run_id: str
-) -> dict[str, Any]:
-    return {
-        "run_id": run_id,
-        "kind": "mc",
-        "n_rep": result.n_rep,
-        "n_successful": result.n_successful,
-        "succeeded": result.succeeded,
-        "elapsed_s": result.elapsed_s,
-        "it_s": result.it_s,
-        "step_elapsed_s": dict(result.step_elapsed_s),
-        "step_it_s": dict(result.step_it_s),
-        "step_counts": dict(result.step_counts),
-        "step_failures": dict(result.step_failures),
-        "failures": [
-            {
-                "rep_idx": failure.rep_idx,
-                "step_name": failure.step_name,
-                "error_type": failure.error_type,
-                "message": failure.message,
-            }
-            for failure in result.failures
-        ],
-        "test_summaries": {
-            name: {
-                "test_name": summary.test_name,
-                "n": summary.n,
-                "alpha": float(summary.alpha),
-                "distribution": summary.dist.value,
-                "df": _json_value(summary.df),
-                "pval_method": summary.pval_method.value,
-                "mean_statistic": float(summary.mean_statistic),
-                "mean_pval": float(summary.mean_pval),
-                "rejection_rate": float(summary.rejection_rate),
-                "statistic_se": _json_float(summary.statistic_se),
-                "pval_se": _json_float(summary.pval_se),
-                "statistic_ci": _json_value(summary.statistic_confidence_interval()),
-                "rejection_ci": _json_value(summary.pval_confidence_interval()),
-                "statistic_trace": _json_value(summary.statistic_trace),
-                "pval_trace": _json_value(summary.pval_trace),
-                "status_trace": [int(status) for status in summary.status_trace],
-                "status_counts": _status_counts(summary.status_trace),
-                "statistic_summary": _trace_summary(summary.statistic_trace),
-                "pval_summary": _trace_summary(summary.pval_trace),
-            }
-            for name, summary in result.test_summaries.items()
-        },
-        "regression_summaries": {
-            name: _serialize_regression_summary(summary)
-            for name, summary in result.regression_summaries.items()
-        },
-        "data_summaries": _summarize_context_data(result.contexts or ()),
-    }
-
-
 def _step_catalog(
     step_type: str,
     title: str,
@@ -850,150 +795,3 @@ def _regression_params(params: dict[str, Any]) -> dict[str, Any]:
         for key, value in params.items()
         if key not in conditional or key in allowed
     }
-
-
-def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
-    coefficient_summaries = [
-        {
-            "variable": variable,
-            **_trace_summary(summary.coef_trace[:, index]),
-        }
-        for index, variable in enumerate(summary.variables)
-    ]
-    metrics = {
-        "r2": _trace_summary(summary.r2_trace),
-        "adjusted_r2": _trace_summary(summary.r2_adj_trace),
-        "rmse": _trace_summary(summary.rmse_trace),
-        "mse": _trace_summary(summary.mse_trace),
-        "ssr": _trace_summary(summary.ssr_trace),
-    }
-    out = {
-        "variables": summary.variables,
-        "n_rep": summary.n_rep,
-        "n": summary.n,
-        "k": summary.k,
-        "coef_trace": _json_value(summary.coef_trace),
-        "r2_trace": _json_value(summary.r2_trace),
-        "status_trace": [int(status) for status in summary.status_trace],
-        "status_counts": _status_counts(summary.status_trace),
-        "coefficient_summaries": coefficient_summaries,
-        "metrics": metrics,
-        "ols": None,
-    }
-    if all(isinstance(item, OLSResult) for item in summary.results):
-        out["ols"] = {
-            "mean_standard_errors": _json_value(np.mean(summary.se_trace, axis=0)),
-            "mean_t_statistics": _json_value(np.mean(summary.t_stat_trace, axis=0)),
-            "mean_pvalues": _json_value(np.mean(summary.pval_trace, axis=0)),
-            "mean_partial_r2": _json_value(np.mean(summary.partial_r2_trace, axis=0)),
-            "f_statistic": _trace_summary(summary.F_stat_trace),
-            "f_pvalue": _trace_summary(summary.F_pval_trace),
-        }
-    return out
-
-
-def _status_counts(status_trace: Sequence[Any]) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for status in status_trace:
-        counts[status.name] = counts.get(status.name, 0) + 1
-    return counts
-
-
-def _summarize_context_data(contexts: Sequence[MCContext]) -> dict[str, Any]:
-    arrays: dict[str, list[np.ndarray]] = {}
-    for context in contexts:
-        if context.data is None:
-            continue
-        data = context.data
-        if data.states is not None:
-            arrays.setdefault("states", []).append(np.asarray(data.states))
-        if data.observables is not None:
-            arrays.setdefault("observables", []).append(np.asarray(data.observables))
-        for name, value in data.raw.items():
-            if name != "_X":
-                arrays.setdefault(f"raw:{name}", []).append(np.asarray(value))
-    return {name: _array_collection_summary(values) for name, values in arrays.items()}
-
-
-def _array_collection_summary(values: Sequence[np.ndarray]) -> dict[str, Any]:
-    n_total = sum(int(arr.size) for arr in values)
-    n_finite = 0
-    value_sum = 0.0
-    square_sum = 0.0
-    minimum = np.inf
-    maximum = -np.inf
-    for arr in values:
-        finite = arr[np.isfinite(arr)]
-        if finite.size == 0:
-            continue
-        n_finite += int(finite.size)
-        value_sum += float(finite.sum())
-        square_sum += float(np.square(finite).sum())
-        minimum = min(minimum, float(finite.min()))
-        maximum = max(maximum, float(finite.max()))
-    if n_finite == 0:
-        return {
-            "n_rep": len(values),
-            "shape": list(values[0].shape),
-            "n_values": n_total,
-            "n_finite": 0,
-            "mean": None,
-            "std": None,
-            "min": None,
-            "max": None,
-        }
-    mean = value_sum / n_finite
-    variance = max(0.0, square_sum / n_finite - mean**2)
-    return {
-        "n_rep": len(values),
-        "shape": list(values[0].shape),
-        "n_values": n_total,
-        "n_finite": n_finite,
-        "mean": _json_float(mean),
-        "std": _json_float(variance**0.5),
-        "min": _json_float(minimum),
-        "max": _json_float(maximum),
-    }
-
-
-def _trace_summary(values: Any) -> dict[str, Any]:
-    arr = np.asarray(values, dtype=np.float64).reshape(-1)
-    finite = arr[np.isfinite(arr)]
-    if finite.size == 0:
-        return {
-            "n": int(arr.size),
-            "n_finite": 0,
-            "mean": None,
-            "std": None,
-            "min": None,
-            "max": None,
-            "q025": None,
-            "q975": None,
-        }
-    return {
-        "n": int(arr.size),
-        "n_finite": int(finite.size),
-        "mean": _json_float(finite.mean()),
-        "std": _json_float(finite.std()),
-        "min": _json_float(finite.min()),
-        "max": _json_float(finite.max()),
-        "q025": _json_float(np.quantile(finite, 0.025)),
-        "q975": _json_float(np.quantile(finite, 0.975)),
-    }
-
-
-def _json_float(value: Any) -> float | None:
-    scalar = float(value)
-    return scalar if np.isfinite(scalar) else None
-
-
-def _json_value(value: Any) -> Any:
-    if isinstance(value, np.ndarray):
-        return _json_value(value.tolist())
-    if isinstance(value, tuple | list):
-        return [_json_value(item) for item in value]
-    if isinstance(value, np.integer):
-        return int(value)
-    if isinstance(value, float | np.floating):
-        return _json_float(value)
-    return value

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -1,22 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, Field
 
-MCStepKind = Literal[
-    "simulation",
-    "filter",
-    "wald",
-    "ljung_box",
-    "jarque_bera",
-    "breusch_pagan",
-    "breusch_godfrey",
-    "cusum",
-    "cusumsq",
-    "chow",
-    "regression",
-]
+from SymbolicDSGE.monte_carlo.spec import MCStepKind, PipelineSpec
 
 
 class MCNodeSpec(BaseModel):
@@ -34,6 +22,10 @@ class MCEdgeSpec(BaseModel):
 class MCPipelineSpec(BaseModel):
     nodes: list[MCNodeSpec] = Field(min_length=1)
     edges: list[MCEdgeSpec] = Field(default_factory=list)
+
+    def to_core(self) -> PipelineSpec:
+        """Convert to the pydantic-free core spec (bundle/text serialization)."""
+        return PipelineSpec.from_dict(self.model_dump())
 
 
 class MCRunRequest(BaseModel):

--- a/tests/monte_carlo/test_serialize.py
+++ b/tests/monte_carlo/test_serialize.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.monte_carlo import (
+    EdgeSpec,
+    MCPipeline,
+    MCPipelineResult,
+    NodeSpec,
+    PipelineSpec,
+    jarque_bera_test_step,
+    pipeline_result_wire,
+    raw_data_step,
+    regression_step,
+    result_document,
+    result_traces,
+    serialize_pipeline_result,
+)
+
+
+def _run_demo_pipeline(n_rep: int = 3) -> MCPipelineResult:
+    rng = np.random.default_rng(0)
+    T = 60
+    x = rng.normal(size=(n_rep, T))
+    y = 2.0 * x + rng.normal(size=(n_rep, T))
+    observables = np.stack([y, x], axis=-1)  # (n_rep, T, 2): col 0 = y, col 1 = x
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=observables, observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            regression_step(
+                "ols",
+                y_source="observables",
+                X_source="observables",
+                y_column=0,
+                X_columns=[1],
+                variables=["x"],
+            ),
+        ]
+    )
+    return pipeline.run(
+        reference=cast(SolvedModel, object()),
+        n_rep=n_rep,
+        retain_contexts=True,
+        verbosity=0,
+    )
+
+
+def test_result_document_drops_bulk_traces_and_is_json_safe() -> None:
+    result = _run_demo_pipeline()
+    document = result_document(result, run_id="r1")
+
+    test_entry = document["test_summaries"]["jb"]
+    for key in ("statistic_trace", "pval_trace", "status_trace"):
+        assert key not in test_entry
+    # Scalar summaries / metadata survive.
+    assert test_entry["statistic_summary"]["n"] == 3
+    assert "mean_statistic" in test_entry
+
+    reg_entry = document["regression_summaries"]["ols"]
+    for key in ("coef_trace", "r2_trace", "status_trace"):
+        assert key not in reg_entry
+
+    # No ndarrays / numpy scalars left behind.
+    json.dumps(document)
+
+
+def test_result_traces_keys_and_shapes() -> None:
+    result = _run_demo_pipeline(n_rep=3)
+    traces = result_traces(result)
+
+    assert traces["test.jb.statistic"].shape == (3,)
+    assert traces["test.jb.pval"].shape == (3,)
+    assert traces["test.jb.status"].shape == (3,)
+    assert traces["test.jb.status"].dtype == np.int64
+
+    assert traces["regression.ols.coef"].ndim == 2  # n_rep x k
+    assert traces["regression.ols.coef"].shape[0] == 3
+    assert traces["regression.ols.r2"].shape == (3,)
+    assert traces["regression.ols.status"].shape == (3,)
+
+
+def test_wire_equals_document_plus_traces() -> None:
+    result = _run_demo_pipeline()
+    wire = serialize_pipeline_result(result, run_id="r1")
+    recombined = pipeline_result_wire(
+        result_document(result, run_id="r1"), result_traces(result)
+    )
+    assert recombined == wire
+
+
+def test_pipeline_spec_round_trips() -> None:
+    spec = PipelineSpec(
+        nodes=[
+            NodeSpec(id="n0", step_type="simulation", name="datagen", params={"T": 50}),
+            NodeSpec(
+                id="n1",
+                step_type="jarque_bera",
+                name="jb",
+                params={"source": "observables"},
+            ),
+        ],
+        edges=[EdgeSpec(source="n0", target="n1")],
+    )
+    as_dict = spec.to_dict()
+    assert PipelineSpec.from_dict(as_dict).to_dict() == as_dict
+    assert PipelineSpec.from_json(spec.to_json()).to_dict() == as_dict
+
+
+def test_pipeline_spec_rejects_unknown_step() -> None:
+    with pytest.raises(ValueError):
+        PipelineSpec.from_dict(
+            {"nodes": [{"id": "n", "step_type": "bogus", "name": "n"}], "edges": []}
+        )


### PR DESCRIPTION
Extract MC pipeline serialization into monte_carlo.serialize (serialize_pipeline_result, result_document, result_traces, pipeline_result_wire) so the wire format can be reused outside the HTTP UI. Add PipelineSpec, NodeSpec and EdgeSpec dataclasses (monte_carlo.spec) as a pydantic-free, serializable representation of MC graphs and expose them from the package __init__. Update ui.mc to use the new serialize function and remove duplicated serialization code. Add mc_schemas.to_core to convert pydantic models to the core spec and include tests for serialization, traces, and spec round-tripping.

closes #140 