### PR TITLE
Add estimation spec dataclasses and UI conversion

### DIFF
--- a/SymbolicDSGE/estimation/spec.py
+++ b/SymbolicDSGE/estimation/spec.py
@@ -1,0 +1,270 @@
+"""Serializable estimation specification + result metadata (text only).
+
+Stdlib dataclasses — the core ``estimation`` module must stay pydantic-free
+(pydantic is only present transitively under the ``[ui]`` extra). The UI keeps
+its pydantic request models in :mod:`SymbolicDSGE.ui.schemas` and converts via
+:meth:`EstimationRunRequest.to_core`. This is the text representation a
+``.sdsge`` bundle stores for the estimation tab.
+
+Bulk arrays (observed data ``y``, MCMC ``samples`` and ``logpost_trace``) are
+not carried here — they ride sibling Parquet members and pair with this
+metadata at load time, mirroring the
+:mod:`SymbolicDSGE.monte_carlo.serialize` split.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, get_args
+
+EstimationMethod = Literal["mle", "map", "mcmc"]
+PosteriorPoint = Literal["mean", "map", "last"]
+
+ESTIMATION_METHODS: frozenset[str] = frozenset(get_args(EstimationMethod))
+POSTERIOR_POINTS: frozenset[str] = frozenset(get_args(PosteriorPoint))
+
+
+@dataclass
+class PriorSpec:
+    distribution: str = "normal"
+    parameters: dict[str, float] = field(default_factory=dict)
+    transform: str = "identity"
+    transform_kwargs: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "distribution": self.distribution,
+            "parameters": {str(k): float(v) for k, v in self.parameters.items()},
+            "transform": self.transform,
+            "transform_kwargs": {
+                str(k): float(v) for k, v in self.transform_kwargs.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> PriorSpec:
+        return cls(
+            distribution=str(data.get("distribution", "normal")),
+            parameters={
+                str(k): float(v) for k, v in dict(data.get("parameters", {})).items()
+            },
+            transform=str(data.get("transform", "identity")),
+            transform_kwargs={
+                str(k): float(v)
+                for k, v in dict(data.get("transform_kwargs", {})).items()
+            },
+        )
+
+
+@dataclass
+class EstimationParameterSpec:
+    name: str
+    initial: float
+    estimate: bool = False
+    lower: float | None = None
+    upper: float | None = None
+    prior: PriorSpec | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("EstimationParameterSpec.name must be non-empty.")
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "initial": float(self.initial),
+            "estimate": bool(self.estimate),
+        }
+        if self.lower is not None:
+            out["lower"] = float(self.lower)
+        if self.upper is not None:
+            out["upper"] = float(self.upper)
+        if self.prior is not None:
+            out["prior"] = self.prior.to_dict()
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> EstimationParameterSpec:
+        prior_data = data.get("prior")
+        return cls(
+            name=str(data["name"]),
+            initial=float(data["initial"]),
+            estimate=bool(data.get("estimate", False)),
+            lower=None if data.get("lower") is None else float(data["lower"]),
+            upper=None if data.get("upper") is None else float(data["upper"]),
+            prior=PriorSpec.from_dict(prior_data) if prior_data is not None else None,
+        )
+
+
+@dataclass
+class EstimationSpec:
+    """Text representation of an estimation run (no observed data)."""
+
+    method: str = "mle"
+    parameters: list[EstimationParameterSpec] = field(default_factory=list)
+    observables: list[str] | None = None
+    method_kwargs: dict[str, Any] = field(default_factory=dict)
+    compile_kwargs: dict[str, Any] = field(default_factory=dict)
+    steady_state: list[float] | None = None
+    posterior_point: str = "mean"
+
+    def __post_init__(self) -> None:
+        if self.method not in ESTIMATION_METHODS:
+            raise ValueError(
+                f"Unknown estimation method {self.method!r}; "
+                f"expected one of {sorted(ESTIMATION_METHODS)}."
+            )
+        if not self.parameters:
+            raise ValueError("EstimationSpec.parameters must be non-empty.")
+        if self.posterior_point not in POSTERIOR_POINTS:
+            raise ValueError(
+                f"Unknown posterior_point {self.posterior_point!r}; "
+                f"expected one of {sorted(POSTERIOR_POINTS)}."
+            )
+        active = [p.name for p in self.parameters if p.estimate]
+        if len(set(active)) != len(active):
+            raise ValueError("Estimated parameter names must be unique.")
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "method": self.method,
+            "parameters": [p.to_dict() for p in self.parameters],
+            "method_kwargs": dict(self.method_kwargs),
+            "compile_kwargs": dict(self.compile_kwargs),
+            "posterior_point": self.posterior_point,
+        }
+        if self.observables is not None:
+            out["observables"] = list(self.observables)
+        if self.steady_state is not None:
+            out["steady_state"] = [float(x) for x in self.steady_state]
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> EstimationSpec:
+        return cls(
+            method=str(data.get("method", "mle")),
+            parameters=[
+                EstimationParameterSpec.from_dict(p) for p in data.get("parameters", [])
+            ],
+            observables=(
+                list(data["observables"])
+                if data.get("observables") is not None
+                else None
+            ),
+            method_kwargs=dict(data.get("method_kwargs", {})),
+            compile_kwargs=dict(data.get("compile_kwargs", {})),
+            steady_state=(
+                [float(x) for x in data["steady_state"]]
+                if data.get("steady_state") is not None
+                else None
+            ),
+            posterior_point=str(data.get("posterior_point", "mean")),
+        )
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, text: str) -> EstimationSpec:
+        return cls.from_dict(json.loads(text))
+
+
+@dataclass
+class OptimizationResultMeta:
+    """Text-only metadata for an :class:`OptimizationResult`.
+
+    The raw ``scipy.optimize.OptimizeResult`` and the flat ``x`` vector aren't
+    carried — ``theta`` covers the same information by name, and ``raw`` is
+    opaque scipy state. Sufficient to repaint the MLE/MAP summary on load.
+    """
+
+    kind: str
+    theta: dict[str, float]
+    success: bool
+    message: str
+    fun: float
+    loglik: float
+    logprior: float
+    logpost: float
+    nfev: int
+    nit: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.kind:
+            raise ValueError("OptimizationResultMeta.kind must be non-empty.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "theta": {str(k): float(v) for k, v in self.theta.items()},
+            "success": bool(self.success),
+            "message": self.message,
+            "fun": float(self.fun),
+            "loglik": float(self.loglik),
+            "logprior": float(self.logprior),
+            "logpost": float(self.logpost),
+            "nfev": int(self.nfev),
+            "nit": None if self.nit is None else int(self.nit),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> OptimizationResultMeta:
+        return cls(
+            kind=str(data["kind"]),
+            theta={str(k): float(v) for k, v in dict(data["theta"]).items()},
+            success=bool(data["success"]),
+            message=str(data["message"]),
+            fun=float(data["fun"]),
+            loglik=float(data["loglik"]),
+            logprior=float(data["logprior"]),
+            logpost=float(data["logpost"]),
+            nfev=int(data["nfev"]),
+            nit=None if data.get("nit") is None else int(data["nit"]),
+        )
+
+
+@dataclass
+class MCMCResultMeta:
+    """Text-only metadata for an :class:`MCMCResult`.
+
+    Bulk ``samples`` (``n_draws × len(param_names)``) and ``logpost_trace`` ride
+    a sibling Parquet member via :func:`SymbolicDSGE.bundle.trace_to_json`;
+    pairing this metadata with that trace dict reconstructs the full result.
+    """
+
+    param_names: list[str]
+    accept_rate: float
+    n_draws: int
+    burn_in: int
+    thin: int
+
+    def __post_init__(self) -> None:
+        if not self.param_names:
+            raise ValueError("MCMCResultMeta.param_names must be non-empty.")
+        if self.n_draws <= 0:
+            raise ValueError("MCMCResultMeta.n_draws must be positive.")
+        if self.burn_in < 0:
+            raise ValueError("MCMCResultMeta.burn_in must be non-negative.")
+        if self.thin <= 0:
+            raise ValueError("MCMCResultMeta.thin must be positive.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "param_names": list(self.param_names),
+            "accept_rate": float(self.accept_rate),
+            "n_draws": int(self.n_draws),
+            "burn_in": int(self.burn_in),
+            "thin": int(self.thin),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> MCMCResultMeta:
+        return cls(
+            param_names=[str(name) for name in data["param_names"]],
+            accept_rate=float(data["accept_rate"]),
+            n_draws=int(data["n_draws"]),
+            burn_in=int(data["burn_in"]),
+            thin=int(data["thin"]),
+        )

--- a/SymbolicDSGE/ui/schemas.py
+++ b/SymbolicDSGE/ui/schemas.py
@@ -4,6 +4,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from SymbolicDSGE.estimation.spec import EstimationSpec
+
 Role = Literal["reference", "dgp"]
 ShockDistribution = Literal["norm", "t", "uni"]
 FunctionKind = Literal["array", "figure"]
@@ -84,3 +86,11 @@ class EstimationRunRequest(BaseModel):
     steady_state: list[float] | None = None
     posterior_point: str = "mean"
     estimate_and_solve: bool = False
+
+    def to_core(self) -> EstimationSpec:
+        """Convert to the pydantic-free core spec (bundle/text serialization).
+
+        Drops UI-only fields (``role``, ``y``, ``estimate_and_solve``); ``y``
+        rides a Parquet member alongside the spec in a bundle.
+        """
+        return EstimationSpec.from_dict(self.model_dump())

--- a/tests/estimation/test_spec.py
+++ b/tests/estimation/test_spec.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import pytest
+
+from SymbolicDSGE.estimation.spec import (
+    EstimationParameterSpec,
+    EstimationSpec,
+    MCMCResultMeta,
+    OptimizationResultMeta,
+    PriorSpec,
+)
+
+
+def _baseline_spec() -> EstimationSpec:
+    return EstimationSpec(
+        method="map",
+        parameters=[
+            EstimationParameterSpec(
+                name="beta",
+                initial=0.99,
+                estimate=True,
+                lower=0.0,
+                upper=1.0,
+                prior=PriorSpec(
+                    distribution="beta",
+                    parameters={"alpha": 5.0, "beta": 1.0},
+                    transform="identity",
+                ),
+            ),
+            EstimationParameterSpec(name="rho", initial=0.5, estimate=False),
+        ],
+        observables=["y", "pi"],
+        method_kwargs={"options": {"maxiter": 100}},
+        compile_kwargs={"linearize": True},
+        steady_state=[0.0, 0.0],
+        posterior_point="map",
+    )
+
+
+def test_prior_spec_round_trips() -> None:
+    prior = PriorSpec(
+        distribution="normal",
+        parameters={"mu": 0.0, "sigma": 1.0},
+        transform="logit",
+        transform_kwargs={"low": 0.0, "high": 1.0},
+    )
+    as_dict = prior.to_dict()
+    assert PriorSpec.from_dict(as_dict).to_dict() == as_dict
+
+
+def test_estimation_parameter_round_trips_with_and_without_prior() -> None:
+    with_prior = EstimationParameterSpec(
+        name="phi",
+        initial=1.5,
+        estimate=True,
+        lower=0.0,
+        prior=PriorSpec(distribution="gamma", parameters={"k": 2.0, "theta": 1.0}),
+    )
+    without_prior = EstimationParameterSpec(name="rho", initial=0.5)
+
+    for spec in (with_prior, without_prior):
+        as_dict = spec.to_dict()
+        assert EstimationParameterSpec.from_dict(as_dict).to_dict() == as_dict
+
+
+def test_estimation_parameter_rejects_empty_name() -> None:
+    with pytest.raises(ValueError):
+        EstimationParameterSpec(name="", initial=0.0)
+
+
+def test_estimation_spec_round_trips() -> None:
+    spec = _baseline_spec()
+    as_dict = spec.to_dict()
+    assert EstimationSpec.from_dict(as_dict).to_dict() == as_dict
+    assert EstimationSpec.from_json(spec.to_json()).to_dict() == as_dict
+
+
+def test_estimation_spec_omits_unset_optionals() -> None:
+    spec = EstimationSpec(
+        method="mle",
+        parameters=[EstimationParameterSpec(name="a", initial=0.0, estimate=True)],
+    )
+    as_dict = spec.to_dict()
+    assert "observables" not in as_dict
+    assert "steady_state" not in as_dict
+
+
+def test_estimation_spec_rejects_unknown_method() -> None:
+    with pytest.raises(ValueError):
+        EstimationSpec(
+            method="bogus",
+            parameters=[EstimationParameterSpec(name="a", initial=0.0)],
+        )
+
+
+def test_estimation_spec_rejects_unknown_posterior_point() -> None:
+    with pytest.raises(ValueError):
+        EstimationSpec(
+            method="mcmc",
+            parameters=[EstimationParameterSpec(name="a", initial=0.0)],
+            posterior_point="median",
+        )
+
+
+def test_estimation_spec_rejects_empty_parameters() -> None:
+    with pytest.raises(ValueError):
+        EstimationSpec(method="mle", parameters=[])
+
+
+def test_estimation_spec_rejects_duplicate_active_names() -> None:
+    with pytest.raises(ValueError):
+        EstimationSpec(
+            method="mle",
+            parameters=[
+                EstimationParameterSpec(name="a", initial=0.0, estimate=True),
+                EstimationParameterSpec(name="a", initial=1.0, estimate=True),
+            ],
+        )
+
+
+def test_estimation_spec_allows_duplicate_inactive_names() -> None:
+    # Only estimated names must be unique; inactive duplicates are permitted.
+    EstimationSpec(
+        method="mle",
+        parameters=[
+            EstimationParameterSpec(name="a", initial=0.0, estimate=True),
+            EstimationParameterSpec(name="a", initial=1.0, estimate=False),
+        ],
+    )
+
+
+def test_optimization_result_meta_round_trips() -> None:
+    meta = OptimizationResultMeta(
+        kind="mle",
+        theta={"beta": 0.99, "rho": 0.8},
+        success=True,
+        message="Optimization terminated successfully.",
+        fun=-12.3,
+        loglik=-10.0,
+        logprior=-2.3,
+        logpost=-12.3,
+        nfev=42,
+        nit=15,
+    )
+    as_dict = meta.to_dict()
+    assert OptimizationResultMeta.from_dict(as_dict).to_dict() == as_dict
+
+
+def test_optimization_result_meta_nit_optional() -> None:
+    meta = OptimizationResultMeta(
+        kind="map",
+        theta={"a": 1.0},
+        success=False,
+        message="",
+        fun=0.0,
+        loglik=0.0,
+        logprior=0.0,
+        logpost=0.0,
+        nfev=1,
+        nit=None,
+    )
+    as_dict = meta.to_dict()
+    assert as_dict["nit"] is None
+    assert OptimizationResultMeta.from_dict(as_dict).nit is None
+
+
+def test_mcmc_result_meta_round_trips() -> None:
+    meta = MCMCResultMeta(
+        param_names=["beta", "rho"],
+        accept_rate=0.34,
+        n_draws=1000,
+        burn_in=200,
+        thin=2,
+    )
+    as_dict = meta.to_dict()
+    assert MCMCResultMeta.from_dict(as_dict).to_dict() == as_dict
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"param_names": []},
+        {"n_draws": 0},
+        {"burn_in": -1},
+        {"thin": 0},
+    ],
+)
+def test_mcmc_result_meta_validates(kwargs: dict) -> None:
+    base = dict(
+        param_names=["a"],
+        accept_rate=0.3,
+        n_draws=10,
+        burn_in=0,
+        thin=1,
+    )
+    base.update(kwargs)
+    with pytest.raises(ValueError):
+        MCMCResultMeta(**base)
+
+
+def test_estimation_run_request_to_core_drops_ui_fields() -> None:
+    from SymbolicDSGE.ui.schemas import EstimationRunRequest
+
+    request = EstimationRunRequest(
+        role="reference",
+        method="map",
+        y=[[0.1, 0.2], [0.3, 0.4]],
+        observables=["y", "pi"],
+        parameters=[
+            {
+                "name": "beta",
+                "estimate": True,
+                "initial": 0.99,
+                "lower": 0.0,
+                "upper": 1.0,
+                "prior": {
+                    "distribution": "beta",
+                    "parameters": {"alpha": 5.0, "beta": 1.0},
+                },
+            },
+            {"name": "rho", "estimate": False, "initial": 0.5},
+        ],
+        method_kwargs={"options": {"maxiter": 100}},
+        compile_kwargs={"linearize": True},
+        steady_state=[0.0, 0.0],
+        posterior_point="map",
+        estimate_and_solve=True,
+    )
+
+    core = request.to_core()
+    as_dict = core.to_dict()
+
+    assert "role" not in as_dict
+    assert "y" not in as_dict
+    assert "estimate_and_solve" not in as_dict
+
+    assert as_dict["method"] == "map"
+    assert as_dict["observables"] == ["y", "pi"]
+    assert as_dict["posterior_point"] == "map"
+    assert as_dict["steady_state"] == [0.0, 0.0]
+    assert as_dict["method_kwargs"] == {"options": {"maxiter": 100}}
+    assert as_dict["compile_kwargs"] == {"linearize": True}
+    assert as_dict["parameters"][0]["name"] == "beta"
+    assert as_dict["parameters"][0]["prior"]["distribution"] == "beta"
+    assert "lower" not in as_dict["parameters"][1]  # unset optional dropped


### PR DESCRIPTION
Introduce a pydantic-free, text-serializable estimation spec module (SymbolicDSGE/estimation/spec.py) providing PriorSpec, EstimationParameterSpec, EstimationSpec, OptimizationResultMeta and MCMCResultMeta with to_dict/from_dict (and to_json/from_json) and validation logic. Document that bulk arrays (y, samples, logpost_trace) are stored separately (Parquet) and paired at load time. Update SymbolicDSGE/ui/schemas.py to import EstimationSpec and add EstimationRunRequest.to_core() to convert UI pydantic models into the core dataclasses (dropping UI-only fields). Add comprehensive tests (tests/estimation/test_spec.py) exercising round-trips, validations and the to_core conversion.

closes #139 