### PR TITLE
Add unified UI launcher and workspace preload

### DIFF
--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -336,15 +336,15 @@ class SolvedModel:
             Whether to open a browser window automatically.
         """
         try:
-            from ..ui.cli import run_server
+            from ..ui.serve import serve_from
         except ImportError as exc:  # pragma: no cover - exercised without [ui]
             raise ImportError(
                 "The SymbolicDSGE UI extra is required for .serve(). "
                 "Install it with: pip install 'SymbolicDSGE[ui]'"
             ) from exc
 
-        run_server(
-            reference=self,
+        serve_from(
+            source=self,
             host=host,
             port=port,
             open_browser=open_browser,

--- a/SymbolicDSGE/ui/__init__.py
+++ b/SymbolicDSGE/ui/__init__.py
@@ -1,5 +1,13 @@
 from .app import create_app
 from .cli import run_server
-from .session import UISession
+from .serve import build_workspace, serve_from
+from .session import UISession, Workspace
 
-__all__ = ["UISession", "create_app", "run_server"]
+__all__ = [
+    "UISession",
+    "Workspace",
+    "build_workspace",
+    "create_app",
+    "run_server",
+    "serve_from",
+]

--- a/SymbolicDSGE/ui/app.py
+++ b/SymbolicDSGE/ui/app.py
@@ -25,7 +25,7 @@ from .schemas import (
     SolveModelRequest,
     SubmitFunctionRequest,
 )
-from .session import UISession
+from .session import UISession, Workspace
 
 
 def create_app(
@@ -33,9 +33,12 @@ def create_app(
     session: UISession | None = None,
     reference: SolvedModel | None = None,
     dgp: SolvedModel | None = None,
+    workspace: Workspace | None = None,
 ) -> FastAPI:
     ui_session = (
-        session if session is not None else UISession(reference=reference, dgp=dgp)
+        session
+        if session is not None
+        else UISession(reference=reference, dgp=dgp, workspace=workspace)
     )
     app = FastAPI(title="SymbolicDSGE UI", version="0.1.0")
     app.state.ui_session = ui_session

--- a/SymbolicDSGE/ui/cli.py
+++ b/SymbolicDSGE/ui/cli.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Sequence
 if TYPE_CHECKING:
     from SymbolicDSGE.core.solved_model import SolvedModel
 
+    from .session import Workspace
+
 _STATIC_DIR = Path(__file__).parent / "_static"
 
 _MISSING_UI_DEPS = (
@@ -41,6 +43,7 @@ def run_server(
     *,
     reference: "SolvedModel | None" = None,
     dgp: "SolvedModel | None" = None,
+    workspace: "Workspace | None" = None,
     host: str = "127.0.0.1",
     port: int | None = None,
     open_browser: bool = True,
@@ -103,7 +106,7 @@ def run_server(
                     raise
                 return await super().get_response("index.html", scope)
 
-    app = create_app(reference=reference, dgp=dgp)
+    app = create_app(reference=reference, dgp=dgp, workspace=workspace)
     # Mounted last so it does not shadow the /api routes registered above.
     app.mount("/", _HttpOnlyStaticFiles(directory=_STATIC_DIR, html=True), name="ui")
 
@@ -120,10 +123,22 @@ def run_server(
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """Console-script entry point (``sdsge-ui``)."""
+    """Console-script entry point (``sdsge-ui``).
+
+    With no positional argument the GUI launches empty. Passing a ``.sdsge``
+    bundle path preloads the reference/dgp models and the estimation/MC/sim
+    tabs from the bundle.
+    """
     parser = argparse.ArgumentParser(
         prog="sdsge-ui",
         description="Launch the SymbolicDSGE web playground.",
+    )
+    parser.add_argument(
+        "bundle",
+        nargs="?",
+        type=Path,
+        default=None,
+        help="Optional .sdsge bundle to hydrate the GUI from.",
     )
     parser.add_argument("--host", default="127.0.0.1", help="Bind host.")
     parser.add_argument(
@@ -139,7 +154,19 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    run_server(host=args.host, port=args.port, open_browser=not args.no_browser)
+    if args.bundle is not None and not args.bundle.is_file():
+        raise SystemExit(
+            f"sdsge-ui: bundle path does not exist or is not a file: {args.bundle}"
+        )
+
+    from .serve import serve_from
+
+    serve_from(
+        source=args.bundle,
+        host=args.host,
+        port=args.port,
+        open_browser=not args.no_browser,
+    )
 
 
 if __name__ == "__main__":

--- a/SymbolicDSGE/ui/estimation.py
+++ b/SymbolicDSGE/ui/estimation.py
@@ -11,6 +11,7 @@ from SymbolicDSGE.bayesian.transforms.transform_dispatch import (
 )
 from SymbolicDSGE.estimation.estimator import Estimator
 from SymbolicDSGE.estimation.results import MCMCResult, OptimizationResult
+from SymbolicDSGE.estimation.spec import MCMCResultMeta, OptimizationResultMeta
 
 from .schemas import EstimationParameterSpec, PriorSpec
 
@@ -88,48 +89,97 @@ def build_estimation_inputs(
     return names, theta0, priors, bound_arg
 
 
+def emit_estimation_wire(
+    obj: OptimizationResult | OptimizationResultMeta | MCMCResult | MCMCResultMeta,
+    *,
+    traces: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Render an estimation result (live or loaded-bundle metadata) to the wire dict.
+
+    Single source of truth for the estimation tab's wire shape. Accepts:
+
+    - a live :class:`OptimizationResult` / :class:`MCMCResult` (in-process path);
+    - or an :class:`OptimizationResultMeta` / :class:`MCMCResultMeta` from a
+      loaded ``.sdsge`` bundle (repaint path). For MCMC, the bundle path must
+      supply ``traces`` carrying the ``samples`` (2-D) and ``logpost_trace``
+      / ``logpost`` (1-D) arrays decoded from the Parquet member.
+
+    Dispatches by direct ``isinstance`` so mypy can narrow within each branch;
+    the meta dataclasses and live result classes overlap perfectly on the
+    scalar slice each helper reads.
+    """
+    if isinstance(obj, (OptimizationResult, OptimizationResultMeta)):
+        return _emit_optimization_wire(obj)
+    if isinstance(obj, (MCMCResult, MCMCResultMeta)):
+        return _emit_mcmc_wire(obj, traces)
+    raise TypeError(f"Unsupported estimation result type: {type(obj).__name__}")
+
+
+def _emit_optimization_wire(
+    obj: OptimizationResult | OptimizationResultMeta,
+) -> dict[str, Any]:
+    return {
+        "kind": obj.kind,
+        "success": bool(obj.success),
+        "message": obj.message,
+        "theta": {name: float(value) for name, value in obj.theta.items()},
+        "fun": float(obj.fun),
+        "loglik": float(obj.loglik),
+        "logprior": float(obj.logprior),
+        "logpost": float(obj.logpost),
+        "nfev": int(obj.nfev),
+        "nit": obj.nit,
+    }
+
+
+def _emit_mcmc_wire(
+    obj: MCMCResult | MCMCResultMeta,
+    traces: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    samples_src = getattr(obj, "samples", None)
+    logpost_src = getattr(obj, "logpost_trace", None)
+    if samples_src is None and traces is not None:
+        samples_src = traces.get("samples")
+    if logpost_src is None and traces is not None:
+        # Bundle authoring convention uses "logpost" (natural column name);
+        # the live MCMCResult class exposes "logpost_trace". Accept either.
+        logpost_src = traces.get("logpost_trace", traces.get("logpost"))
+    if samples_src is None or logpost_src is None:
+        raise ValueError(
+            "MCMC wire emission requires 'samples' and 'logpost_trace'/'logpost' "
+            "— supply them on the object or via the 'traces' mapping."
+        )
+    samples = np.asarray(samples_src, dtype=np.float64)
+    logpost = np.asarray(logpost_src, dtype=np.float64)
+    return {
+        "kind": "mcmc",
+        "param_names": list(obj.param_names),
+        "posterior_mean": {
+            name: float(samples[:, index].mean())
+            for index, name in enumerate(obj.param_names)
+        },
+        "posterior_std": {
+            name: float(samples[:, index].std())
+            for index, name in enumerate(obj.param_names)
+        },
+        "samples": {
+            name: samples[:, index].tolist()
+            for index, name in enumerate(obj.param_names)
+        },
+        "logpost_trace": logpost.tolist(),
+        "accept_rate": float(obj.accept_rate),
+        "n_draws": int(obj.n_draws),
+        "burn_in": int(obj.burn_in),
+        "thin": int(obj.thin),
+        "logpost_mean": float(logpost.mean()),
+        "logpost_min": float(logpost.min()),
+        "logpost_max": float(logpost.max()),
+    }
+
+
 def serialize_estimation_result(result: Any) -> dict[str, Any]:
-    if isinstance(result, OptimizationResult):
-        return {
-            "kind": result.kind,
-            "success": result.success,
-            "message": result.message,
-            "theta": {name: float(value) for name, value in result.theta.items()},
-            "fun": float(result.fun),
-            "loglik": float(result.loglik),
-            "logprior": float(result.logprior),
-            "logpost": float(result.logpost),
-            "nfev": result.nfev,
-            "nit": result.nit,
-        }
-    if isinstance(result, MCMCResult):
-        samples = np.asarray(result.samples, dtype=np.float64)
-        logpost = np.asarray(result.logpost_trace, dtype=np.float64)
-        return {
-            "kind": "mcmc",
-            "param_names": list(result.param_names),
-            "posterior_mean": {
-                name: float(samples[:, index].mean())
-                for index, name in enumerate(result.param_names)
-            },
-            "posterior_std": {
-                name: float(samples[:, index].std())
-                for index, name in enumerate(result.param_names)
-            },
-            "samples": {
-                name: samples[:, index].tolist()
-                for index, name in enumerate(result.param_names)
-            },
-            "logpost_trace": logpost.tolist(),
-            "accept_rate": float(result.accept_rate),
-            "n_draws": result.n_draws,
-            "burn_in": result.burn_in,
-            "thin": result.thin,
-            "logpost_mean": float(logpost.mean()),
-            "logpost_min": float(logpost.min()),
-            "logpost_max": float(logpost.max()),
-        }
-    raise TypeError(f"Unsupported estimation result type: {type(result).__name__}")
+    """Backwards-compatible thin wrapper around :func:`emit_estimation_wire`."""
+    return emit_estimation_wire(result)
 
 
 def _make_prior(spec: PriorSpec) -> Any:

--- a/SymbolicDSGE/ui/serve.py
+++ b/SymbolicDSGE/ui/serve.py
@@ -1,0 +1,110 @@
+"""Unified launcher for the SymbolicDSGE web UI.
+
+:func:`serve_from` is the single entry point all three call sites share:
+
+- the ``sdsge-ui`` CLI (``sdsge-ui [BUNDLE.sdsge]``);
+- :meth:`SymbolicDSGE.core.solved_model.SolvedModel.serve` (in-process);
+- programmatic callers (``from SymbolicDSGE.ui import serve_from``).
+
+``source`` is polymorphic:
+
+- ``None`` -> empty session (the Builder tab is the entry point);
+- a :class:`~SymbolicDSGE.core.solved_model.SolvedModel` -> preload as the
+  ``reference`` slot;
+- a path / string -> open the ``.sdsge`` bundle, hydrate ``reference``/``dgp``
+  and the estimation/MC/sim prefill into the session's :class:`Workspace`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from .estimation import emit_estimation_wire
+from .session import Workspace
+
+if TYPE_CHECKING:
+    from SymbolicDSGE.bundle.loader import LoadedBundle
+    from SymbolicDSGE.core.solved_model import SolvedModel
+
+
+def serve_from(
+    source: "str | Path | SolvedModel | None" = None,
+    *,
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    open_browser: bool = True,
+) -> None:
+    """Launch the SymbolicDSGE web UI, optionally hydrated from ``source``."""
+    from SymbolicDSGE.core.solved_model import SolvedModel
+
+    from .cli import run_server
+
+    if source is None:
+        run_server(host=host, port=port, open_browser=open_browser)
+        return
+
+    if isinstance(source, SolvedModel):
+        run_server(
+            reference=source,
+            host=host,
+            port=port,
+            open_browser=open_browser,
+        )
+        return
+
+    path = Path(source)
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"serve_from: bundle path does not exist or is not a file: {path}"
+        )
+
+    from SymbolicDSGE.bundle.loader import build_from
+
+    loaded = build_from(path)
+    workspace = build_workspace(loaded)
+    run_server(
+        reference=loaded.reference,
+        dgp=loaded.dgp,
+        workspace=workspace,
+        host=host,
+        port=port,
+        open_browser=open_browser,
+    )
+
+
+def build_workspace(loaded: "LoadedBundle") -> Workspace:
+    """Project a :class:`LoadedBundle` into a :class:`Workspace` preload payload.
+
+    The estimation/MC tabs are seeded with their canonical wire dicts (same
+    shape an in-process run would produce), so the frontend can repaint without
+    re-running anything. The simulation prefill rides as the SimSpec dict so
+    the Outputs tab pre-fills the seed/T/shock controls.
+    """
+    estimation_wire: dict[str, Any] | None = None
+    estimation_spec_dict: dict[str, Any] | None = None
+    if loaded.estimation is not None:
+        estimation_spec_dict = loaded.estimation.spec.to_dict()
+        if loaded.estimation.result is not None:
+            estimation_wire = emit_estimation_wire(
+                loaded.estimation.result,
+                traces=loaded.estimation.posterior,
+            )
+
+    mc_wire: dict[str, Any] | None = None
+    mc_pipeline_dict: dict[str, Any] | None = None
+    if loaded.mc is not None:
+        mc_pipeline_dict = loaded.mc.spec.to_dict()
+        mc_wire = loaded.mc.wire()
+
+    simulation_dict: dict[str, Any] | None = (
+        loaded.simulation.to_dict() if loaded.simulation is not None else None
+    )
+
+    return Workspace(
+        estimation=estimation_wire,
+        estimation_spec=estimation_spec_dict,
+        mc=mc_wire,
+        mc_pipeline=mc_pipeline_dict,
+        simulation=simulation_dict,
+    )

--- a/SymbolicDSGE/ui/session.py
+++ b/SymbolicDSGE/ui/session.py
@@ -75,12 +75,30 @@ class RunRecord:
     payload: Mapping[str, Any]
 
 
+@dataclass
+class Workspace:
+    """One-shot preload payload for a session.
+
+    Each field carries the wire-shaped dict the corresponding tab would
+    populate after a run, so the frontend can seed its state on first paint
+    without the user having to drive the GUI manually. Populated by
+    :func:`SymbolicDSGE.ui.serve.serve_from` from a loaded ``.sdsge`` bundle.
+    """
+
+    estimation: dict[str, Any] | None = None
+    mc: dict[str, Any] | None = None
+    simulation: dict[str, Any] | None = None
+    estimation_spec: dict[str, Any] | None = None
+    mc_pipeline: dict[str, Any] | None = None
+
+
 class UISession:
     def __init__(
         self,
         *,
         reference: SolvedModel | None = None,
         dgp: SolvedModel | None = None,
+        workspace: Workspace | None = None,
     ) -> None:
         self.slots: dict[Role, ModelSlot] = {
             "reference": ModelSlot(role="reference"),
@@ -91,6 +109,7 @@ class UISession:
             "reference": {},
             "dgp": {},
         }
+        self.workspace: Workspace = workspace if workspace is not None else Workspace()
         if reference is not None:
             self.set_solved_model("reference", reference)
         if dgp is not None:
@@ -108,7 +127,23 @@ class UISession:
                 }
                 for run in self.runs.values()
             ],
+            "workspace": self._workspace_payload(),
         }
+
+    def _workspace_payload(self) -> dict[str, Any]:
+        """Wire shape for the workspace preload (omits unset slots)."""
+        out: dict[str, Any] = {}
+        if self.workspace.estimation is not None:
+            out["estimation"] = self.workspace.estimation
+        if self.workspace.estimation_spec is not None:
+            out["estimation_spec"] = self.workspace.estimation_spec
+        if self.workspace.mc is not None:
+            out["mc"] = self.workspace.mc
+        if self.workspace.mc_pipeline is not None:
+            out["mc_pipeline"] = self.workspace.mc_pipeline
+        if self.workspace.simulation is not None:
+            out["simulation"] = self.workspace.simulation
+        return out
 
     def set_solved_model(self, role: Role, model: SolvedModel) -> dict[str, Any]:
         slot = self._slot(role)

--- a/tests/ui/test_serve.py
+++ b/tests/ui/test_serve.py
@@ -1,0 +1,322 @@
+"""Tests for ``serve_from``, the workspace preload, and the unified emitter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from SymbolicDSGE import DSGESolver, ModelParser
+from SymbolicDSGE.bundle.builder import BundleBuilder
+from SymbolicDSGE.bundle.loader import build_from
+from SymbolicDSGE.bundle.manifest import ShockGeneration, SimSpec
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.estimation.results import MCMCResult, OptimizationResult
+from SymbolicDSGE.estimation.spec import (
+    EstimationParameterSpec,
+    EstimationSpec,
+    MCMCResultMeta,
+    OptimizationResultMeta,
+)
+from SymbolicDSGE.monte_carlo.spec import NodeSpec, PipelineSpec
+from SymbolicDSGE.ui import build_workspace, create_app, serve_from
+from SymbolicDSGE.ui.estimation import emit_estimation_wire, serialize_estimation_result
+from SymbolicDSGE.ui.session import UISession, Workspace
+
+_MODEL_YAML = Path("MODELS/test.yaml").read_text(encoding="utf-8")
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _solved_test_model() -> SolvedModel:
+    parser = ModelParser.from_string(_MODEL_YAML)
+    model, kalman = parser.get_all()
+    solver = DSGESolver(model, kalman)
+    return solver.solve(solver.compile(n_state=3, n_exog=2))
+
+
+def _estimation_spec() -> EstimationSpec:
+    return EstimationSpec(
+        method="mcmc",
+        parameters=[
+            EstimationParameterSpec(name="beta", initial=0.99, estimate=True),
+            EstimationParameterSpec(name="sigma", initial=1.0, estimate=True),
+        ],
+        observables=["Infl", "Rate"],
+    )
+
+
+def _hydrated_bundle(tmp_path: Path) -> Path:
+    """Build a bundle that hits every preload slot (estimation+mc+sim)."""
+    rng = np.random.default_rng(0)
+    observed = rng.standard_normal((10, 2))
+    posterior = {
+        "samples": rng.standard_normal((20, 2)),
+        "logpost": rng.standard_normal(20),
+    }
+    result_meta = MCMCResultMeta(
+        param_names=["beta", "sigma"],
+        accept_rate=0.33,
+        n_draws=20,
+        burn_in=5,
+        thin=1,
+    )
+    pipeline = PipelineSpec(
+        nodes=[NodeSpec(id="n1", step_type="simulation", name="sim", params={"T": 20})]
+    )
+    sim_spec = SimSpec(role="reference", T=8, shock_generation=ShockGeneration(seed=42))
+
+    return (
+        BundleBuilder(created_by="serve-test")
+        .add_model("reference", _MODEL_YAML, compile_kwargs={"n_state": 3, "n_exog": 2})
+        .add_estimation(
+            _estimation_spec(),
+            result=result_meta,
+            observed=observed,
+            observable_names=["Infl", "Rate"],
+            posterior=posterior,
+        )
+        .add_mc(pipeline)
+        .set_simulation(sim_spec)
+        .write(tmp_path / "hydrate.sdsge")
+    )
+
+
+# -- emit_estimation_wire parity --------------------------------------------
+
+
+def test_emit_wire_optimization_meta_matches_live_result() -> None:
+    from scipy.optimize import OptimizeResult
+
+    theta = {"beta": 0.99, "rho": 0.8}
+    raw = OptimizeResult(success=True, x=np.array(list(theta.values())))
+    live = OptimizationResult(
+        kind="mle",
+        x=np.array(list(theta.values())),
+        theta={k: np.float64(v) for k, v in theta.items()},
+        success=True,
+        message="ok",
+        fun=np.float64(-12.3),
+        loglik=np.float64(-10.0),
+        logprior=np.float64(-2.3),
+        logpost=np.float64(-12.3),
+        nfev=42,
+        nit=15,
+        raw=raw,
+    )
+    meta = OptimizationResultMeta(
+        kind="mle",
+        theta=theta,
+        success=True,
+        message="ok",
+        fun=-12.3,
+        loglik=-10.0,
+        logprior=-2.3,
+        logpost=-12.3,
+        nfev=42,
+        nit=15,
+    )
+    assert emit_estimation_wire(live) == emit_estimation_wire(meta)
+
+
+def test_emit_wire_mcmc_meta_plus_traces_matches_live_result() -> None:
+    rng = np.random.default_rng(7)
+    samples = rng.standard_normal((30, 2))
+    logpost = rng.standard_normal(30)
+    live = MCMCResult(
+        param_names=["beta", "sigma"],
+        samples=samples,
+        logpost_trace=logpost,
+        accept_rate=np.float64(0.31),
+        n_draws=30,
+        burn_in=5,
+        thin=1,
+    )
+    meta = MCMCResultMeta(
+        param_names=["beta", "sigma"],
+        accept_rate=0.31,
+        n_draws=30,
+        burn_in=5,
+        thin=1,
+    )
+    traces = {"samples": samples, "logpost_trace": logpost}
+    assert emit_estimation_wire(live) == emit_estimation_wire(meta, traces=traces)
+
+
+def test_emit_wire_mcmc_meta_requires_traces() -> None:
+    meta = MCMCResultMeta(
+        param_names=["beta"], accept_rate=0.3, n_draws=10, burn_in=0, thin=1
+    )
+    with pytest.raises(ValueError, match="samples"):
+        emit_estimation_wire(meta)
+
+
+def test_serialize_estimation_result_shim_delegates() -> None:
+    meta = OptimizationResultMeta(
+        kind="map",
+        theta={"a": 1.0},
+        success=False,
+        message="x",
+        fun=0.0,
+        loglik=0.0,
+        logprior=0.0,
+        logpost=0.0,
+        nfev=1,
+        nit=None,
+    )
+    assert serialize_estimation_result(meta) == emit_estimation_wire(meta)
+
+
+# -- Workspace + session summary -------------------------------------------
+
+
+def test_session_summary_carries_empty_workspace_by_default() -> None:
+    client = TestClient(create_app())
+    payload = client.get("/api/session").json()
+    assert payload["workspace"] == {}
+
+
+def test_session_summary_surfaces_workspace_preload() -> None:
+    workspace = Workspace(
+        estimation={"kind": "mcmc", "param_names": ["beta"]},
+        estimation_spec={"method": "mcmc"},
+        mc={"kind": "mc"},
+        mc_pipeline={"nodes": []},
+        simulation={"T": 8},
+    )
+    client = TestClient(create_app(workspace=workspace))
+    payload = client.get("/api/session").json()["workspace"]
+    assert payload["estimation"]["kind"] == "mcmc"
+    assert payload["estimation_spec"]["method"] == "mcmc"
+    assert payload["mc"]["kind"] == "mc"
+    assert payload["mc_pipeline"] == {"nodes": []}
+    assert payload["simulation"] == {"T": 8}
+
+
+def test_session_summary_drops_unset_workspace_slots() -> None:
+    workspace = Workspace(simulation={"T": 5})  # only simulation populated
+    client = TestClient(create_app(workspace=workspace))
+    payload = client.get("/api/session").json()["workspace"]
+    assert payload == {"simulation": {"T": 5}}
+
+
+# -- build_workspace from a LoadedBundle -----------------------------------
+
+
+def test_build_workspace_populates_all_slots(tmp_path: Path) -> None:
+    loaded = build_from(_hydrated_bundle(tmp_path))
+    ws = build_workspace(loaded)
+    assert ws.estimation is not None and ws.estimation["kind"] == "mcmc"
+    assert ws.estimation["param_names"] == ["beta", "sigma"]
+    # bulk traces survived round-trip into the wire dict
+    assert len(ws.estimation["samples"]["beta"]) == 20
+    assert ws.estimation_spec is not None
+    assert ws.estimation_spec["method"] == "mcmc"
+    assert ws.mc_pipeline is not None
+    assert ws.mc is None  # no MC result was attached at build time
+    assert ws.simulation is not None
+    assert ws.simulation["T"] == 8
+    assert ws.simulation["shock_generation"]["seed"] == 42
+
+
+# -- serve_from dispatch ---------------------------------------------------
+
+
+def test_serve_from_none_calls_run_server_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run_server(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("SymbolicDSGE.ui.cli.run_server", fake_run_server)
+    serve_from(source=None, open_browser=False, port=12345)
+    assert captured["port"] == 12345
+    assert "reference" not in captured  # not forwarded when source is None
+    assert "workspace" not in captured
+
+
+def test_serve_from_solved_model_preloads_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run_server(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("SymbolicDSGE.ui.cli.run_server", fake_run_server)
+    solved = _solved_test_model()
+    serve_from(source=solved, open_browser=False)
+    assert captured["reference"] is solved
+    assert captured.get("workspace") is None
+
+
+def test_serve_from_bundle_path_hydrates_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run_server(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("SymbolicDSGE.ui.cli.run_server", fake_run_server)
+    bundle = _hydrated_bundle(tmp_path)
+    serve_from(source=bundle, open_browser=False)
+    assert isinstance(captured["reference"], SolvedModel)
+    assert captured["dgp"] is None
+    assert isinstance(captured["workspace"], Workspace)
+    assert captured["workspace"].estimation is not None
+    assert captured["workspace"].simulation is not None
+
+
+def test_serve_from_rejects_missing_bundle(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="bundle path"):
+        serve_from(source=tmp_path / "nope.sdsge")
+
+
+# -- CLI argparse ---------------------------------------------------------
+
+
+def test_cli_main_with_bundle_delegates_to_serve_from(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_serve_from(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("SymbolicDSGE.ui.serve.serve_from", fake_serve_from)
+    bundle = _hydrated_bundle(tmp_path)
+    from SymbolicDSGE.ui.cli import main
+
+    main([str(bundle), "--no-browser", "--port", "9999"])
+    assert captured["source"] == bundle
+    assert captured["port"] == 9999
+    assert captured["open_browser"] is False
+
+
+def test_cli_main_without_bundle_passes_none_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_serve_from(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("SymbolicDSGE.ui.serve.serve_from", fake_serve_from)
+    from SymbolicDSGE.ui.cli import main
+
+    main(["--no-browser"])
+    assert captured["source"] is None
+
+
+def test_cli_main_rejects_missing_bundle_path(tmp_path: Path) -> None:
+    from SymbolicDSGE.ui.cli import main
+
+    with pytest.raises(SystemExit, match="bundle path"):
+        main([str(tmp_path / "missing.sdsge"), "--no-browser"])


### PR DESCRIPTION
This pull request introduces a unified, extensible mechanism for launching the SymbolicDSGE web UI, enabling it to preload session state from a `.sdsge` bundle, a `SolvedModel`, or run empty. The main improvements include the addition of a new `serve_from` entry point, the introduction of a `Workspace` preload payload, and refactoring of the CLI and session logic to support seamless GUI hydration and state restoration.

**Unified UI launch and workspace preload:**

- **New unified launcher:** Added `serve_from` in `SymbolicDSGE/ui/serve.py`, which can launch the UI from an empty state, a `SolvedModel`, or a `.sdsge` bundle, hydrating the session with prefilled estimation, MC, and simulation state as needed. This is now the single entry point for CLI, in-process, and programmatic launches. [[1]](diffhunk://#diff-b9fe3c4c3118fb25550ac76cee01ce994ed2a296c9146cee95efd666bd10f7aeR1-R110) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL339-R347)

- **Workspace preload structure:** Introduced the `Workspace` dataclass in `session.py` to encapsulate all tab prefill payloads (estimation, MC, simulation, and their specs/pipelines). The session now manages this workspace and exposes it in its summary. [[1]](diffhunk://#diff-4fa50b1a194cd92908aecf0a9b257d682b2180945f3efe4bd686b37e866c516dR78-R101) [[2]](diffhunk://#diff-4fa50b1a194cd92908aecf0a9b257d682b2180945f3efe4bd686b37e866c516dR112) [[3]](diffhunk://#diff-4fa50b1a194cd92908aecf0a9b257d682b2180945f3efe4bd686b37e866c516dR130-R147)

**CLI and API refactoring:**

- **CLI enhancements:** The CLI (`sdsge-ui`) now accepts an optional `.sdsge` bundle path, validates it, and uses `serve_from` to hydrate the GUI. The CLI and server logic now consistently support preloading state from bundles. [[1]](diffhunk://#diff-36d8933da89342104cef80dcad4305a5d38edc9870793f1b020a6acc73ab8582L123-R142) [[2]](diffhunk://#diff-36d8933da89342104cef80dcad4305a5d38edc9870793f1b020a6acc73ab8582L142-R169)

- **API changes:** The `run_server` and `create_app` functions now accept an optional `workspace` argument, ensuring the preloaded state is available to the frontend on startup. [[1]](diffhunk://#diff-36d8933da89342104cef80dcad4305a5d38edc9870793f1b020a6acc73ab8582R46) [[2]](diffhunk://#diff-36d8933da89342104cef80dcad4305a5d38edc9870793f1b020a6acc73ab8582L106-R109) [[3]](diffhunk://#diff-ab330c3711f58a4d9c0a683a67f7fcc549c14ceb5477d2f7fcc78cf5de11edb1L28-R41)

**Estimation wire serialization improvements:**

- **Robust result serialization:** Refactored estimation result serialization into a single `emit_estimation_wire` function, which supports both live and loaded-bundle result objects, ensuring consistent frontend wire format regardless of the data source.

**Imports and API surface:**

- **Public API updates:** Updated `__init__.py` to expose `Workspace`, `build_workspace`, and `serve_from` for programmatic use.

These changes provide a robust foundation for session state restoration and reproducibility in the SymbolicDSGE UI, greatly enhancing user experience and developer ergonomics.

closes #151 