### PR TITLE
Add .sdsge bundle docs and guides

### DIFF
--- a/docs/Documentation/SolvedModel.md
+++ b/docs/Documentation/SolvedModel.md
@@ -274,3 +274,81 @@ __Returns:__
 | __Type__ | __Description__ |
 |:---------|----------------:|
 | `#!python dict[str, Any]` | Dictionary representation of the `#!python SolvedModel` object. |
+
+&nbsp;
+
+```python
+SolvedModel.save_sdsge(
+    path: str | Path,
+    *,
+    yaml_text: str | None = None, # (1)!
+    role: str = "reference",
+    compile_kwargs: Mapping[str, Any] | None = None,
+    solve_kwargs: Mapping[str, Any] | None = None,
+) -> Path
+```
+
+1. Override the YAML embedded in the bundle. Defaults to `compiled.config.source_yaml` (populated automatically by `#!python ModelParser`).
+
+Write a model-only `.sdsge` bundle around this `#!python SolvedModel`. For bundles that also carry estimation, Monte Carlo, or simulation members, use [`SolvedModel.to_bundle_builder`](#solvedmodelto_bundle_builder) and chain the additions before calling `.write()`.
+
+???+ warning "Source YAML required"
+    Raises `#!python ValueError` when `compiled.config.source_yaml` is `#!python None` and no `yaml_text=` override is supplied. Loading via `#!python ModelParser(path)` or `#!python ModelParser.from_string(text)` populates `source_yaml` automatically; programmatic `#!python ModelConfig` construction does not.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| path | Output `.sdsge` path. |
+| yaml_text | Explicit YAML override. |
+| role | `"reference"` or `"dgp"`. |
+| compile_kwargs | Kwargs the loader will use to rebuild the `#!python SolvedModel`. |
+| solve_kwargs | Kwargs the loader will use at the solve step. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python Path` | The path the bundle was written to. |
+
+&nbsp;
+
+```python
+SolvedModel.to_bundle_builder(
+    *,
+    yaml_text: str | None = None,
+    role: str = "reference",
+    compile_kwargs: Mapping[str, Any] | None = None,
+    solve_kwargs: Mapping[str, Any] | None = None,
+    created_by: str | None = None, # (1)!
+) -> BundleBuilder
+```
+
+1. Defaults to `#!python "SymbolicDSGE <version>"` when omitted.
+
+Return a [`#!python BundleBuilder`](./bundle/BundleBuilder.md) pre-seeded with this model's YAML. Chain estimation, Monte Carlo, or simulation members and then call `.write()` to materialize the archive.
+
+```python
+sol.to_bundle_builder() \
+    .add_estimation(spec, observed=y, observable_names=["Infl", "Rate"]) \
+    .add_mc(pipeline) \
+    .write("experiment-1.sdsge")
+```
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| yaml_text | Explicit YAML override; defaults to `compiled.config.source_yaml`. |
+| role | `"reference"` or `"dgp"`. |
+| compile_kwargs | Kwargs the loader will use to rebuild the `#!python SolvedModel`. |
+| solve_kwargs | Kwargs the loader will use at the solve step. |
+| created_by | Manifest `created_by` string. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python BundleBuilder` | A fluent builder with the model member already attached. |
+
+See the [`bundle` module documentation](./bundle/index.md) and the [Bundle Authoring Guide](../guides/bundle_authoring_guide.md) for the complete picture.

--- a/docs/documentation/bundle/BundleBuilder.md
+++ b/docs/documentation/bundle/BundleBuilder.md
@@ -1,0 +1,209 @@
+---
+tags:
+    - doc
+---
+# BundleBuilder
+
+```python
+class BundleBuilder()
+```
+
+`BundleBuilder` is the fluent in-code assembler for `.sdsge` archives. Members are appended via `add_*` methods, then committed by `.write()` or returned in memory via `.build()`. Every `add_*` method returns `self` to support chaining.
+
+`BundleBuilder` is re-exported at `SymbolicDSGE` root.
+
+__Constructor:__
+
+```python
+BundleBuilder(
+    *,
+    created_by: str | None = None,
+)
+```
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| created_by | Manifest `created_by` string. Defaults to `"SymbolicDSGE <version>"`. |
+
+&nbsp;
+
+__Methods:__
+
+```python
+BundleBuilder.add_model(
+    role: str,
+    yaml_text: str,
+    *,
+    compile_kwargs: Mapping[str, Any] | None = None, # (1)!
+    solve_kwargs: Mapping[str, Any] | None = None,   # (2)!
+) -> BundleBuilder
+```
+
+1. Forwarded to `DSGESolver.compile(...)` when the loader rebuilds the `SolvedModel`.
+2. Forwarded to `DSGESolver.solve(...)` at the same step.
+
+Add a model configuration to the bundle. `role` is `"reference"` or `"dgp"`. `yaml_text` is the source YAML the loader will re-parse.
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| role | `"reference"` or `"dgp"`. At least one model is required for a valid bundle. |
+| yaml_text | Source YAML text. Available on a parsed `ModelConfig` at `config.source_yaml`. |
+| compile_kwargs | Compile kwargs the loader passes to `DSGESolver.compile`. |
+| solve_kwargs | Solve kwargs the loader passes to `DSGESolver.solve`. |
+
+&nbsp;
+
+```python
+BundleBuilder.add_raw_data(
+    name: str,
+    data: bytes | str,
+    *,
+    as_parquet: bool = True, # (1)!
+) -> BundleBuilder
+```
+
+1. Pass `False` to embed the CSV verbatim (for hand-zip-friendly bundles).
+
+Add a raw observable file. CSV input is re-encoded as Parquet by default.
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| name | Member stem — stored under `data/<name>.csv` or `data/<name>.parquet`. |
+| data | CSV bytes or text. Parquet input should be added through [`add_member`](#raw-passthrough) instead. |
+| as_parquet | When `True` the CSV is re-encoded as Parquet for size; when `False` it is stored verbatim. |
+
+&nbsp;
+
+```python
+BundleBuilder.add_estimation(
+    spec: EstimationSpec,
+    *,
+    result: OptimizationResultMeta | MCMCResultMeta | None = None,
+    observed: NDArray[Any] | None = None,
+    observable_names: list[str] | None = None,
+    posterior: Mapping[str, NDArray[Any]] | None = None,
+    as_parquet: bool = True,
+) -> BundleBuilder
+```
+
+Add the estimation tab. `spec` is always written; the other arguments are conditional. With `as_parquet=False`, `observed` is stored as a semantic-header CSV (using `observable_names` as headers) and `posterior` is stored via mechanical `{name}.{j}` expansion.
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| spec | `EstimationSpec` for the run (method, parameters, observables, kwargs, posterior point). |
+| result | Result metadata — either `OptimizationResultMeta` (MLE/MAP) or `MCMCResultMeta` (MCMC). Bulk MCMC traces ride alongside via `posterior`. |
+| observed | Observed `y` matrix shaped `(n, k)`. |
+| observable_names | List of `k` observable names matching the matrix columns. Stored on the manifest member for semantic-header CSV authoring. |
+| posterior | MCMC posterior columns — typically `{"samples": (n_draws, n_params), "logpost": (n_draws,)}`. Either `logpost` or `logpost_trace` is accepted as the bulk-log key. |
+| as_parquet | When `False` the bulk members are written as CSV instead of Parquet. |
+
+???+ warning "Observable name validation"
+    `observable_names` must match the model's `observables` in count **and** order. Mismatch raises at compile time with an actionable message. See [`sdsge-compile` validation](../../portable_experiments/sdsge-compile.md#validation) for the details.
+
+&nbsp;
+
+```python
+BundleBuilder.add_mc(
+    pipeline: PipelineSpec,
+    *,
+    result: MCPipelineResult | None = None,
+    run_id: str = "",
+    as_parquet: bool = True,
+) -> BundleBuilder
+```
+
+Add the Monte Carlo tab. The pipeline spec is always written; an attached `result` is split into a trace-free document (JSON) plus a trace member (Parquet by default, CSV when `as_parquet=False`).
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| pipeline | `PipelineSpec` describing the MC graph. |
+| result | Optional live `MCPipelineResult`; the builder splits the document from the bulk traces internally. |
+| run_id | Identifier embedded in the result document. |
+| as_parquet | When `False` the trace member is written as CSV. |
+
+&nbsp;
+
+```python
+BundleBuilder.set_simulation(
+    simulation: SimSpec,
+) -> BundleBuilder
+```
+
+Attach the simulation prefill. `SimSpec` rides inline in the manifest rather than as its own member.
+
+&nbsp;
+
+```python
+BundleBuilder.add_member(
+    member: Member,
+    data: bytes,
+) -> BundleBuilder
+```
+
+Low-level passthrough — append a pre-encoded member at its declared path. Used by `sdsge-compile` to embed Parquet `data/` files verbatim and to stage pre-split MC result + traces pairs.
+
+???+ note "When to use `add_member` directly"
+    Prefer the typed `add_*` methods. Reach for `add_member` only when the member bytes are already in their final form and one of the higher-level methods would re-encode them.
+
+&nbsp;
+
+```python
+BundleBuilder.write(
+    path: str | Path,
+) -> Path
+```
+
+Materialize the bundle to disk and return the written path. Equivalent to `write_bundle(path, builder.manifest(), files)`.
+
+&nbsp;
+
+```python
+BundleBuilder.build(
+) -> tuple[Manifest, dict[str, bytes]]
+```
+
+Return the in-memory `(manifest, files)` pair instead of writing — useful for tests and for callers that handle the I/O themselves.
+
+&nbsp;
+
+```python
+BundleBuilder.manifest(
+) -> Manifest
+```
+
+Return a `Manifest` describing the currently-accumulated members. Each call regenerates `created_at` and re-computes SHA-256 checksums over the staged bytes.
+
+## Example
+
+```python
+from SymbolicDSGE import (
+    BundleBuilder,
+    DSGESolver,
+    ModelParser,
+)
+
+parser = ModelParser("MODELS/POST82.yaml") # (1)!
+model, kalman = parser.get_all()
+solver = DSGESolver(model, kalman)
+sol = solver.solve(solver.compile())
+
+bundle_path = (
+    BundleBuilder(created_by="experiment-1") # (2)!
+    .add_model(
+        "reference",
+        model.source_yaml, # (3)!
+        compile_kwargs={"linearize": False},
+    )
+    .write("experiment-1.sdsge")
+)
+```
+
+1. `ModelParser` populates `ModelConfig.source_yaml` automatically.
+2. `created_by` is purely metadata. Defaults to `"SymbolicDSGE <version>"` when omitted.
+3. The loader re-parses this YAML and re-solves with the recorded `compile_kwargs`.
+
+## See also
+
+- [`sdsge-compile`](../../portable_experiments/sdsge-compile.md) — the CLI equivalent.
+- [Bundle Authoring Guide](../../guides/bundle_authoring_guide.md) — full walkthrough.
+- [`SolvedModel.save_sdsge`](../SolvedModel.md) and [`SolvedModel.to_bundle_builder`](../SolvedModel.md) — convenience wrappers for the model-only case.

--- a/docs/documentation/bundle/LoadedBundle.md
+++ b/docs/documentation/bundle/LoadedBundle.md
@@ -1,0 +1,102 @@
+---
+tags:
+    - doc
+---
+# LoadedBundle
+
+```python
+@dataclass
+class LoadedBundle()
+```
+
+`LoadedBundle` is the return value of `load_bundle` (and the underlying `bundle.loader.build_from`). Each field is `None` when the corresponding component is absent from the archive.
+
+`LoadedBundle` is re-exported at `SymbolicDSGE` root.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| manifest | `#!python Manifest` | The full bundle manifest, including member inventory, checksums, and inline `SimSpec`. |
+| reference | `#!python SolvedModel \| None` | Re-solved reference model, or `None` if the bundle has no `reference.yaml`. |
+| dgp | `#!python SolvedModel \| None` | Re-solved DGP model, or `None` if absent. |
+| estimation | `#!python LoadedEstimation \| None` | Estimation artifacts, or `None` if `estimation/` was not in the bundle. |
+| mc | `#!python LoadedMC \| None` | Monte Carlo artifacts, or `None` if `montecarlo/` was not in the bundle. |
+| simulation | `#!python SimSpec \| None` | Simulation prefill, or `None` if not set. |
+
+???+ info "Re-solving on load"
+    `reference` and `dgp` are reconstructed by re-parsing the embedded YAML and re-running `DSGESolver.compile(**compile_kwargs).solve(**solve_kwargs)` with the kwargs recorded at compile time. The receiver does not need the original parser state.
+
+## `LoadedEstimation`
+
+```python
+@dataclass
+class LoadedEstimation()
+```
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| spec | `#!python EstimationSpec` | The text-only run specification. Always present when `LoadedEstimation` is. |
+| result | `#!python OptimizationResultMeta \| MCMCResultMeta \| None` | Result metadata (scalar slice). Discriminated by `"type": "mcmc" \| "optimization"` in the embedded JSON. |
+| observed | `#!python NDArray[np.float64] \| None` | Observed `y` matrix shaped `(n, k)`, reconstructed from the CSV or Parquet member. |
+| posterior | `#!python dict[str, NDArray] \| None` | MCMC posterior columns — `{"samples": (n_draws, n_params), "logpost": (n_draws,)}` by convention. |
+
+???+ note "Pairing metadata with traces"
+    `MCMCResultMeta` carries only the scalar slice. To reconstruct the full sampling diagnostics or repaint the GUI, pair the metadata with `posterior` — both come back as part of the same `LoadedEstimation` so callers don't have to track member paths.
+
+## `LoadedMC`
+
+```python
+@dataclass
+class LoadedMC()
+```
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| spec | `#!python PipelineSpec` | The pipeline graph (nodes + edges). Always present when `LoadedMC` is. |
+| document | `#!python dict[str, Any] \| None` | Trace-free run document (test/regression summaries, timing, etc.). |
+| traces | `#!python dict[str, NDArray] \| None` | Bulk trace columns keyed by `test.<name>.{statistic,pval,status}` / `regression.<name>.{coef,r2,status}`. |
+
+__Methods:__
+
+```python
+LoadedMC.wire(
+) -> dict[str, Any] | None
+```
+
+Re-merge `document` and `traces` into the canonical UI wire shape (the same dict an in-process run would emit). Returns `None` when either side is missing.
+
+???+ info "When `wire()` returns `None`"
+    A bundle authored with the pipeline spec only (no completed run attached) carries neither `document` nor `traces`. `wire()` reports `None` so callers can distinguish "no run available" from a run with empty traces.
+
+## Example
+
+```python
+from SymbolicDSGE import load_bundle
+
+loaded = load_bundle("experiment-1.sdsge")
+
+# Use the re-solved reference model directly.
+if loaded.reference is not None:
+    sim = loaded.reference.sim(T=25, observables=True)
+
+# Inspect the estimation tab.
+if loaded.estimation is not None:
+    print(loaded.estimation.spec.method)
+    if loaded.estimation.posterior is not None:
+        samples = loaded.estimation.posterior["samples"]
+        print(samples.shape)
+
+# Manifest is always present.
+print(loaded.manifest.created_by, loaded.manifest.created_at)
+```
+
+## See also
+
+- [`load_bundle`](load_bundle.md) — the constructor.
+- [`Manifest`](Manifest.md) — the archive index.
+- [Bundle Loading Guide](../../guides/bundle_loading_guide.md) — end-to-end walkthrough.

--- a/docs/documentation/bundle/Manifest.md
+++ b/docs/documentation/bundle/Manifest.md
@@ -1,0 +1,172 @@
+---
+tags:
+    - doc
+---
+# Manifest
+
+```python
+@dataclass
+class Manifest()
+```
+
+`Manifest` is the schema for `manifest.json` at the root of every `.sdsge` archive. It indexes the included members, records provenance, and (optionally) carries the simulation prefill inline.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| created_by | `#!python str` | Library version string. Defaults to `"SymbolicDSGE <version>"` when produced by `BundleBuilder`. |
+| created_at | `#!python str \| None` | UTC ISO-8601 timestamp set at write time. |
+| sdsge_version | `#!python int` | Format version. Readers reject bundles with `sdsge_version > SDSGE_FORMAT_VERSION`. |
+| members | `#!python list[Member]` | Member inventory — every archive entry has one. |
+| simulation | `#!python SimSpec \| None` | Inline simulation prefill (no separate member). |
+| checksums | `#!python dict[str, str]` | SHA-256 hex digests keyed by member path. |
+
+__Methods:__
+
+```python
+Manifest.members_by_kind(
+    kind: str,
+) -> list[Member]
+```
+
+Return every member with the given `kind` (e.g. `"model_config"`, `"estimation_data"`).
+
+```python
+Manifest.model_member(
+    role: str,
+) -> Member | None
+```
+
+Convenience accessor — return the `model_config` member with the given `role` (`"reference"` or `"dgp"`), or `None` if absent.
+
+```python
+Manifest.to_dict() -> dict[str, Any]
+Manifest.to_json(*, indent: int | None = 2) -> str
+Manifest.from_dict(data: Mapping[str, Any]) -> Manifest      # @classmethod
+Manifest.from_json(text: str) -> Manifest                    # @classmethod
+```
+
+Round-trippable JSON shape. `from_dict` / `from_json` validate `sdsge_version` and raise `ValueError` when the bundle is newer than the installed library supports.
+
+???+ warning "Forward / backward compatibility"
+    Readers are forward-tolerant on older versions (a v1 reader opens v1 bundles) but strict on newer ones (a v1 reader refuses a v2 bundle). Bump `SDSGE_FORMAT_VERSION` only on breaking manifest changes.
+
+## `Member`
+
+```python
+@dataclass
+class Member()
+```
+
+One archive entry described in the manifest.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| path | `#!python str` | POSIX path inside the archive (e.g. `model/reference.yaml`). |
+| kind | `#!python str` | Semantic kind — one of `MEMBER_KINDS` (see below). |
+| format | `#!python str` | `"yaml"` / `"json"` / `"csv"` / `"parquet"`. Inferred from `path` extension when omitted on construction. |
+| role | `#!python str \| None` | `"reference"` / `"dgp"` for model members. |
+| columns | `#!python list[str] \| None` | Column names for tabular members (e.g. observable names on `estimation_data`). |
+| options | `#!python dict[str, Any]` | Kind-specific metadata. For `model_config` this carries `compile_kwargs` / `solve_kwargs`. |
+
+__Recognized kinds (`MEMBER_KINDS`):__
+
+| Kind | Purpose |
+| --- | --- |
+| `model_config` | YAML configuration for a role. |
+| `raw_data` | Raw observable file (CSV or Parquet). |
+| `estimation_spec` | `EstimationSpec` JSON. |
+| `estimation_result` | Wrapped `{"type": "mcmc" \| "optimization", "data": {...}}`. |
+| `estimation_data` | Observed `y` matrix (CSV or Parquet). |
+| `estimation_trace` | MCMC posterior columns (CSV or Parquet). |
+| `mc_pipeline` | `PipelineSpec` JSON. |
+| `mc_result` | Trace-free MC run document (JSON). |
+| `mc_trace` | MC trace columns (CSV or Parquet). |
+
+???+ note "Kind whitelist"
+    `Member.__post_init__` raises `ValueError` for any kind outside `MEMBER_KINDS`. Adding a new kind requires bumping `SDSGE_FORMAT_VERSION` so older readers don't silently drop it.
+
+## `SimSpec`
+
+```python
+@dataclass
+class SimSpec()
+```
+
+Simulation prefill — the receiver clicks **Run** in the GUI to reproduce the author's intended simulation. Stored inline in `Manifest.simulation`, not as a member.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| role | `#!python str` | Active model slot — typically `"reference"`. |
+| T | `#!python int` | Periods to simulate. |
+| observables | `#!python bool` | Include observable paths in the output. |
+| shock_scale | `#!python float` | Multiplier applied to all shocks. |
+| shock_generation | `#!python ShockGeneration \| None` | RNG settings; `None` if raw shock paths are supplied instead. |
+| shock_std | `#!python dict[str, float]` | Per-shock standard deviation overrides. |
+| shock_corr | `#!python dict[str, float]` | Pairwise shock correlation overrides keyed by `"a,b"` syntax. |
+| shocks | `#!python dict[str, list[float]] \| None` | Optional raw shock paths inline. |
+
+???+ info "Determinism"
+    Sim results are not stored. Replaying the prefill against the preloaded model reproduces the intended run because numpy `PCG64` + a fixed `ShockGeneration.seed` are deterministic.
+
+## `ShockGeneration`
+
+```python
+@dataclass
+class ShockGeneration()
+```
+
+RNG settings for replayed shock generation.
+
+__Fields:__
+
+| __Name__ | __Type__ | __Description__ |
+|:---------|:--------:|----------------:|
+| dist | `#!python str` | Distribution name — `"norm"` / `"t"` / `"uni"`. |
+| seed | `#!python int \| None` | RNG seed for reproducibility. |
+| loc | `#!python float` | Location parameter. |
+| df | `#!python float` | Degrees of freedom (Student's `t`). |
+
+## Example
+
+```python
+from SymbolicDSGE.bundle import Manifest, Member, SimSpec, ShockGeneration
+
+manifest = Manifest(
+    created_by="experiment-1",
+    members=[
+        Member(
+            path="model/reference.yaml",
+            kind="model_config",
+            role="reference",
+            options={"compile_kwargs": {"linearize": False}},
+        ),
+        Member(
+            path="estimation/spec.json",
+            kind="estimation_spec",
+        ),
+        Member(
+            path="estimation/observed.csv",
+            kind="estimation_data",
+            columns=["Infl", "Rate"],
+        ),
+    ],
+    simulation=SimSpec(
+        role="reference",
+        T=25,
+        shock_generation=ShockGeneration(seed=42),
+    ),
+)
+
+print(manifest.to_json())
+```
+
+## See also
+
+- [`LoadedBundle`](LoadedBundle.md) — carries the manifest at load time.
+- [`sdsge-decompile`](../../portable_experiments/sdsge-decompile.md) — extracts the manifest to disk.

--- a/docs/documentation/bundle/index.md
+++ b/docs/documentation/bundle/index.md
@@ -1,0 +1,44 @@
+---
+tags:
+    - doc
+---
+# Bundle
+
+The `bundle` module produces and consumes `.sdsge` archives — a versioned zip containing a model + Kalman configuration, optional estimation spec/result/data, optional Monte Carlo pipeline/result, and an optional simulation prefill. Authored bundles are portable: a receiver only needs `pip install SymbolicDSGE` to reach every component the bundle carries, and `pip install "SymbolicDSGE[ui]"` to hydrate the GUI with one.
+
+For task-oriented walkthroughs see the [Bundle Authoring Guide](../../guides/bundle_authoring_guide.md) and [Bundle Loading Guide](../../guides/bundle_loading_guide.md). For the CLI counterparts see the [Portable Experiments](../../portable_experiments/index.md) section.
+
+???+ note "Top-level imports"
+    `BundleBuilder`, `LoadedBundle`, and `load_bundle` are re-exported at `SymbolicDSGE` root. Everything else in this section lives under `SymbolicDSGE.bundle`.
+
+## Module layout
+
+| Class / function | Description |
+| --- | --- |
+| [`BundleBuilder`](BundleBuilder.md) | Fluent assembler for the in-code authoring path. |
+| [`load_bundle`](load_bundle.md) | Open a `.sdsge` and reconstruct its components into Python objects. |
+| [`LoadedBundle`](LoadedBundle.md) | Container holding every component returned by `load_bundle`. |
+| [`Manifest`](Manifest.md) | Versioned archive index — schema for `manifest.json`. |
+
+## Estimation result metadata
+
+Estimation results carry both a small text-only metadata slice and (for MCMC) bulk trace arrays. The metadata classes live in `SymbolicDSGE.estimation.spec`:
+
+| Class | Purpose |
+| --- | --- |
+| `OptimizationResultMeta` | Scalar metadata for `OptimizationResult` (`kind`, `theta`, `success`, `message`, `fun`, `loglik`, `logprior`, `logpost`, `nfev`, `nit`). Sufficient to repaint MLE/MAP summaries on load. |
+| `MCMCResultMeta` | Scalar metadata for `MCMCResult` (`param_names`, `accept_rate`, `n_draws`, `burn_in`, `thin`). Bulk `samples` and `logpost_trace` ride a Parquet member alongside the metadata and pair with it at load time. |
+
+Both classes expose `to_dict()` / `from_dict()` and are reused unchanged by both the in-code path and the bundle.
+
+## Convention summary
+
+| Topic | Behavior |
+| --- | --- |
+| Format version | `Manifest.sdsge_version`; readers reject bundles with a newer-than-supported version. |
+| Compression | Parquet members are stored uncompressed (`ZIP_STORED`); text members deflate. |
+| Determinism | Bundle stores simulation specs + seed, not simulation results. Reproducibility relies on numpy `PCG64`. |
+| Round-trip | Model YAML re-parsed and re-solved with stored `compile_kwargs`/`solve_kwargs`. |
+
+???+ warning "Bundle format scope"
+    `.sdsge` is designed for sharing model setups and result snapshots, not as a long-term data archive. The format is versioned; older versions read forward, but newer-than-supported versions are rejected. Keep the producing library version recorded alongside the bundle for reproducibility.

--- a/docs/documentation/bundle/load_bundle.md
+++ b/docs/documentation/bundle/load_bundle.md
@@ -1,0 +1,94 @@
+---
+tags:
+    - doc
+---
+# load_bundle
+
+```python
+def load_bundle(
+    path: str | Path,
+) -> LoadedBundle
+```
+
+Open a `.sdsge` archive and reconstruct its components. Equivalent to `SymbolicDSGE.bundle.build_from`; `load_bundle` is the friendlier top-level alias.
+
+`load_bundle` is re-exported at `SymbolicDSGE` root.
+
+__Inputs:__
+
+| __Name__ | __Description__ |
+|:---------|----------------:|
+| path | Path to the `.sdsge` file. |
+
+__Returns:__
+
+| __Type__ | __Description__ |
+|:---------|----------------:|
+| `#!python LoadedBundle` | Container with `manifest`, `reference`/`dgp` (re-solved models), `estimation` artifacts, `mc` artifacts, and the optional `simulation` prefill. See [`LoadedBundle`](LoadedBundle.md). |
+
+__Behavior:__
+
+1. Read `manifest.json` and validate `sdsge_version`.
+2. Walk every member declared in the manifest:
+    - YAML models are re-parsed and re-compiled+solved using stored `compile_kwargs` / `solve_kwargs`.
+    - Estimation / MC text members are parsed back into their respective dataclasses.
+    - CSV / Parquet members are dispatched by `Member.format` and decoded into numpy arrays.
+3. Inline `SimSpec` is read from the manifest itself.
+
+???+ info "Format-agnostic reader"
+    `load_bundle` dispatches each tabular member on `Member.format`. A hand-zipped CSV-only bundle and a CLI-built Parquet bundle both load through the same path. No `[bundle]` extra is required — `parquet-engine` is a regular dependency.
+
+???+ warning "Re-solve cost"
+    Loading runs the full parse → compile → solve pipeline once per model member. For large models or scripts that open many bundles in a loop, cache the `LoadedBundle` rather than reopening.
+
+## Example
+
+```python
+from SymbolicDSGE import load_bundle
+
+loaded = load_bundle("experiment-1.sdsge")
+
+print(loaded.manifest.created_by)
+if loaded.reference is not None:
+    print(loaded.reference.policy.stab == 0)
+```
+
+## In-code authoring counterpart
+
+```python
+SolvedModel.save_sdsge(
+    path: str | Path,
+    *,
+    yaml_text: str | None = None, # (1)!
+    role: str = "reference",
+    compile_kwargs: Mapping[str, Any] | None = None,
+    solve_kwargs: Mapping[str, Any] | None = None,
+) -> Path
+```
+
+1. Override the YAML embedded in the bundle. Defaults to `compiled.config.source_yaml` (populated by `ModelParser`).
+
+Convenience wrapper around [`SolvedModel.to_bundle_builder`](../SolvedModel.md) for the model-only case. For bundles that include estimation / MC / sim members, call `to_bundle_builder` and chain the additions.
+
+```python
+SolvedModel.to_bundle_builder(
+    *,
+    yaml_text: str | None = None,
+    role: str = "reference",
+    compile_kwargs: Mapping[str, Any] | None = None,
+    solve_kwargs: Mapping[str, Any] | None = None,
+    created_by: str | None = None,
+) -> BundleBuilder
+```
+
+Return a `BundleBuilder` pre-seeded with the model's YAML. Chain estimation / MC / simulation members, then call `.write()` to materialize the archive.
+
+???+ warning "Source YAML required"
+    `to_bundle_builder` raises `ValueError` if `compiled.config.source_yaml` is `None` and no `yaml_text=` override is given. `ModelParser(path)` and `ModelParser.from_string(text)` both populate `source_yaml` automatically; programmatically constructed `ModelConfig` instances do not.
+
+## See also
+
+- [`BundleBuilder`](BundleBuilder.md) — assemble bundles from code.
+- [`LoadedBundle`](LoadedBundle.md) — the return type.
+- [`sdsge-decompile`](../../portable_experiments/sdsge-decompile.md) — the CLI counterpart.
+- [Bundle Loading Guide](../../guides/bundle_loading_guide.md) — full walkthrough.

--- a/docs/gui_usage/index.md
+++ b/docs/gui_usage/index.md
@@ -20,6 +20,9 @@ A solved model can also open the GUI with itself preloaded as the reference mode
 solved.serve()
 ```
 
+???+ info "Opening a `.sdsge` bundle"
+    `sdsge-ui` accepts an optional positional argument: `sdsge-ui my-experiment.sdsge` launches the GUI with every tab pre-populated from the bundle. See [Portable Experiments](../portable_experiments/index.md) for how bundles are produced.
+
 ## Shared Controls
 
 The sidebar controls the active model role and is available from every tab.

--- a/docs/guides/bundle_authoring_guide.md
+++ b/docs/guides/bundle_authoring_guide.md
@@ -1,0 +1,253 @@
+---
+tags:
+    - guide
+---
+
+# Bundle Authoring Guide
+
+This guide walks through assembling a complete `.sdsge` bundle from code — model + Kalman config, estimation spec and result, observed data, Monte Carlo pipeline and traces, simulation prefill. Every member type the bundle supports is covered.
+
+We start from `MODELS/POST82.yaml` (also used in the [Quick Start](quickstart.md)). The full assembly fits in a single script you can copy and run.
+
+???+ tip "Where the bundle ends up"
+    The example writes `experiment-1.sdsge` in the current directory. Open it later via [`load_bundle`](../documentation/bundle/load_bundle.md), inspect components with [`sdsge-decompile`](../portable_experiments/sdsge-decompile.md), or open it directly in the GUI with `sdsge-ui experiment-1.sdsge`.
+
+## Solve a reference model
+
+```python
+from SymbolicDSGE import DSGESolver, ModelParser
+from numpy import array, float64
+
+parser = ModelParser("MODELS/POST82.yaml") # (1)!
+model, kalman = parser.get_all()
+
+solver = DSGESolver(model, kalman)
+compiled = solver.compile(
+    linearize=False, # (2)!
+)
+sol = solver.solve(
+    compiled,
+    steady_state=array([0.0, 0.0, 0.0, 0.0, 0.0], dtype=float64),
+)
+```
+
+1. `ModelParser` populates `ModelConfig.source_yaml` automatically; the bundle re-uses it without re-reading the file.
+2. Set `True` for models authored in nonlinear levels — see the [Quick Start](quickstart.md#compilation) for details.
+
+???+ note "Why we solve first"
+    The bundle preserves the YAML and the recorded compile/solve kwargs, then re-runs them at load time. Solving here is only required if we want to attach an estimation, an MC pipeline, or a `SolvedModel`-derived result. Author-only bundles do not need a live `SolvedModel`.
+
+## Specify the estimation tab
+
+We define a small MAP run estimating `psi_pi` and `psi_x` against synthetic observed data. The spec captures the run shape and parameter priors; the result captures the optimization outcome. Observed data is fed in as a numpy matrix and stored as a CSV column-pair with semantic headers.
+
+```python
+import numpy as np
+
+from SymbolicDSGE.estimation.spec import (
+    EstimationParameterSpec,
+    EstimationSpec,
+    OptimizationResultMeta,
+    PriorSpec,
+)
+
+estimation_spec = EstimationSpec(
+    method="map", # (1)!
+    parameters=[
+        EstimationParameterSpec(
+            name="psi_pi",
+            initial=1.5,
+            estimate=True,
+            lower=1.0,
+            upper=3.0,
+            prior=PriorSpec(
+                distribution="normal",
+                parameters={"loc": 1.5, "scale": 0.25},
+            ),
+        ),
+        EstimationParameterSpec(
+            name="psi_x",
+            initial=0.5,
+            estimate=True,
+            lower=0.0,
+            upper=1.0,
+            prior=PriorSpec(
+                distribution="normal",
+                parameters={"loc": 0.5, "scale": 0.2},
+            ),
+        ),
+    ],
+    observables=["Infl", "Rate"], # (2)!
+    method_kwargs={"options": {"maxiter": 50}},
+)
+
+rng = np.random.default_rng(0)
+observed = rng.standard_normal((40, 2)) # (3)!
+estimation_result_meta = OptimizationResultMeta(
+    kind="map",
+    theta={"psi_pi": 1.48, "psi_x": 0.55}, # (4)!
+    success=True,
+    message="Optimization converged.",
+    fun=-87.3,
+    loglik=-85.1,
+    logprior=-2.2,
+    logpost=-87.3,
+    nfev=124,
+    nit=14,
+)
+```
+
+1. `"mle"`, `"map"`, or `"mcmc"`. MAP/MCMC require priors; MLE does not.
+2. Order matters — the loader cross-checks these against the model's declared observables at compile time.
+3. Synthetic data shaped `(n_periods, n_observables)`. Substitute the real `y` matrix you fitted the model to.
+4. The bundle stores only the result metadata, not the raw `scipy.optimize.OptimizeResult` — `theta` carries the same information by parameter name.
+
+???+ info "Source of the result metadata"
+    A live `OptimizationResult` from `Estimator.run(...)` projects to `OptimizationResultMeta` field-for-field. The same applies to `MCMCResult` ↔ `MCMCResultMeta` — except MCMC also requires the `samples` and `logpost` bulk arrays as a separate `posterior` dict.
+
+## Build a Monte Carlo pipeline
+
+`PipelineSpec` is the pydantic-free representation of an MC graph. Here we attach the pipeline spec without a completed run; the loader returns the spec for the GUI to render and the user to fill in `n_rep` and click **Run**.
+
+```python
+from SymbolicDSGE.monte_carlo.spec import EdgeSpec, NodeSpec, PipelineSpec
+
+mc_pipeline = PipelineSpec(
+    nodes=[
+        NodeSpec(
+            id="sim",
+            step_type="simulation",
+            name="DGP Simulation",
+            params={"T": 100},
+        ),
+        NodeSpec(
+            id="jb",
+            step_type="jarque_bera",
+            name="Normality Check",
+            params={"source": "observables"},
+        ),
+    ],
+    edges=[EdgeSpec(source="sim", target="jb")], # (1)!
+)
+```
+
+1. Edges describe the directed graph of step dependencies. See the [Monte Carlo Guide](monte_carlo_guide.md) for the full pipeline grammar.
+
+???+ note "Attaching a completed MC run"
+    If you already have an `MCPipelineResult` from a live run, pass it as `result=` to `add_mc(...)` below. `BundleBuilder` splits the trace-free document from the bulk traces internally — no manual unpacking required.
+
+## Specify a simulation prefill
+
+`SimSpec` rides inline in the manifest. It controls what the GUI's Outputs tab pre-fills when the receiver opens the bundle.
+
+```python
+from SymbolicDSGE.bundle import ShockGeneration, SimSpec
+
+simulation = SimSpec(
+    role="reference",
+    T=25,
+    observables=True,
+    shock_scale=1.0,
+    shock_generation=ShockGeneration(
+        dist="norm",
+        seed=42, # (1)!
+        loc=0.0,
+    ),
+)
+```
+
+1. The seed makes the replayed simulation deterministic — both the bundle author and the receiver produce identical paths when clicking **Run**.
+
+## Assemble and write
+
+`BundleBuilder` chains every component into one archive. Each `add_*` call returns `self`; the final `.write(path)` materializes the bundle and returns the path written.
+
+```python
+from SymbolicDSGE import BundleBuilder
+
+bundle_path = (
+    BundleBuilder(created_by="experiment-1") # (1)!
+    .add_model(
+        "reference",
+        model.source_yaml, # (2)!
+        compile_kwargs={"linearize": False},
+    )
+    .add_estimation(
+        estimation_spec,
+        result=estimation_result_meta,
+        observed=observed,
+        observable_names=["Infl", "Rate"], # (3)!
+    )
+    .add_mc(mc_pipeline)
+    .set_simulation(simulation)
+    .write("experiment-1.sdsge")
+)
+
+print("Bundle written to:", bundle_path)
+```
+
+1. `created_by` is purely metadata recorded in the manifest. Defaults to `"SymbolicDSGE <version>"` when omitted.
+2. `model.source_yaml` is the YAML text retained on the `ModelConfig` by `ModelParser`. For programmatically constructed configs you would supply the YAML as a string here directly.
+3. The names must match the model's `observables` in count and order — the loader validates this at compile time and refuses to write a mismatched bundle.
+
+???+ warning "Observable name validation"
+    Order is significant. `["Rate", "Infl"]` is rejected even if `["Infl", "Rate"]` would have been accepted — the bundle's downstream consumers index observed data by column position, so reordering would silently produce wrong inference. See the [`sdsge-compile` validation reference](../portable_experiments/sdsge-compile.md#validation) for the message format.
+
+## Add raw data alongside the model
+
+`add_raw_data` covers any extra CSV files you want to ship in `data/`. They are not interpreted by the loader — they are passthrough storage for context the receiver may want.
+
+```python
+import io
+import pandas as pd
+
+aux = pd.DataFrame({
+    "date": pd.date_range("2000-01-01", periods=40, freq="Q"),
+    "gdp_growth": rng.standard_normal(40),
+})
+csv_buffer = io.StringIO()
+aux.to_csv(csv_buffer, index=False)
+
+BundleBuilder() \
+    .add_model("reference", model.source_yaml) \
+    .add_raw_data("auxiliary_series", csv_buffer.getvalue()) \
+    .write("with-raw-data.sdsge")
+```
+
+???+ info "CSV vs Parquet for raw data"
+    `add_raw_data` re-encodes CSV input as Parquet by default. Pass `as_parquet=False` to embed the CSV verbatim — useful for hand-zip-friendly bundles.
+
+## Inspect the result
+
+The bundle is a zip — every member is human-inspectable.
+
+```bash
+unzip -l experiment-1.sdsge
+```
+
+```text
+Archive:  experiment-1.sdsge
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     ...    ...        ...    manifest.json
+     ...    ...        ...    model/reference.yaml
+     ...    ...        ...    estimation/spec.json
+     ...    ...        ...    estimation/result.json
+     ...    ...        ...    estimation/observed.parquet
+     ...    ...        ...    montecarlo/pipeline.json
+```
+
+For a structured view, decompile it:
+
+```bash
+sdsge-decompile experiment-1.sdsge -o experiment-1/
+```
+
+Or open it directly in Python — see the [Bundle Loading Guide](bundle_loading_guide.md).
+
+## Further steps
+
+- [`sdsge-compile`](../portable_experiments/sdsge-compile.md) — the directory-driven CLI equivalent.
+- [`SolvedModel.save_sdsge`](../documentation/SolvedModel.md) — one-shot bundle write for the model-only case.
+- [`SolvedModel.to_bundle_builder`](../documentation/SolvedModel.md) — pre-seeded builder factory, equivalent to the chain in this guide.
+- [`BundleBuilder` API reference](../documentation/bundle/BundleBuilder.md).

--- a/docs/guides/bundle_loading_guide.md
+++ b/docs/guides/bundle_loading_guide.md
@@ -1,0 +1,187 @@
+---
+tags:
+    - guide
+---
+
+# Bundle Loading Guide
+
+This guide walks through opening a `.sdsge` bundle and reaching each library object it carries — the re-solved `SolvedModel`s, the estimation spec / result / observed data / posterior, the Monte Carlo pipeline / result / traces, and the simulation prefill.
+
+We use `experiment-1.sdsge` as produced by the [Bundle Authoring Guide](bundle_authoring_guide.md). Substitute any other bundle path.
+
+???+ tip "What `load_bundle` actually does"
+    `load_bundle` re-parses every embedded YAML, re-runs `DSGESolver.compile(**compile_kwargs).solve(**solve_kwargs)` with the kwargs recorded at write time, and decodes every tabular member by `Member.format` (CSV or Parquet). Loading is deterministic — the resulting policy matrices match those the author had in hand.
+
+## Open the bundle
+
+```python
+from SymbolicDSGE import load_bundle
+
+loaded = load_bundle("experiment-1.sdsge") # (1)!
+```
+
+1. `load_bundle` is a top-level re-export of `SymbolicDSGE.bundle.build_from`. Both names are interchangeable.
+
+`loaded` is a [`LoadedBundle`](../documentation/bundle/LoadedBundle.md) — every component is reachable through a typed field.
+
+```python
+print("Created by:", loaded.manifest.created_by)
+print("Created at:", loaded.manifest.created_at)
+print("Format version:", loaded.manifest.sdsge_version)
+```
+
+???+ info "Manifest provenance"
+    `Manifest.checksums` carries SHA-256 hex digests over each member's bytes — useful for integrity checks before trusting the contents downstream.
+
+## Reach the re-solved models
+
+`reference` and `dgp` are full `SolvedModel` instances. They behave exactly like models you would have solved in-process — including IRFs, simulation, and Kalman filtering.
+
+```python
+reference = loaded.reference
+if reference is not None:
+    print("Stable:", reference.policy.stab == 0)
+    print("Eigenvalues:", reference.policy.eig)
+    print("A shape:", reference.A.shape)
+```
+
+A quick deterministic simulation against pre-generated shocks confirms the policy round-tripped:
+
+```python
+import numpy as np
+
+T = 20
+rng = np.random.default_rng(42)
+shocks = {
+    "g,z": rng.standard_normal((T, 2)), # (1)!
+}
+sim = reference.sim(
+    T=T,
+    shocks=shocks,
+    observables=True,
+)
+print(sim["Infl"][:5])
+```
+
+1. See [`SolvedModel.sim`](../documentation/SolvedModel.md) for the shock specification grammar.
+
+???+ note "DGP slot may be absent"
+    `loaded.dgp` is `None` whenever the bundle did not carry a `dgp.yaml`. Test before use.
+
+## Reach the estimation tab
+
+`LoadedEstimation` carries every text and bulk component of the estimation run.
+
+```python
+estimation = loaded.estimation
+
+if estimation is not None:
+    print("Method:", estimation.spec.method) # (1)!
+    print("Observables:", estimation.spec.observables)
+    print("Parameters:", [p.name for p in estimation.spec.parameters])
+```
+
+1. `estimation.spec` is an [`EstimationSpec`](../documentation/bundle/index.md#estimation-result-metadata) instance — round-trippable to / from JSON via `to_dict()` / `from_dict()`.
+
+The result metadata discriminates by type. For MLE / MAP runs the result is an `OptimizationResultMeta`; for MCMC it is an `MCMCResultMeta` paired with bulk traces in `estimation.posterior`.
+
+```python
+from SymbolicDSGE.estimation.spec import (
+    MCMCResultMeta,
+    OptimizationResultMeta,
+)
+
+result = estimation.result
+if isinstance(result, OptimizationResultMeta):
+    print("Point estimate:", result.theta)
+    print("Log-posterior:", result.logpost)
+elif isinstance(result, MCMCResultMeta):
+    print("Acceptance:", result.accept_rate)
+    print("Draws:", result.n_draws, "burn-in:", result.burn_in)
+```
+
+Observed data and (when present) MCMC posterior are numpy arrays decoded from the embedded CSV or Parquet member.
+
+```python
+if estimation.observed is not None:
+    print("Observed shape:", estimation.observed.shape) # (1)!
+if estimation.posterior is not None:
+    samples = estimation.posterior["samples"] # (2)!
+    print("Posterior mean:", samples.mean(axis=0))
+```
+
+1. Shape is `(n_periods, n_observables)` with column order matching `estimation.spec.observables`.
+2. Pair with `result.param_names` for column-to-parameter mapping. The `logpost` key holds the 1-D log-posterior trace.
+
+???+ warning "MCMCResult reconstruction"
+    `MCMCResultMeta` carries the scalar slice only. To rebuild a live `MCMCResult` for sampling diagnostics, construct it explicitly:
+
+    ```python
+    from SymbolicDSGE.estimation.results import MCMCResult
+
+    mcmc = MCMCResult(
+        param_names=result.param_names,
+        samples=estimation.posterior["samples"],
+        logpost_trace=estimation.posterior["logpost"],
+        accept_rate=result.accept_rate,
+        n_draws=result.n_draws,
+        burn_in=result.burn_in,
+        thin=result.thin,
+    )
+    mcmc.hpd_intervals(alpha=0.05)
+    ```
+
+## Reach the Monte Carlo tab
+
+`LoadedMC.spec` is the [`PipelineSpec`](../documentation/monte_carlo/pipeline.md) describing the graph. When the bundle carries a completed run, `document` holds the trace-free summary and `traces` holds the bulk columns. The convenience method `wire()` re-merges them into the canonical UI shape.
+
+```python
+mc = loaded.mc
+
+if mc is not None:
+    print("Pipeline nodes:", [n.id for n in mc.spec.nodes])
+    print("Pipeline edges:", [(e.source, e.target) for e in mc.spec.edges])
+
+    if mc.document is not None:
+        wire = mc.wire() # (1)!
+        print("Run kind:", wire["kind"])
+```
+
+1. `mc.wire()` returns `None` when either `document` or `traces` is missing — a bundle authored with only the pipeline spec carries neither.
+
+???+ info "Re-running a loaded pipeline"
+    To re-run the pipeline against the loaded models, build an `MCPipeline` via `build_pipeline(loaded.mc.spec, dgp=loaded.dgp)` and call `pipeline.run(...)`. See the [Monte Carlo Guide](monte_carlo_guide.md).
+
+## Reach the simulation prefill
+
+The `SimSpec` rides inline in the manifest, so it is reachable from `loaded.simulation` directly (no separate member).
+
+```python
+sim_spec = loaded.simulation
+
+if sim_spec is not None:
+    print("T:", sim_spec.T)
+    print("Observables flag:", sim_spec.observables)
+    if sim_spec.shock_generation is not None:
+        print("Seed:", sim_spec.shock_generation.seed)
+        print("Distribution:", sim_spec.shock_generation.dist)
+```
+
+???+ note "Determinism"
+    Replaying `sim_spec` against `loaded.reference` reproduces the author's intended simulation exactly. The bundle stores no simulation outputs — they are reconstructed on demand from `(SolvedModel, seed, shock spec)`.
+
+## Round-trip safety
+
+Two properties to rely on after `load_bundle`:
+
+1. **Manifest integrity**: every member declared in the manifest is present in the archive (and vice versa). `BundleArchive.open` validates this on read and raises if the bundle is malformed.
+2. **Format-version compatibility**: a newer-than-supported bundle raises immediately with a clear message. Older bundles read forward without intervention.
+
+???+ warning "Reproducing simulations across machines"
+    Deterministic reproduction requires the receiver run the same numpy / SciPy versions on the same platform. The bundle does not pin those — record them externally if exact reproducibility across heterogeneous environments matters.
+
+## Further steps
+
+- [`sdsge-decompile`](../portable_experiments/sdsge-decompile.md) — extract the same components to disk for inspection or editing.
+- [`LoadedBundle` API reference](../documentation/bundle/LoadedBundle.md).
+- [Bundle Authoring Guide](bundle_authoring_guide.md) — the other half of the round-trip.

--- a/docs/portable_experiments/index.md
+++ b/docs/portable_experiments/index.md
@@ -1,0 +1,52 @@
+---
+tags:
+    - guide
+---
+
+# Portable Experiments
+
+A `.sdsge` file packages everything needed to reopen a model in the GUI or recover its components in code — model and Kalman configuration, estimation spec + results, Monte Carlo pipeline + traces, observed data, and a simulation prefill — into a single shareable archive. The file is a zip with a versioned manifest (`manifest.json`) and an aliased extension; nothing about reading or writing it requires a custom tool beyond the bundled CLIs.
+
+The container exists so a non-coding collaborator can run an experiment by opening one file, and so a coding collaborator can reach every component the bundle carries without re-deriving them.
+
+## What lives in a bundle
+
+| Component | Format | Source |
+| --- | --- | --- |
+| Model config | YAML | `ModelParser` source (path or string) |
+| Estimation spec | JSON | `EstimationSpec.to_json()` |
+| Estimation result metadata | JSON | `OptimizationResultMeta` / `MCMCResultMeta` |
+| Observed data | CSV or Parquet | Author-supplied or `Estimator` inputs |
+| MCMC posterior | CSV or Parquet | `MCMCResult.samples` + `logpost_trace` |
+| Monte Carlo pipeline | JSON | `PipelineSpec.to_json()` |
+| Monte Carlo result + traces | JSON + CSV/Parquet | `MCPipelineResult` |
+| Simulation prefill | Inline (manifest) | `SimSpec` |
+
+???+ note "Authoring formats"
+    Bulk numeric members are written as Parquet by default for size. CSV authoring is also supported — `sdsge-compile --csv-only` keeps everything as CSV, and `sdsge-decompile --csv` re-encodes Parquet members back to CSV. The reader is format-agnostic: a hand-zipped CSV-only bundle and a CLI-built Parquet bundle both validate.
+
+## Entry points
+
+There are three ways to produce or consume a `.sdsge`:
+
+- **Command line** — [`sdsge-compile`](sdsge-compile.md) walks a directory layout and assembles a bundle; [`sdsge-decompile`](sdsge-decompile.md) extracts a bundle into a re-compilable directory.
+- **In-code** — [`SolvedModel.save_sdsge()`](../documentation/SolvedModel.md) and [`SymbolicDSGE.load_bundle()`](../documentation/bundle/index.md) handle the round-trip from Python; the [Authoring](../guides/bundle_authoring_guide.md) and [Loading](../guides/bundle_loading_guide.md) guides walk through both.
+- **GUI** — passing a `.sdsge` to [`sdsge-ui`](../gui_usage/index.md) launches the playground with every tab pre-populated.
+
+???+ info "When to author from code vs from a directory"
+    Author from code when the bundle is the output of a Python workflow (you already have a `SolvedModel`, an `MCPipelineResult`, etc.). Author from a directory when the bundle is composed by hand or by a non-Python tool — drop CSVs / YAMLs / JSONs into the conventional layout and call `sdsge-compile`.
+
+## Determinism
+
+The bundle stores simulation specs and a seed, not simulation results — `Run` on the receiver's side reproduces the author's intended simulation deterministically (numpy `PCG64` + fixed seed). Re-solving the embedded YAML at load time is also deterministic, so the receiver's policy matrices match the author's.
+
+???+ warning "Source YAML embedding"
+    `SolvedModel.save_sdsge()` requires a source YAML — populated automatically when the model was loaded via `ModelParser(path)` or `ModelParser.from_string(text)`. Programmatically constructed `ModelConfig` instances need `yaml_text=` passed explicitly.
+
+## Where to next
+
+- [`sdsge-compile`](sdsge-compile.md): CLI reference for directory → `.sdsge`.
+- [`sdsge-decompile`](sdsge-decompile.md): CLI reference for `.sdsge` → directory.
+- [Bundle Authoring Guide](../guides/bundle_authoring_guide.md): assemble a full bundle in code.
+- [Bundle Loading Guide](../guides/bundle_loading_guide.md): open a bundle and reach each library object.
+- [`bundle` API reference](../documentation/bundle/index.md): class- and function-level documentation.

--- a/docs/portable_experiments/sdsge-compile.md
+++ b/docs/portable_experiments/sdsge-compile.md
@@ -1,0 +1,126 @@
+---
+tags:
+    - guide
+---
+
+# `sdsge-compile`
+
+`sdsge-compile` assembles a `.sdsge` bundle from a conventional directory layout. The layout is auto-detected — no separate manifest file is required to drive the compile.
+
+```bash
+sdsge-compile <source-directory> [-o OUTPUT] [--csv-only] [--created-by NAME]
+```
+
+## Directory layout
+
+A bundle source directory has at least one model YAML at its root. Every other entry is optional.
+
+```text
+my-experiment/
+├── reference.yaml                # required (or dgp.yaml, or both)
+├── reference.options.json        # optional: compile_kwargs / solve_kwargs
+├── dgp.yaml                      # optional
+├── dgp.options.json              # optional
+├── estimation/
+│   ├── spec.json                 # required if estimation/ is present
+│   ├── result.json               # optional result metadata
+│   ├── observed.csv|.parquet     # optional observed data
+│   └── posterior.csv|.parquet    # optional MCMC posterior traces
+├── montecarlo/
+│   ├── pipeline.json             # required if montecarlo/ is present
+│   ├── result.json               # optional run document (trace-free)
+│   └── traces.csv|.parquet       # optional run traces
+├── simulation.json               # optional simulation prefill
+└── data/
+    └── *.csv|*.parquet           # optional raw data members
+```
+
+???+ note "Model role files"
+    `reference.yaml` is the main model. `dgp.yaml` is only required when the bundle ships a Monte Carlo pipeline that needs a data-generating process. At least one of the two must be present.
+
+???+ info "Options sidecars"
+    `<role>.options.json` carries the `compile_kwargs` and `solve_kwargs` the loader will use to rebuild the `SolvedModel`. The file is a JSON object:
+
+    ```json
+    {
+        "compile_kwargs": {"n_state": 3, "n_exog": 2},
+        "solve_kwargs": {}
+    }
+    ```
+
+    Both keys are optional; an absent file is equivalent to empty kwargs.
+
+## Arguments
+
+| Argument | Description |
+| --- | --- |
+| `source` | Directory containing the bundle members. |
+| `-o`, `--output` | Output `.sdsge` path. Defaults to `<source>.sdsge` next to the source directory. |
+| `--csv-only` | Keep CSV bulk members as CSV instead of converting to Parquet. The reader is format-agnostic, so the resulting bundle is still valid. |
+| `--created-by` | Override the manifest `created_by` field. Defaults to `"SymbolicDSGE <version>"`. |
+
+## Examples
+
+Compile with all defaults — Parquet conversion on, output alongside the directory.
+
+```bash
+sdsge-compile my-experiment/
+```
+
+CSV-only bundle for a hand-zip-friendly workflow:
+
+```bash
+sdsge-compile my-experiment/ --csv-only -o my-experiment.sdsge
+```
+
+## Validation
+
+`sdsge-compile` cross-checks observed-data columns against the model's declared observables. The check is **strict on order** because downstream consumers operate by column index. Three failure modes have dedicated messages:
+
+| Failure | Message excerpt | Remedy |
+| --- | --- | --- |
+| Numeric-looking headers | `inferred observable names look numeric; file may be missing a header row` | Add observable names as the first CSV row. |
+| Name mismatch | `columns [...] do not match model observables [...]. Rename columns to match (order matters).` | Rename CSV/Parquet columns to match the model. |
+| Count mismatch | `has K columns but model declares N observables` | Add or remove columns to match. |
+
+???+ warning "Order matters"
+    The observable-name validation enforces same names **and** same order — even sets that match cause failure if reordered. The bundle's consumers index observed data by position, so reordering would silently produce wrong results.
+
+## Member format inference
+
+The reader dispatches each member by file extension:
+
+| Extension | Format |
+| --- | --- |
+| `.yaml`, `.yml` | YAML |
+| `.json` | JSON |
+| `.csv` | CSV |
+| `.parquet` | Parquet |
+
+???+ note "Both formats present"
+    Authoring both `observed.csv` and `observed.parquet` (or any other CSV/Parquet pair) is rejected at compile time with `both ... and ... exist in <dir>; choose one`.
+
+## Embedding pre-computed result members
+
+`estimation/result.json` and `montecarlo/result.json` are embedded verbatim — they are code-generated artifacts. Their wire shape is:
+
+```json
+{
+    "type": "mcmc",
+    "data": {
+        "param_names": ["beta", "sigma"],
+        "accept_rate": 0.31,
+        "n_draws": 1000,
+        "burn_in": 100,
+        "thin": 2
+    }
+}
+```
+
+`type` discriminates `"mcmc"` from `"optimization"`; `data` is the result-metadata dataclass `to_dict()`. See [`MCMCResultMeta`](../documentation/bundle/index.md#estimation-result-metadata) and [`OptimizationResultMeta`](../documentation/bundle/index.md#estimation-result-metadata) for the field-level documentation.
+
+## See also
+
+- [`sdsge-decompile`](sdsge-decompile.md) — the inverse operation.
+- [Bundle Authoring Guide](../guides/bundle_authoring_guide.md) — assemble a bundle from code.
+- [`BundleBuilder`](../documentation/bundle/index.md#bundlebuilder) — the in-code equivalent of this CLI.

--- a/docs/portable_experiments/sdsge-decompile.md
+++ b/docs/portable_experiments/sdsge-decompile.md
@@ -1,0 +1,88 @@
+---
+tags:
+    - guide
+---
+
+# `sdsge-decompile`
+
+`sdsge-decompile` extracts a `.sdsge` bundle into a directory. The output layout matches the [`sdsge-compile`](sdsge-compile.md) input convention, so the result can be edited and recompiled into an equivalent bundle.
+
+```bash
+sdsge-decompile <bundle> [-o OUTPUT] [--csv] [--force]
+```
+
+## Arguments
+
+| Argument | Description |
+| --- | --- |
+| `bundle` | `.sdsge` file to extract. |
+| `-o`, `--output` | Output directory. Defaults to `<bundle-stem>/` next to the file. |
+| `--csv` | Re-encode Parquet members as CSV in the output (useful for editing). |
+| `--force` | Overwrite the output directory if it already exists. Without this flag an existing directory raises `FileExistsError`. |
+
+## Examples
+
+Extract verbatim — Parquet members stay Parquet:
+
+```bash
+sdsge-decompile my-experiment.sdsge
+```
+
+Decompile for editing — Parquet members are re-encoded as CSV:
+
+```bash
+sdsge-decompile my-experiment.sdsge --csv -o my-experiment/
+```
+
+## What lands where
+
+The extractor writes each member at its compile-input authoring path, not at its archive path. For most kinds these match; the one exception is `model_config`:
+
+| Member kind | Archive path | Extracted path |
+| --- | --- | --- |
+| `model_config` (role=reference) | `model/reference.yaml` | `reference.yaml` |
+| `model_config` (role=dgp) | `model/dgp.yaml` | `dgp.yaml` |
+| `estimation_*` | `estimation/...` | `estimation/...` |
+| `mc_*` | `montecarlo/...` | `montecarlo/...` |
+| `raw_data` | `data/...` | `data/...` |
+| Simulation prefill (inline in manifest) | — | `simulation.json` |
+
+???+ info "Options sidecars"
+    Model `Member.options` (e.g. `compile_kwargs`/`solve_kwargs`) are extracted to `<role>.options.json` at the directory root. The compile entry point reads these sidecars on recompile, so the round-trip preserves them.
+
+???+ note "Inline simulation prefill"
+    The `SimSpec` rides inline in the manifest (it has no member of its own). On decompile it is written to `simulation.json` at the root so the recompile picks it up via the standard directory layout.
+
+## `--csv` re-encoding
+
+With `--csv`, every Parquet member is decoded to CSV. The extension and `manifest.json` `format` field are rewritten to reflect the new layout.
+
+| Member | CSV header strategy |
+| --- | --- |
+| `estimation_data` | Observable names from `Member.columns` (semantic headers — user-friendly). |
+| `estimation_trace` | Mechanical `{name}.{j}` expansion from `trace_to_csv`. |
+| `mc_trace` | Same mechanical expansion. |
+| `raw_data` | Existing column names from the Parquet schema. |
+
+???+ warning "Checksum field on decompile"
+    The `manifest.json` written by `sdsge-decompile` omits checksums. They were SHA-256 over the archive bytes; after extraction (and especially after `--csv` re-encoding) those bytes change. A subsequent `sdsge-compile` recomputes them. Treat the decompiled `manifest.json` as informational, not as a re-compile input — the compile pass auto-detects the layout.
+
+## Round-trip
+
+`compile → decompile [--csv] → edit → compile` produces a bundle equivalent on every reconstructable component:
+
+```bash
+sdsge-compile my-experiment/                  # → my-experiment.sdsge
+sdsge-decompile my-experiment.sdsge --csv     # → my-experiment/ (editable)
+# ... edit reference.yaml, observed.csv, estimation/spec.json, etc.
+sdsge-compile my-experiment/                  # → updated my-experiment.sdsge
+```
+
+???+ info "What is preserved across the round-trip"
+    Model YAML, estimation spec/result, observed data, MCMC posterior, MC pipeline/result, simulation prefill, model options (compile/solve kwargs). The `created_by` and `created_at` fields are regenerated on each compile.
+
+## See also
+
+- [`sdsge-compile`](sdsge-compile.md) — the inverse operation.
+- [Bundle Loading Guide](../guides/bundle_loading_guide.md) — read a `.sdsge` from code instead.
+- [`load_bundle`](../documentation/bundle/index.md#load_bundle) — the in-code equivalent of this CLI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,12 +157,18 @@ nav:
       - Outputs: gui_usage/outputs.md
       - Estimation: gui_usage/estimation.md
       - MC Pipeline: gui_usage/monte_carlo.md
+  - Portable Experiments:
+      - Overview: portable_experiments/index.md
+      - sdsge-compile: portable_experiments/sdsge-compile.md
+      - sdsge-decompile: portable_experiments/sdsge-decompile.md
   - Guides:
       - Model Configuration Guide: guides/model_config_guide.md
       - Quick Start: guides/quickstart.md
       - Kalman Filter Configuration Guide: guides/kalman_config_guide.md
       - Estimation Guide: guides/estimation_guide.md
       - Monte Carlo Guide: guides/monte_carlo_guide.md
+      - Bundle Authoring Guide: guides/bundle_authoring_guide.md
+      - Bundle Loading Guide: guides/bundle_loading_guide.md
   - Documentation:
       - ModelConfig: documentation/ModelConfig.md
       - ModelParser: documentation/ModelParser.md
@@ -180,6 +186,12 @@ nav:
           - Ridge: documentation/regression/ridge.md
           - Lasso: documentation/regression/lasso.md
           - Elastic Net: documentation/regression/elastic_net.md
+      - Bundle:
+          - Overview: documentation/bundle/index.md
+          - BundleBuilder: documentation/bundle/BundleBuilder.md
+          - LoadedBundle: documentation/bundle/LoadedBundle.md
+          - Manifest: documentation/bundle/Manifest.md
+          - load_bundle: documentation/bundle/load_bundle.md
       - Monte Carlo:
           - Overview: documentation/monte_carlo/index.md
           - MCPipeline: documentation/monte_carlo/pipeline.md


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the new `.sdsge` bundle format in the `SymbolicDSGE` library. It adds detailed guides and API references for creating, using, and understanding portable model bundles, including their structure, usage patterns, and conventions. The documentation covers the main bundle-building and loading classes, the manifest schema, and all major methods and fields, making it much easier for users to author, share, and consume model archives.

The most important changes are:

**Bundle authoring and usage documentation:**
- Added a complete API reference for the `BundleBuilder` class, detailing its constructor, all `add_*` methods, and usage examples for assembling `.sdsge` archives in code.
- Documented the `SolvedModel.save_sdsge` and `SolvedModel.to_bundle_builder` methods, describing how to wrap models into bundles and chain additional components.

**Bundle loading and manifest structure:**
- Added documentation for the `LoadedBundle` class, including its fields for all possible bundle components and detailed notes on how models, estimation, and Monte Carlo results are reconstructed on load.
- Provided a full schema and explanation for the `Manifest` and `Member` classes, including recognized member kinds, compatibility notes, and examples.

**Overview and conventions:**
- Introduced a new `bundle/index.md` file summarizing the bundle module, its top-level classes/functions, estimation result metadata, and format conventions for portability and reproducibility.

closes #153 
closes #144 