### PR TITLE
Add ModelParser serialization and round-trip tests

### DIFF
--- a/SymbolicDSGE/core/model_parser.py
+++ b/SymbolicDSGE/core/model_parser.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Iterator
 
 import yaml
@@ -60,6 +62,24 @@ class ModelParser:
 
     def get_all(self) -> ParsedConfig:
         return self.parsed
+
+    @classmethod
+    def from_string(cls, text: str) -> "ModelParser":
+        """Construct a parser from YAML *text* (e.g. a bundle config member).
+
+        Mirrors path-based construction by routing the text through a temporary
+        file, so the full parse pipeline (including the Kalman block) runs
+        unchanged.
+        """
+        with NamedTemporaryFile(
+            "w", suffix=".yaml", encoding="utf-8", delete=False
+        ) as handle:
+            handle.write(text)
+            tmp_path = Path(handle.name)
+        try:
+            return cls(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
     # --- existing validators unchanged ---
     @classmethod
@@ -148,45 +168,52 @@ class ModelParser:
         )
         return data, ParsedConfig(model=mdl_cfg, kalman=kalman_cfg)
 
+    def to_yaml(
+        self,
+        config: ModelConfig | None = None,
+        *,
+        digits: int = 3,
+    ) -> str:
+        """Emit the authored configuration as canonical YAML text.
+
+        Re-dumps the retained ``raw_data`` so the Kalman block and the
+        ``(t)``/``(t+1)`` equation grammar round-trip through :class:`ModelParser`
+        unchanged. When ``config`` is given, its calibration is baked in (rounded
+        to ``digits``), capturing e.g. estimated parameter values.
+        """
+        data_out = copy.deepcopy(self.raw_data)
+
+        if config is not None:
+            normalized_params = {
+                str(k): round(float(v), digits)
+                for k, v in config.calibration.parameters.items()
+            }
+            data_out["parameters"] = list(normalized_params.keys())
+            data_out.setdefault("calibration", {})["parameters"] = normalized_params
+
+        for key in ("parameters", "variables", "observables"):
+            if isinstance(data_out.get(key), list):
+                data_out[key] = InlineList(data_out[key])
+        kalman = data_out.get("kalman")
+        if isinstance(kalman, dict) and isinstance(kalman.get("y"), list):
+            kalman["y"] = InlineList(kalman["y"])
+
+        yaml.add_representer(InlineList, _list_representer)
+        buffer = StringIO()
+        yaml.dump(data_out, buffer, sort_keys=False)
+        return buffer.getvalue()
+
     def update_calibration_parameters(
         self,
         new_config: ModelConfig,
         digits: int = 3,
         output_path: str | Path | None = None,
     ) -> StringIO:
-        new_params = new_config.calibration.parameters
-        data_out = self.raw_data.copy()
-
-        normalized_params = {
-            str(k): round(float(v), digits) for k, v in new_params.items()
-        }
-        param_names = list(normalized_params.keys())
-        param_names = InlineList(param_names)
-        data_out["parameters"] = param_names
-
-        data_out.setdefault("calibration", {})["parameters"] = normalized_params
-        raw_variables = data_out.get("variables", [])
-        if isinstance(raw_variables, list):
-            data_out["variables"] = InlineList(raw_variables)
-
-        obs = data_out.get("observables", [])
-        data_out["observables"] = InlineList(obs)
-
-        kalman = data_out.get("kalman", None)
-        if kalman:
-            y = kalman.get("y", [])
-            kalman["y"] = InlineList(y)
-
-        buffer = StringIO()
-
-        yaml.add_representer(InlineList, _list_representer)
-        yaml.dump(data_out, buffer, sort_keys=False)
-        buffer.seek(0)
-
+        text = self.to_yaml(new_config, digits=digits)
         if output_path:
             with open(output_path, "w", encoding="utf-8") as f:
-                f.write(buffer.getvalue())
-        return buffer
+                f.write(text)
+        return StringIO(text)
 
     # ---------------- helpers ----------------
 

--- a/docs/Documentation/ModelParser.md
+++ b/docs/Documentation/ModelParser.md
@@ -15,6 +15,7 @@ __Parameters:__
 | __Name__ | __Type__ | __Description__ |
 |:---------|:--------:|----------------:|
 | config_path | `#!python str \| pathlib.Path` | Path to the YAML config file. |
+| raw_data | `#!python dict[str, Any]` | The authored YAML mapping, retained for canonical re-emission. |
 | parsed | `#!python ParsedConfig` | Parsed model/kalman config pair populated at initialization. |
 
 &nbsp;
@@ -23,12 +24,18 @@ __Methods:__
 
 | __Signature__ | __Return Type__ | __Description__ |
 |:--------------|:---------------:|----------------:|
-| `#!python .from_yaml()` | `#!python ParsedConfig` | Reads the file and populates `#!python ModelParser.parsed`. Runs at `#!python __init__`. |
+| `#!python ModelParser.from_string(text)` | `#!python ModelParser` | Classmethod. Builds a parser from YAML text instead of a path (routed through the same parse pipeline). |
+| `#!python .from_yaml()` | `#!python tuple[dict, ParsedConfig]` | Reads the file and populates `#!python ModelParser.raw_data` / `#!python .parsed`. Runs at `#!python __init__`. |
 | `#!python .get()` | `#!python ModelConfig` | Returns the currently parsed model config. |
 | `#!python .get_all()` | `#!python ParsedConfig` | Returns the currently parsed model/kalman config pair. |
+| `#!python .to_yaml(config=None, *, digits=3)` | `#!python str` | Emits the authored configuration as canonical YAML text. When `config` is supplied, its calibration is baked in (rounded to `digits`). |
+| `#!python .update_calibration_parameters(new_config, digits=3, output_path=None)` | `#!python io.StringIO` | Convenience wrapper over `to_yaml` that bakes `new_config`'s calibration and optionally writes the result to `output_path`. |
 
 ???+ note "ParsedConfig"
     `ParsedConfig` is an unpack-able `dataclass` holding `#!python ParsedConfig.model: ModelConfig` and `#!python ParsedConfig.kalman: KalmanConfig`
+
+???+ info "Serialization round-trip"
+    `to_yaml` re-dumps `raw_data`, so the `(t)`/`(t+1)` equation grammar and any `kalman:` block are preserved verbatim; `ModelParser.from_string(...)` re-parses that text back into an equivalent `ParsedConfig`. The Kalman configuration is not serialized as an object — it rides inside the emitted YAML, and the parser re-derives the (model-dependent) measurement-noise machinery on load. This pairing is what the `.sdsge` bundle uses to carry a model's configuration as text.
 
 ???+ warning "Calibration Completeness"
     Parsing enforces that every declared parameter has a calibration value, and every parameter referenced in shock/Kalman sections is declared and calibrated.

--- a/tests/core/test_model_serialization.py
+++ b/tests/core/test_model_serialization.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.core.model_parser import ModelParser
+
+
+def _model_signature(parser: ModelParser) -> dict[str, Any]:
+    cfg = parser.get()
+    return {
+        "name": cfg.name,
+        "parameters": sorted(s.name for s in cfg.parameters),
+        "observables": [s.name for s in cfg.observables],
+        "shock_map": {k.name: v.name for k, v in cfg.shock_map.items()},
+        "calibration": {
+            k.name: float(v) for k, v in cfg.calibration.parameters.items()
+        },
+    }
+
+
+def test_model_config_round_trips_without_kalman() -> None:
+    parser = ModelParser("MODELS/test.yaml")
+    rebuilt = ModelParser.from_string(parser.to_yaml())
+
+    assert _model_signature(rebuilt) == _model_signature(parser)
+    assert rebuilt.get_all().kalman is None
+
+
+def test_kalman_config_round_trips_via_reparse() -> None:
+    parser = ModelParser("MODELS/POST82.yaml")
+    rebuilt = ModelParser.from_string(parser.to_yaml())
+
+    k0 = parser.get_all().kalman
+    k1 = rebuilt.get_all().kalman
+    assert k0 is not None and k1 is not None
+
+    # Authored fields survive verbatim.
+    assert k1.y_names == k0.y_names
+    assert k1.jitter == k0.jitter
+    assert k1.symmetrize == k0.symmetrize
+    assert k1.P0.mode == k0.P0.mode
+    assert k1.P0.scale == k0.P0.scale
+    assert k1.P0.diag == k0.P0.diag
+
+    # Derived R machinery is rebuilt by the parser, not serialized.
+    assert k1.R_param_names == k0.R_param_names
+    assert k1.R_std_param_map == k0.R_std_param_map
+    assert k1.R_corr_param_map == k0.R_corr_param_map
+    assert (k0.R is None) == (k1.R is None)
+    if k0.R is not None:
+        np.testing.assert_allclose(np.asarray(k1.R), np.asarray(k0.R))
+
+
+def test_to_yaml_bakes_updated_calibration() -> None:
+    parser = ModelParser("MODELS/test.yaml")
+    config = parser.get()
+    target = next(iter(config.calibration.parameters))
+    config.calibration.parameters[target] = np.float64(0.123)
+
+    rebuilt = ModelParser.from_string(parser.to_yaml(config))
+    rebuilt_calib = {
+        k.name: float(v) for k, v in rebuilt.get().calibration.parameters.items()
+    }
+    assert rebuilt_calib[target.name] == pytest.approx(0.123)
+
+
+def test_to_yaml_emits_kalman_block_when_present() -> None:
+    parser = ModelParser("MODELS/POST82.yaml")
+    text = parser.to_yaml()
+    assert "kalman:" in text
+
+    text_no_kalman = ModelParser("MODELS/test.yaml").to_yaml()
+    assert "kalman:" not in text_no_kalman


### PR DESCRIPTION
Implement canonical YAML serialization and re-parsing for ModelParser. Add ModelParser.from_string(...) to build a parser from YAML text (via a temporary file) and to_yaml(...) to emit the retained raw_data as canonical YAML, optionally baking in a provided ModelConfig's calibration (rounded to a given precision). Refactor update_calibration_parameters to use to_yaml and return a StringIO, and ensure lists and the kalman.y list are serialized using InlineList. Preserve raw_data with a deepcopy to guarantee the (t)/(t+1) equation grammar and Kalman block round-trip unchanged. Update docs to document raw_data, from_string, to_yaml, and the updated updater, and add tests verifying model/kalman round-trips and calibration baking.

closes #137 
closes #138 