### PR TITLE
Add sdsge-compile/decompile CLI and tests

### DIFF
--- a/SymbolicDSGE/bundle/builder.py
+++ b/SymbolicDSGE/bundle/builder.py
@@ -213,6 +213,19 @@ class BundleBuilder:
         self._simulation = simulation
         return self
 
+    # -- low-level passthrough ------------------------------------------------
+
+    def add_member(self, member: Member, data: bytes) -> BundleBuilder:
+        """Append a pre-encoded member at its declared path.
+
+        Public seam for callers that already hold the final member bytes —
+        e.g. the ``sdsge-compile`` CLI copying a Parquet ``data/`` file through
+        verbatim, or staging a pre-split MC result + traces pair. The
+        higher-level ``add_*`` methods would otherwise re-encode.
+        """
+        self._add(member, data)
+        return self
+
     # -- emit -----------------------------------------------------------------
 
     def manifest(self) -> Manifest:

--- a/SymbolicDSGE/bundle/cli.py
+++ b/SymbolicDSGE/bundle/cli.py
@@ -1,0 +1,528 @@
+"""CLI entry points for ``sdsge-compile`` and ``sdsge-decompile``.
+
+``sdsge-compile <dir>`` walks a conventional directory layout and assembles a
+``.sdsge`` bundle::
+
+    my-bundle/
+    ├── reference.yaml              # required (or dgp.yaml, or both)
+    ├── reference.options.json      # optional {"compile_kwargs":..., "solve_kwargs":...}
+    ├── dgp.yaml / dgp.options.json # optional
+    ├── estimation/
+    │   ├── spec.json               # required if estimation/ is present
+    │   ├── result.json             # optional ({"type":"mcmc"|"optimization","data":{...}})
+    │   ├── observed.csv|.parquet   # optional
+    │   └── posterior.csv|.parquet  # optional
+    ├── montecarlo/
+    │   ├── pipeline.json           # required if montecarlo/ is present
+    │   ├── result.json             # optional
+    │   └── traces.csv|.parquet     # optional
+    ├── simulation.json             # optional (SimSpec)
+    └── data/*.csv|*.parquet        # optional raw data members
+
+``sdsge-decompile <file>`` extracts the bundle's members back into a directory
+re-compilable into an equivalent bundle. Pass ``--csv`` to re-encode Parquet
+members as CSV (for editing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import shutil
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..core.model_parser import ModelParser
+from ..estimation.spec import (
+    EstimationSpec,
+    MCMCResultMeta,
+    OptimizationResultMeta,
+)
+from ..monte_carlo.spec import PipelineSpec
+from .builder import BundleBuilder
+from .container import BundleArchive
+from .manifest import Manifest, Member, SimSpec
+from .parquet import (
+    collapse_columns,
+    csv_to_columns,
+    from_parquet_columns,
+    trace_to_csv,
+)
+
+
+class CompileError(ValueError):
+    """Raised when the compile source directory cannot be assembled into a bundle."""
+
+
+# -- entry points -----------------------------------------------------------
+
+
+def main_compile(argv: Sequence[str] | None = None) -> int:
+    """``sdsge-compile`` entry point. Returns a process exit code."""
+    parser = argparse.ArgumentParser(
+        prog="sdsge-compile",
+        description="Assemble a .sdsge bundle from a directory layout.",
+    )
+    parser.add_argument(
+        "source", type=Path, help="Directory containing the bundle members."
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output .sdsge path (default: <source>.sdsge alongside the directory).",
+    )
+    parser.add_argument(
+        "--csv-only",
+        action="store_true",
+        help="Skip CSV->Parquet conversion (paired with format-agnostic reader).",
+    )
+    parser.add_argument(
+        "--created-by",
+        default=None,
+        help="Override the manifest 'created_by' field.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        out = compile_directory(
+            args.source,
+            args.output,
+            csv_only=args.csv_only,
+            created_by=args.created_by,
+        )
+    except (CompileError, FileNotFoundError, ValueError) as exc:
+        print(f"sdsge-compile: {exc}", file=sys.stderr)
+        return 1
+    print(f"wrote {out}")
+    return 0
+
+
+def main_decompile(argv: Sequence[str] | None = None) -> int:
+    """``sdsge-decompile`` entry point. Returns a process exit code."""
+    parser = argparse.ArgumentParser(
+        prog="sdsge-decompile",
+        description="Extract a .sdsge bundle into a directory.",
+    )
+    parser.add_argument("source", type=Path, help=".sdsge file to extract.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output directory (default: <source stem>/ alongside the file).",
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        help="Re-encode Parquet members as CSV in the output (for editing).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the output directory if it already exists.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        out = decompile_bundle(
+            args.source,
+            args.output,
+            also_csv=args.csv,
+            force=args.force,
+        )
+    except (FileNotFoundError, ValueError, FileExistsError) as exc:
+        print(f"sdsge-decompile: {exc}", file=sys.stderr)
+        return 1
+    print(f"extracted to {out}")
+    return 0
+
+
+# -- compile ----------------------------------------------------------------
+
+
+def compile_directory(
+    source: Path,
+    output: Path | None = None,
+    *,
+    csv_only: bool = False,
+    created_by: str | None = None,
+) -> Path:
+    """Assemble a ``.sdsge`` bundle from ``source`` per the layout convention."""
+    source = Path(source).resolve()
+    if not source.is_dir():
+        raise FileNotFoundError(f"compile source must be a directory: {source}")
+    out_path = (
+        Path(output) if output is not None else source.parent / f"{source.name}.sdsge"
+    )
+
+    builder = BundleBuilder(created_by=created_by)
+
+    model_observables: dict[str, list[str]] = {}
+    for role in ("reference", "dgp"):
+        yaml_file = source / f"{role}.yaml"
+        if not yaml_file.exists():
+            continue
+        yaml_text = yaml_file.read_text(encoding="utf-8")
+        opts = _load_model_options(source / f"{role}.options.json")
+        builder.add_model(
+            role,
+            yaml_text,
+            compile_kwargs=opts.get("compile_kwargs"),
+            solve_kwargs=opts.get("solve_kwargs"),
+        )
+        parsed = ModelParser.from_string(yaml_text).parsed.model
+        model_observables[role] = [str(o) for o in parsed.observables]
+
+    if not model_observables:
+        raise CompileError(
+            f"compile source {source} must contain at least one of "
+            "'reference.yaml' or 'dgp.yaml'."
+        )
+
+    _compile_raw_data(builder, source / "data", csv_only=csv_only)
+    _compile_estimation(
+        builder,
+        source / "estimation",
+        model_observables=model_observables,
+        csv_only=csv_only,
+    )
+    _compile_mc(builder, source / "montecarlo", csv_only=csv_only)
+
+    sim_path = source / "simulation.json"
+    if sim_path.exists():
+        sim_spec = SimSpec.from_dict(json.loads(sim_path.read_text(encoding="utf-8")))
+        builder.set_simulation(sim_spec)
+
+    return builder.write(out_path)
+
+
+def _load_model_options(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _compile_raw_data(
+    builder: BundleBuilder, data_dir: Path, *, csv_only: bool
+) -> None:
+    if not data_dir.is_dir():
+        return
+    for entry in sorted(data_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        stem = entry.stem
+        if entry.suffix == ".csv":
+            builder.add_raw_data(
+                stem, entry.read_text(encoding="utf-8"), as_parquet=not csv_only
+            )
+        elif entry.suffix == ".parquet":
+            # Embed verbatim — re-encoding would lose any pre-existing layout.
+            builder.add_member(
+                Member(path=f"data/{stem}.parquet", kind="raw_data"),
+                entry.read_bytes(),
+            )
+        else:
+            raise CompileError(
+                f"unrecognized raw data file '{entry.name}' "
+                f"(expected .csv or .parquet)"
+            )
+
+
+def _compile_estimation(
+    builder: BundleBuilder,
+    est_dir: Path,
+    *,
+    model_observables: dict[str, list[str]],
+    csv_only: bool,
+) -> None:
+    if not est_dir.is_dir():
+        return
+
+    spec_path = est_dir / "spec.json"
+    if not spec_path.exists():
+        raise CompileError(f"{est_dir}/ is present but spec.json is missing.")
+    spec = EstimationSpec.from_json(spec_path.read_text(encoding="utf-8"))
+
+    result: OptimizationResultMeta | MCMCResultMeta | None = None
+    result_path = est_dir / "result.json"
+    if result_path.exists():
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+        data = payload["data"]
+        if payload.get("type") == "mcmc":
+            result = MCMCResultMeta.from_dict(data)
+        else:
+            result = OptimizationResultMeta.from_dict(data)
+
+    expected_observables = model_observables.get("reference") or model_observables.get(
+        "dgp"
+    )
+
+    observed: NDArray[np.float64] | None = None
+    observable_names: list[str] | None = None
+    obs_path = _pick_one_of(est_dir, "observed")
+    if obs_path is not None:
+        observed, observable_names = _load_observed(obs_path, expected_observables)
+
+    posterior: dict[str, NDArray[Any]] | None = None
+    post_path = _pick_one_of(est_dir, "posterior")
+    if post_path is not None:
+        posterior = _load_posterior(post_path)
+
+    builder.add_estimation(
+        spec,
+        result=result,
+        observed=observed,
+        observable_names=observable_names,
+        posterior=posterior,
+        as_parquet=not csv_only,
+    )
+
+
+def _compile_mc(builder: BundleBuilder, mc_dir: Path, *, csv_only: bool) -> None:
+    if not mc_dir.is_dir():
+        return
+
+    pipeline_path = mc_dir / "pipeline.json"
+    if not pipeline_path.exists():
+        raise CompileError(f"{mc_dir}/ is present but pipeline.json is missing.")
+    pipeline = PipelineSpec.from_json(pipeline_path.read_text(encoding="utf-8"))
+    builder.add_mc(pipeline)
+
+    # Pre-split mc_result + mc_trace authoring: embed verbatim via add_member
+    # (the in-code add_mc takes a live MCPipelineResult and splits it).
+    result_path = mc_dir / "result.json"
+    if result_path.exists():
+        builder.add_member(
+            Member(path="montecarlo/result.json", kind="mc_result"),
+            result_path.read_bytes(),
+        )
+
+    trace_path = _pick_one_of(mc_dir, "traces")
+    if trace_path is not None:
+        if trace_path.suffix == ".csv":
+            target = "montecarlo/traces.csv"
+        else:
+            target = "montecarlo/traces.parquet"
+        builder.add_member(
+            Member(path=target, kind="mc_trace"), trace_path.read_bytes()
+        )
+
+
+def _pick_one_of(directory: Path, stem: str) -> Path | None:
+    csv_path = directory / f"{stem}.csv"
+    parquet_path = directory / f"{stem}.parquet"
+    if csv_path.exists() and parquet_path.exists():
+        raise CompileError(
+            f"both {csv_path.name} and {parquet_path.name} exist in {directory}; "
+            "choose one."
+        )
+    if csv_path.exists():
+        return csv_path
+    if parquet_path.exists():
+        return parquet_path
+    return None
+
+
+def _load_observed(
+    path: Path, expected_observables: list[str] | None
+) -> tuple[NDArray[np.float64], list[str] | None]:
+    columns = _read_columns(path)
+    if not columns:
+        raise CompileError(f"{path}: file is empty.")
+
+    # Mechanical layout: collapse_columns recovers a single (n, k) 'y' matrix.
+    collapsed = collapse_columns(columns)
+    y = collapsed.get("y")
+    if isinstance(y, np.ndarray) and y.ndim == 2:
+        if expected_observables is not None and y.shape[1] != len(expected_observables):
+            raise CompileError(
+                f"{path}: has {y.shape[1]} columns but model declares "
+                f"{len(expected_observables)} observables "
+                f"{expected_observables}."
+            )
+        return y.astype(np.float64, copy=False), None
+
+    # Semantic-header layout: column names ARE observable names.
+    inferred = list(columns.keys())
+    if any(_looks_numeric(name) for name in inferred):
+        raise CompileError(
+            f"{path}: inferred observable names {inferred!r} look numeric; "
+            "file may be missing a header row. Add observable names as the "
+            "first row and re-run."
+        )
+    if expected_observables is not None and inferred != expected_observables:
+        raise CompileError(
+            f"{path}: columns {inferred!r} do not match model observables "
+            f"{expected_observables!r}. Rename columns to match (order matters)."
+        )
+    matrix = np.column_stack(
+        [
+            np.asarray(
+                [np.nan if v is None else v for v in columns[name]], dtype=np.float64
+            )
+            for name in inferred
+        ]
+    )
+    return matrix, inferred
+
+
+def _load_posterior(path: Path) -> dict[str, NDArray[Any]]:
+    return collapse_columns(_read_columns(path))
+
+
+def _read_columns(path: Path) -> dict[str, list[Any]]:
+    if path.suffix == ".csv":
+        return csv_to_columns(path.read_text(encoding="utf-8"))
+    return from_parquet_columns(path.read_bytes())
+
+
+def _looks_numeric(value: str) -> bool:
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+# -- decompile --------------------------------------------------------------
+
+
+def decompile_bundle(
+    source: Path,
+    output: Path | None = None,
+    *,
+    also_csv: bool = False,
+    force: bool = False,
+) -> Path:
+    """Extract ``source`` into a directory that recompiles to an equivalent bundle."""
+    source = Path(source).resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"decompile source must be a file: {source}")
+    out_dir = (
+        Path(output).resolve() if output is not None else source.parent / source.stem
+    )
+
+    if out_dir.exists():
+        if not force:
+            raise FileExistsError(
+                f"output directory exists: {out_dir}; pass --force to overwrite."
+            )
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    archive = BundleArchive.open(source)
+    manifest = archive.manifest
+
+    rewritten: list[Member] = []
+    for member in manifest.members:
+        raw = archive.read(member.path)
+        write_path = _authoring_path_for(member)
+        new_path: str
+        new_format: str
+
+        if also_csv and member.format == "parquet":
+            new_path, data = _parquet_member_to_csv(member, raw)
+            # If we already remapped (model), keep the authoring path; only the
+            # format-rewrite branch changes the extension.
+            if write_path != member.path:
+                new_path = write_path[: -len(".parquet")] + ".csv"
+            new_format = "csv"
+        else:
+            new_path = write_path
+            data = raw
+            new_format = member.format
+
+        target = out_dir / new_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        rewritten.append(
+            Member(
+                path=new_path,
+                kind=member.kind,
+                format=new_format,
+                role=member.role,
+                columns=member.columns,
+                options=dict(member.options),
+            )
+        )
+
+        # Model options sidecar at the authoring location so recompile picks it up.
+        if member.kind == "model_config" and member.options and member.role:
+            (out_dir / f"{member.role}.options.json").write_text(
+                json.dumps(dict(member.options), indent=2), encoding="utf-8"
+            )
+
+    # Simulation prefill rides inline in the manifest; on decompile extract it
+    # to simulation.json at root so a recompile picks it up via the standard
+    # directory layout.
+    if manifest.simulation is not None:
+        (out_dir / "simulation.json").write_text(
+            json.dumps(manifest.simulation.to_dict(), indent=2), encoding="utf-8"
+        )
+
+    out_manifest = Manifest(
+        created_by=manifest.created_by,
+        created_at=manifest.created_at,
+        sdsge_version=manifest.sdsge_version,
+        members=rewritten,
+        simulation=manifest.simulation,
+        # Checksums are sha256(bytes); skip on decompile — recompile recomputes.
+        checksums={},
+    )
+    (out_dir / "manifest.json").write_text(out_manifest.to_json(), encoding="utf-8")
+
+    return out_dir
+
+
+def _authoring_path_for(member: Member) -> str:
+    """Map a bundle member's archive path to its compile-input authoring path.
+
+    Most kinds share the same path in both directions; ``model_config`` is the
+    exception because the bundle stores it under ``model/{role}.yaml`` while the
+    compile convention is ``{role}.yaml`` at the directory root.
+    """
+    if member.kind == "model_config" and member.role:
+        return f"{member.role}.yaml"
+    return member.path
+
+
+def _parquet_member_to_csv(member: Member, raw: bytes) -> tuple[str, bytes]:
+    """Re-emit a Parquet member as CSV, preserving observable-name metadata."""
+    columns = from_parquet_columns(raw)
+    new_path = member.path[: -len(".parquet")] + ".csv"
+
+    if member.kind == "estimation_data" and member.columns:
+        collapsed = collapse_columns(columns)
+        y = collapsed.get("y")
+        if isinstance(y, np.ndarray) and y.ndim == 2:
+            return new_path, _matrix_to_csv(y, list(member.columns))
+
+    # Generic path: emit columns with their current names (1-D each, since they
+    # came from a flat parquet file — no 2-D expansion).
+    return new_path, trace_to_csv({k: np.asarray(v) for k, v in columns.items()})
+
+
+def _matrix_to_csv(matrix: NDArray[Any], headers: list[str]) -> bytes:
+    out = io.StringIO()
+    writer = csv.writer(out, lineterminator="\n")
+    writer.writerow(headers)
+    for i in range(matrix.shape[0]):
+        writer.writerow(
+            [
+                (
+                    ""
+                    if not math.isfinite(float(matrix[i, j]))
+                    else repr(float(matrix[i, j]))
+                )
+                for j in range(matrix.shape[1])
+            ]
+        )
+    return out.getvalue().encode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ Repository = "https://github.com/GongJr0/SymbolicDSGE"
 
 [project.scripts]
 sdsge-ui = "SymbolicDSGE.ui.cli:main"
+sdsge-compile = "SymbolicDSGE.bundle.cli:main_compile"
+sdsge-decompile = "SymbolicDSGE.bundle.cli:main_decompile"
 
 [project.optional-dependencies]
 fred = [

--- a/tests/bundle/test_cli.py
+++ b/tests/bundle/test_cli.py
@@ -1,0 +1,255 @@
+"""Tests for the ``sdsge-compile`` / ``sdsge-decompile`` CLI commands.
+
+Drives ``main_compile`` / ``main_decompile`` through their argv lists so the
+production entry points exercise the same code paths the installed scripts will.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.bundle.cli import (
+    CompileError,
+    compile_directory,
+    decompile_bundle,
+    main_compile,
+    main_decompile,
+)
+from SymbolicDSGE.bundle.loader import build_from
+from SymbolicDSGE.bundle.manifest import ShockGeneration, SimSpec
+from SymbolicDSGE.core.model_parser import ModelParser
+
+_MODEL_YAML = Path("MODELS/test.yaml").read_text(encoding="utf-8")
+_OBSERVABLES = [
+    str(o) for o in ModelParser.from_string(_MODEL_YAML).parsed.model.observables
+]
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _observed_csv(matrix: np.ndarray, headers: list[str]) -> str:
+    rows = "\n".join(",".join(repr(float(v)) for v in row) for row in matrix)
+    return ",".join(headers) + "\n" + rows + "\n"
+
+
+def _baseline_dir(tmp_path: Path, *, with_estimation: bool = True) -> Path:
+    src = tmp_path / "bundle"
+    src.mkdir()
+    _write_text(src / "reference.yaml", _MODEL_YAML)
+    _write_text(
+        src / "reference.options.json",
+        json.dumps({"compile_kwargs": {"n_state": 3, "n_exog": 2}}),
+    )
+    if with_estimation:
+        spec = {
+            "method": "mle",
+            "parameters": [{"name": "beta", "initial": 0.99, "estimate": True}],
+            "method_kwargs": {},
+            "compile_kwargs": {},
+            "posterior_point": "mean",
+        }
+        _write_text(src / "estimation" / "spec.json", json.dumps(spec))
+        matrix = np.arange(12, dtype=np.float64).reshape(6, len(_OBSERVABLES))
+        _write_text(
+            src / "estimation" / "observed.csv",
+            _observed_csv(matrix, _OBSERVABLES),
+        )
+    return src
+
+
+# -- compile entry point ----------------------------------------------------
+
+
+def test_main_compile_emits_bundle(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    src = _baseline_dir(tmp_path, with_estimation=False)
+    out = tmp_path / "out.sdsge"
+    rc = main_compile([str(src), "-o", str(out), "--created-by", "cli-test"])
+    assert rc == 0
+    assert out.exists()
+    assert f"wrote {out}" in capsys.readouterr().out
+
+    loaded = build_from(out)
+    assert loaded.manifest.created_by == "cli-test"
+    assert loaded.reference is not None
+
+
+def test_main_compile_default_output_path(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path, with_estimation=False)
+    rc = main_compile([str(src)])
+    assert rc == 0
+    default_out = src.parent / f"{src.name}.sdsge"
+    assert default_out.exists()
+
+
+def test_compile_requires_at_least_one_model(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(CompileError, match="reference.yaml"):
+        compile_directory(empty)
+
+
+def test_compile_observed_round_trips_through_loader(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    out = compile_directory(src, tmp_path / "obs.sdsge")
+    loaded = build_from(out)
+    assert loaded.estimation is not None
+    assert loaded.estimation.observed is not None
+    expected = np.arange(12, dtype=np.float64).reshape(6, len(_OBSERVABLES))
+    np.testing.assert_allclose(loaded.estimation.observed, expected)
+
+
+def test_compile_csv_only_keeps_csv_member(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    out = compile_directory(src, tmp_path / "csv.sdsge", csv_only=True)
+    loaded = build_from(out)
+    data_member = next(
+        m for m in loaded.manifest.members if m.kind == "estimation_data"
+    )
+    assert data_member.format == "csv"
+    assert data_member.path.endswith(".csv")
+
+
+def test_compile_rejects_observable_name_mismatch(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    matrix = np.zeros((3, len(_OBSERVABLES)))
+    # Wrong header names (model expects 'Infl,Rate').
+    _write_text(
+        src / "estimation" / "observed.csv",
+        _observed_csv(matrix, ["foo", "bar"]),
+    )
+    with pytest.raises(CompileError, match="do not match model observables"):
+        compile_directory(src, tmp_path / "bad.sdsge")
+
+
+def test_compile_rejects_headerless_numeric_csv(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    # Numeric "headers" — file is effectively missing its header row.
+    _write_text(
+        src / "estimation" / "observed.csv",
+        "0.1,0.2\n0.3,0.4\n0.5,0.6\n",
+    )
+    with pytest.raises(CompileError, match="missing a header row"):
+        compile_directory(src, tmp_path / "nohdr.sdsge")
+
+
+def test_compile_rejects_column_count_mismatch_on_mechanical_layout(
+    tmp_path: Path,
+) -> None:
+    src = _baseline_dir(tmp_path)
+    # Mechanical y.0..y.{k-1} layout with the wrong k.
+    _write_text(
+        src / "estimation" / "observed.csv",
+        "y.0,y.1,y.2\n1,2,3\n4,5,6\n",
+    )
+    with pytest.raises(CompileError, match="model declares"):
+        compile_directory(src, tmp_path / "wrongk.sdsge")
+
+
+def test_compile_rejects_both_csv_and_parquet_for_same_member(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    _write_text(src / "estimation" / "observed.parquet", "junk")
+    with pytest.raises(CompileError, match="choose one"):
+        compile_directory(src, tmp_path / "ambig.sdsge")
+
+
+# -- decompile entry point --------------------------------------------------
+
+
+def test_main_decompile_extracts_members(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    out_bundle = compile_directory(_baseline_dir(tmp_path), tmp_path / "in.sdsge")
+    out_dir = tmp_path / "extracted"
+    rc = main_decompile([str(out_bundle), "-o", str(out_dir)])
+    assert rc == 0
+    assert (out_dir / "manifest.json").exists()
+    assert (out_dir / "reference.yaml").exists()
+    assert (out_dir / "reference.options.json").exists()
+    assert (out_dir / "estimation" / "spec.json").exists()
+    assert f"extracted to {out_dir.resolve()}" in capsys.readouterr().out
+
+
+def test_decompile_then_recompile_yields_equivalent_bundle(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    # Add a sim prefill so the inline-in-manifest path is also exercised.
+    src_sim = SimSpec(
+        role="reference",
+        T=8,
+        shock_generation=ShockGeneration(seed=42),
+    )
+    pass1 = compile_directory(src, tmp_path / "pass1.sdsge")
+    # Patch the bundle to carry the sim spec via the loader path... actually
+    # easier: write simulation.json into the source dir directly and recompile.
+    _write_text(src / "simulation.json", json.dumps(src_sim.to_dict()))
+    pass1 = compile_directory(src, tmp_path / "pass1.sdsge")
+    loaded1 = build_from(pass1)
+    assert loaded1.simulation is not None and loaded1.simulation.T == 8
+
+    out_dir = decompile_bundle(pass1, tmp_path / "extracted", also_csv=True)
+    assert (out_dir / "simulation.json").exists()  # inline SimSpec extracted
+    pass2 = compile_directory(out_dir, tmp_path / "pass2.sdsge")
+    loaded2 = build_from(pass2)
+
+    assert loaded2.simulation is not None and loaded2.simulation.T == 8
+    np.testing.assert_allclose(loaded1.estimation.observed, loaded2.estimation.observed)
+    assert loaded1.estimation.spec.to_dict() == loaded2.estimation.spec.to_dict()
+
+
+def test_decompile_csv_mode_rewrites_parquet_member_to_csv(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    bundle = compile_directory(src, tmp_path / "p.sdsge")
+    # Confirm the input bundle uses parquet.
+    data_member = next(
+        m for m in build_from(bundle).manifest.members if m.kind == "estimation_data"
+    )
+    assert data_member.format == "parquet"
+
+    out_dir = decompile_bundle(bundle, tmp_path / "as_csv", also_csv=True)
+    assert (out_dir / "estimation" / "observed.csv").exists()
+    assert not (out_dir / "estimation" / "observed.parquet").exists()
+
+    # Header should be the semantic observable names (not mechanical y.0/y.1).
+    header = (out_dir / "estimation" / "observed.csv").read_text().splitlines()[0]
+    assert header == ",".join(_OBSERVABLES)
+
+
+def test_decompile_rejects_existing_dir_without_force(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    bundle = compile_directory(src, tmp_path / "b.sdsge")
+    out_dir = tmp_path / "exists"
+    out_dir.mkdir()
+    with pytest.raises(FileExistsError, match="--force"):
+        decompile_bundle(bundle, out_dir)
+
+
+def test_decompile_force_overwrites(tmp_path: Path) -> None:
+    src = _baseline_dir(tmp_path)
+    bundle = compile_directory(src, tmp_path / "b.sdsge")
+    out_dir = tmp_path / "occupied"
+    out_dir.mkdir()
+    (out_dir / "stale.txt").write_text("old")
+    decompile_bundle(bundle, out_dir, force=True)
+    assert not (out_dir / "stale.txt").exists()
+    assert (out_dir / "manifest.json").exists()
+
+
+def test_main_compile_returns_nonzero_on_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    rc = main_compile([str(empty)])
+    assert rc == 1
+    assert "sdsge-compile:" in capsys.readouterr().err


### PR DESCRIPTION
This pull request adds comprehensive CLI support for compiling and decompiling SymbolicDSGE bundles, along with robust testing. The main changes include introducing new CLI entry points for `sdsge-compile` and `sdsge-decompile`, implementing a low-level passthrough for adding pre-encoded bundle members, and adding a thorough test suite for the new CLI commands.

**New CLI commands and entry points:**

* Added `sdsge-compile` and `sdsge-decompile` as public CLI entry points in `pyproject.toml`, enabling users to compile and decompile bundles from the command line.

**Bundle building enhancements:**

* Introduced a low-level `add_member` method to `BundleBuilder` for appending pre-encoded members, supporting efficient CLI operations without unnecessary re-encoding.

**Testing improvements:**

* Added a new test module `tests/bundle/test_cli.py` with comprehensive tests for both CLI commands, covering scenarios such as round-trip bundle compilation/decompilation, error handling, format conversions, and validation of model and data consistency.

closes #150 