### PR TITLE
Add bundle demo notebooks and TL;DR tips

### DIFF
--- a/docs/assets/bundle_authoring.ipynb
+++ b/docs/assets/bundle_authoring.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0b74ae98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from SymbolicDSGE import DSGESolver, ModelParser\n",
+    "from SymbolicDSGE.estimation.spec import (\n",
+    "    EstimationParameterSpec,\n",
+    "    EstimationSpec,\n",
+    "    OptimizationResultMeta,\n",
+    "    PriorSpec,\n",
+    ")\n",
+    "from SymbolicDSGE.monte_carlo.spec import EdgeSpec, NodeSpec, PipelineSpec\n",
+    "from SymbolicDSGE.bundle import ShockGeneration, SimSpec\n",
+    "from SymbolicDSGE import BundleBuilder\n",
+    "import numpy as np\n",
+    "from numpy import array, float64\n",
+    "\n",
+    "import io\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d334e391",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parser = ModelParser(\"../../MODELS/POST82.yaml\")\n",
+    "model, kalman = parser.get_all()\n",
+    "\n",
+    "solver = DSGESolver(model, kalman)\n",
+    "compiled = solver.compile(\n",
+    "    linearize=False,\n",
+    ")\n",
+    "sol = solver.solve(\n",
+    "    compiled,\n",
+    "    steady_state=array([0.0, 0.0, 0.0, 0.0, 0.0], dtype=float64),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6252c452",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimation_spec = EstimationSpec(\n",
+    "    method=\"map\",\n",
+    "    parameters=[\n",
+    "        EstimationParameterSpec(\n",
+    "            name=\"psi_pi\",\n",
+    "            initial=1.5,\n",
+    "            estimate=True,\n",
+    "            lower=1.0,\n",
+    "            upper=3.0,\n",
+    "            prior=PriorSpec(\n",
+    "                distribution=\"normal\",\n",
+    "                parameters={\"loc\": 1.5, \"scale\": 0.25},\n",
+    "            ),\n",
+    "        ),\n",
+    "        EstimationParameterSpec(\n",
+    "            name=\"psi_x\",\n",
+    "            initial=0.5,\n",
+    "            estimate=True,\n",
+    "            lower=0.0,\n",
+    "            upper=1.0,\n",
+    "            prior=PriorSpec(\n",
+    "                distribution=\"normal\",\n",
+    "                parameters={\"loc\": 0.5, \"scale\": 0.2},\n",
+    "            ),\n",
+    "        ),\n",
+    "    ],\n",
+    "    observables=[\"Infl\", \"Rate\"],\n",
+    "    method_kwargs={\"options\": {\"maxiter\": 50}},\n",
+    ")\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "observed = rng.standard_normal((40, 2))\n",
+    "estimation_result_meta = OptimizationResultMeta(\n",
+    "    kind=\"map\",\n",
+    "    theta={\"psi_pi\": 1.48, \"psi_x\": 0.55},\n",
+    "    success=True,\n",
+    "    message=\"Optimization converged.\",\n",
+    "    fun=-87.3,\n",
+    "    loglik=-85.1,\n",
+    "    logprior=-2.2,\n",
+    "    logpost=-87.3,\n",
+    "    nfev=124,\n",
+    "    nit=14,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e83ae2c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mc_pipeline = PipelineSpec(\n",
+    "    nodes=[\n",
+    "        NodeSpec(\n",
+    "            id=\"sim\",\n",
+    "            step_type=\"simulation\",\n",
+    "            name=\"DGP Simulation\",\n",
+    "            params={\"T\": 100},\n",
+    "        ),\n",
+    "        NodeSpec(\n",
+    "            id=\"jb\",\n",
+    "            step_type=\"jarque_bera\",\n",
+    "            name=\"Normality Check\",\n",
+    "            params={\"source\": \"observables\"},\n",
+    "        ),\n",
+    "    ],\n",
+    "    edges=[EdgeSpec(source=\"sim\", target=\"jb\")],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9565f739",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simulation = SimSpec(\n",
+    "    role=\"reference\",\n",
+    "    T=25,\n",
+    "    observables=True,\n",
+    "    shock_scale=1.0,\n",
+    "    shock_generation=ShockGeneration(\n",
+    "        dist=\"norm\",\n",
+    "        seed=42,\n",
+    "        loc=0.0,\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2baaf3a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bundle written to: experiment-1.sdsge\n"
+     ]
+    }
+   ],
+   "source": [
+    "bundle_path = (\n",
+    "    BundleBuilder(created_by=\"experiment-1\")  # (1)!\n",
+    "    .add_model(\n",
+    "        \"reference\",\n",
+    "        model.source_yaml,  # (2)!\n",
+    "        compile_kwargs={\"linearize\": False},\n",
+    "    )\n",
+    "    .add_estimation(\n",
+    "        estimation_spec,\n",
+    "        result=estimation_result_meta,\n",
+    "        observed=observed,\n",
+    "        observable_names=[\"Infl\", \"Rate\"],  # (3)!\n",
+    "    )\n",
+    "    .add_mc(mc_pipeline)\n",
+    "    .set_simulation(simulation)\n",
+    "    .write(\"experiment-1.sdsge\")\n",
+    ")\n",
+    "\n",
+    "print(\"Bundle written to:\", bundle_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5c23e7c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('with-raw-data.sdsge')"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "aux = pd.DataFrame(\n",
+    "    {\n",
+    "        \"date\": pd.date_range(\"2000-01-01\", periods=40, freq=\"QS\"),\n",
+    "        \"gdp_growth\": rng.standard_normal(40),\n",
+    "    }\n",
+    ")\n",
+    "csv_buffer = io.StringIO()\n",
+    "aux.to_csv(csv_buffer, index=False)\n",
+    "\n",
+    "BundleBuilder().add_model(\"reference\", model.source_yaml).add_raw_data(\n",
+    "    \"auxiliary_series\", csv_buffer.getvalue()\n",
+    ").write(\"with-raw-data.sdsge\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f9065186",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Archive:  experiment-1.sdsge\n",
+      "  Length      Date    Time    Name\n",
+      "---------  ---------- -----   ----\n",
+      "     1627  13-06-2026 12:29   manifest.json\n",
+      "     2599  13-06-2026 12:29   model/reference.yaml\n",
+      "      864  13-06-2026 12:29   estimation/spec.json\n",
+      "      305  13-06-2026 12:29   estimation/result.json\n",
+      "     1380  13-06-2026 12:29   estimation/observed.parquet\n",
+      "      389  13-06-2026 12:29   montecarlo/pipeline.json\n",
+      "---------                     -------\n",
+      "     7164                     6 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "!unzip -l experiment-1.sdsge"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "symbolicdsge (3.13.9)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/assets/bundle_loading.ipynb
+++ b/docs/assets/bundle_loading.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d6289143",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from SymbolicDSGE import load_bundle\n",
+    "from SymbolicDSGE.estimation.spec import (\n",
+    "    MCMCResultMeta,\n",
+    "    OptimizationResultMeta,\n",
+    ")\n",
+    "from SymbolicDSGE.estimation.results import MCMCResult\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2ea4771",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded = load_bundle(\"experiment-1.sdsge\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2e9fdbf6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created by: experiment-1\n",
+      "Created at: 2026-06-13T10:29:08.789883+00:00\n",
+      "Format version: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Created by:\", loaded.manifest.created_by)\n",
+    "print(\"Created at:\", loaded.manifest.created_at)\n",
+    "print(\"Format version:\", loaded.manifest.sdsge_version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bce87cea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stable: True\n",
+      "Eigenvalues: [0.28018451+0.j 0.83      +0.j 0.85      +0.j 2.60451546+0.j\n",
+      " 1.18546572+0.j]\n",
+      "A shape: (5, 5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "reference = loaded.reference\n",
+    "if reference is not None:\n",
+    "    print(\"Stable:\", reference.policy.stab == 0)\n",
+    "    print(\"Eigenvalues:\", reference.policy.eig)\n",
+    "    print(\"A shape:\", reference.A.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "27fef774",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[  3.43         8.20387037  10.83531974 -12.17755328   0.91492503]\n"
+     ]
+    }
+   ],
+   "source": [
+    "T = 20\n",
+    "rng = np.random.default_rng(42)\n",
+    "shocks = {\n",
+    "    \"g,z\": rng.standard_normal((T, 2)),\n",
+    "}\n",
+    "sim = reference.sim(\n",
+    "    T=T,\n",
+    "    shocks=shocks,\n",
+    "    observables=True,\n",
+    ")\n",
+    "print(sim[\"Infl\"][:5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6075d011",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Method: map\n",
+      "Observables: ['Infl', 'Rate']\n",
+      "Parameters: ['psi_pi', 'psi_x']\n"
+     ]
+    }
+   ],
+   "source": [
+    "estimation = loaded.estimation\n",
+    "\n",
+    "if estimation is not None:\n",
+    "    print(\"Method:\", estimation.spec.method)\n",
+    "    print(\"Observables:\", estimation.spec.observables)\n",
+    "    print(\"Parameters:\", [p.name for p in estimation.spec.parameters])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "82ebc2b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Point estimate: {'psi_pi': 1.48, 'psi_x': 0.55}\n",
+      "Log-posterior: -87.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = estimation.result\n",
+    "if isinstance(result, OptimizationResultMeta):\n",
+    "    print(\"Point estimate:\", result.theta)\n",
+    "    print(\"Log-posterior:\", result.logpost)\n",
+    "elif isinstance(result, MCMCResultMeta):\n",
+    "    print(\"Acceptance:\", result.accept_rate)\n",
+    "    print(\"Draws:\", result.n_draws, \"burn-in:\", result.burn_in)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "02a36401",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Observed shape: (40, 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "if estimation.observed is not None:\n",
+    "    print(\"Observed shape:\", estimation.observed.shape)\n",
+    "if estimation.posterior is not None:\n",
+    "    samples = estimation.posterior[\"samples\"]\n",
+    "    print(\"Posterior mean:\", samples.mean(axis=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "712f157e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pipeline nodes: ['sim', 'jb']\n",
+      "Pipeline edges: [('sim', 'jb')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "mc = loaded.mc\n",
+    "\n",
+    "if mc is not None:\n",
+    "    print(\"Pipeline nodes:\", [n.id for n in mc.spec.nodes])\n",
+    "    print(\"Pipeline edges:\", [(e.source, e.target) for e in mc.spec.edges])\n",
+    "\n",
+    "    if mc.document is not None:\n",
+    "        wire = mc.wire()\n",
+    "        print(\"Run kind:\", wire[\"kind\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c14c3632",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T: 25\n",
+      "Observables flag: True\n",
+      "Seed: 42\n",
+      "Distribution: norm\n"
+     ]
+    }
+   ],
+   "source": [
+    "sim_spec = loaded.simulation\n",
+    "\n",
+    "if sim_spec is not None:\n",
+    "    print(\"T:\", sim_spec.T)\n",
+    "    print(\"Observables flag:\", sim_spec.observables)\n",
+    "    if sim_spec.shock_generation is not None:\n",
+    "        print(\"Seed:\", sim_spec.shock_generation.seed)\n",
+    "        print(\"Distribution:\", sim_spec.shock_generation.dist)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "symbolicdsge (3.13.9)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/guides/bundle_authoring_guide.md
+++ b/docs/guides/bundle_authoring_guide.md
@@ -5,6 +5,11 @@ tags:
 
 # Bundle Authoring Guide
 
+??? tip "__TL;DR__"
+    Assemble a complete `.sdsge` bundle from code with `BundleBuilder` — chain `add_model`, `add_estimation`, `add_mc`, `set_simulation`, and `add_raw_data`, then `.write(...)` the archive. Each member is optional, so the same builder covers a model-only bundle and a full experiment alike.
+
+    You can find a demonstration notebook [here](../assets/bundle_authoring.ipynb).
+
 This guide walks through assembling a complete `.sdsge` bundle from code — model + Kalman config, estimation spec and result, observed data, Monte Carlo pipeline and traces, simulation prefill. Every member type the bundle supports is covered.
 
 We start from `MODELS/POST82.yaml` (also used in the [Quick Start](quickstart.md)). The full assembly fits in a single script you can copy and run.
@@ -202,7 +207,7 @@ import io
 import pandas as pd
 
 aux = pd.DataFrame({
-    "date": pd.date_range("2000-01-01", periods=40, freq="Q"),
+    "date": pd.date_range("2000-01-01", periods=40, freq="QS"),
     "gdp_growth": rng.standard_normal(40),
 })
 csv_buffer = io.StringIO()

--- a/docs/guides/bundle_loading_guide.md
+++ b/docs/guides/bundle_loading_guide.md
@@ -5,6 +5,11 @@ tags:
 
 # Bundle Loading Guide
 
+??? tip "__TL;DR__"
+    Open a `.sdsge` bundle with `load_bundle(...)` and reach every component through the typed `LoadedBundle` fields — the re-solved `SolvedModel`s, the estimation spec / result / observed data / posterior, the Monte Carlo pipeline / result / traces, and the simulation prefill. Loading is deterministic: the policy matrices match the author's.
+
+    You can find a demonstration notebook [here](../assets/bundle_loading.ipynb).
+
 This guide walks through opening a `.sdsge` bundle and reaching each library object it carries — the re-solved `SolvedModel`s, the estimation spec / result / observed data / posterior, the Monte Carlo pipeline / result / traces, and the simulation prefill.
 
 We use `experiment-1.sdsge` as produced by the [Bundle Authoring Guide](bundle_authoring_guide.md). Substitute any other bundle path.


### PR DESCRIPTION
This pull request adds two new demonstration Jupyter notebooks showing how to author and load `.sdsge` bundles, and updates the corresponding guides with concise TL;DR tips and notebook links. It also fixes a minor frequency code in an example. These changes provide clear, runnable examples for users and improve the discoverability and clarity of the bundle authoring/loading workflow.

**Documentation improvements:**

* Added a new notebook, `docs/assets/bundle_authoring.ipynb`, demonstrating how to assemble a `.sdsge` bundle using `BundleBuilder`, including model, estimation, Monte Carlo pipeline, simulation, and raw data components.
* Added a new notebook, `docs/assets/bundle_loading.ipynb`, demonstrating how to load a `.sdsge` bundle with `load_bundle` and access its components (model, estimation results, MC pipeline, simulation, etc.).
* Updated `docs/guides/bundle_authoring_guide.md` and `docs/guides/bundle_loading_guide.md` to include TL;DR tips summarizing the workflow and links to the new demonstration notebooks for quick reference. [[1]](diffhunk://#diff-0072f8432e2e0ccb01de5712a248dce9464ad4daa7eac1532056a0b750f3da5cR8-R12) [[2]](diffhunk://#diff-46ade4b293a2013b7dea993598bc9023845dc5bf6ef342d132e44dec3a1c588fR8-R12)

**Example and code fixes:**

* Fixed the frequency string in the pandas `date_range` example from `"Q"` to `"QS"` in the bundle authoring guide for correctness and consistency with the notebook.