### PR TITLE
Implement POSTPROC support and artifact handling in MCPipeline

### DIFF
--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -18,6 +18,7 @@ from .catalog import (
 )
 from .core import MCPipeline
 from .custom_op import NumpyCustomFunc, custom_operation
+from .postproc import Raw, Summary
 from .mc_constructs import (
     MCContext,
     MCData,
@@ -41,6 +42,8 @@ __all__ = [
     "OpType",
     "custom_operation",
     "NumpyCustomFunc",
+    "Summary",
+    "Raw",
     # graph spec (serialization / bundle)
     "PipelineSpec",
     "NodeSpec",

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import cached_property
 from time import perf_counter
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 import numpy as np
 
@@ -27,6 +27,7 @@ from .mc_constructs import (
     report_mc_performance,
     report_mc_step_performance,
 )
+from .postproc import normalize_artifacts
 
 
 @dataclass(frozen=True)
@@ -103,12 +104,18 @@ class MCPipeline:
         step_counts: dict[str, int] = {step.name: 0 for step in self.steps}
         step_failures: dict[str, int] = {step.name: 0 for step in self.steps}
 
+        # POSTPROC ops don't run per replication — they run once after the loop,
+        # over the assembled across-rep traces.
+        postproc_steps = [s for s in self.steps if s.op_type is OpType.POSTPROC]
+        rep_steps = [s for s in self.steps if s.op_type is not OpType.POSTPROC]
+        payload_columns: dict[str, list[np.ndarray]] = {}
+
         run_start = perf_counter()
         for rep_idx in range(n_rep):
             context = MCContext(rep_idx=rep_idx, reference=reference, dgp=dgp)
             failed_step_name: str | None = None
             try:
-                for step in self.steps:
+                for step in rep_steps:
                     failed_step_name = step.name
                     step_start = perf_counter()
                     try:
@@ -141,9 +148,24 @@ class MCPipeline:
                 regression_results_by_step.setdefault(name, []).append(
                     regression_result
                 )
+            if postproc_steps:
+                _accumulate_payload_columns(payload_columns, context.payloads)
 
         test_summaries = _summarize_tests(results_by_step)
         regression_summaries = _summarize_regressions(regression_results_by_step)
+        postproc = self._run_postproc(
+            postproc_steps,
+            test_summaries=test_summaries,
+            regression_summaries=regression_summaries,
+            payload_columns=payload_columns,
+            reference=reference,
+            dgp=dgp,
+            fail_fast=fail_fast,
+            failures=failures,
+            step_elapsed_s=step_elapsed_s,
+            step_counts=step_counts,
+            step_failures=step_failures,
+        )
         elapsed_s = perf_counter() - run_start
         result = MCPipelineResult(
             n_rep=n_rep,
@@ -162,6 +184,7 @@ class MCPipeline:
             step_elapsed_s=step_elapsed_s,
             step_counts=step_counts,
             step_failures=step_failures,
+            postproc=postproc,
         )
         if verbosity == 1:
             report_mc_performance(result)
@@ -210,6 +233,107 @@ class MCPipeline:
                 raise TypeError("TEST steps must return TestResult.")
             context.results[step.name] = out
         context.payloads[step.output_key] = out
+
+    def _run_postproc(
+        self,
+        postproc_steps: Sequence[MCStep],
+        *,
+        test_summaries: Mapping[str, Any],
+        regression_summaries: Mapping[str, Any],
+        payload_columns: Mapping[str, list[np.ndarray]],
+        reference: SolvedModel,
+        dgp: SolvedModel | None,
+        fail_fast: bool,
+        failures: list[MCFailure],
+        step_elapsed_s: dict[str, float],
+        step_counts: dict[str, int],
+        step_failures: dict[str, int],
+    ) -> dict[str, Any]:
+        """Run POSTPROC ops once over the assembled traces; collect artifacts.
+
+        ``traces`` carries every keyed across-rep ndarray — the test/regression
+        summary traces (shared with the result wire) plus stacked transform
+        payloads. A failing op honors ``fail_fast`` (re-raise) or records an
+        :class:`MCFailure` with ``rep_idx=-1`` (post-loop sentinel) and is skipped.
+        """
+        if not postproc_steps:
+            return {}
+
+        from .serialize import traces_from_summaries
+
+        traces: dict[str, np.ndarray] = traces_from_summaries(
+            test_summaries, regression_summaries
+        )
+        traces.update(_stack_payload_columns(payload_columns))
+
+        postproc: dict[str, Any] = {}
+        for step in postproc_steps:
+            step_start = perf_counter()
+            out: Any = None
+            failed = False
+            try:
+                out = step.func(
+                    reference=reference,
+                    dgp=dgp,
+                    traces=traces,
+                    **dict(step.kwargs),
+                )
+            except Exception as exc:
+                failed = True
+                step_failures[step.name] += 1
+                if fail_fast:
+                    raise
+                failures.append(
+                    MCFailure(
+                        rep_idx=-1,
+                        step_name=step.name,
+                        error_type=type(exc).__name__,
+                        message=str(exc),
+                    )
+                )
+            finally:
+                step_elapsed_s[step.name] += perf_counter() - step_start
+                step_counts[step.name] += 1
+            if not failed:
+                postproc.update(normalize_artifacts(out, step.name))
+        return postproc
+
+
+def _payload_to_array(value: object) -> np.ndarray | None:
+    """A per-rep payload value as a stackable numeric array, else ``None``.
+
+    Only numeric ndarray / scalar payloads (e.g. transform outputs) qualify;
+    structured payloads (``MCData`` / ``FilterResult`` / result objects) are
+    skipped from the post-loop trace registry.
+    """
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, (int, float, np.number)):
+        return np.asarray(value, dtype=np.float64)
+    return None
+
+
+def _accumulate_payload_columns(
+    columns: dict[str, list[np.ndarray]], payloads: Mapping[str, object]
+) -> None:
+    for key, value in payloads.items():
+        array = _payload_to_array(value)
+        if array is not None:
+            columns.setdefault(key, []).append(array)
+
+
+def _stack_payload_columns(
+    columns: Mapping[str, list[np.ndarray]],
+) -> dict[str, np.ndarray]:
+    """Stack per-rep payload arrays into ``payload.<name>`` traces.
+
+    Only keys whose per-rep arrays share a shape across replications are stacked
+    (a transform whose output length varies per rep is skipped)."""
+    out: dict[str, np.ndarray] = {}
+    for name, arrays in columns.items():
+        if arrays and len({array.shape for array in arrays}) == 1:
+            out[f"payload.{name}"] = np.stack(arrays)
+    return out
 
 
 def _df_metadata_matches(a: object, b: object) -> bool:

--- a/SymbolicDSGE/monte_carlo/graph.py
+++ b/SymbolicDSGE/monte_carlo/graph.py
@@ -171,6 +171,10 @@ class PipelineGraph:
 def _resolve_inputs(step: MCStep, *, root_name: str) -> tuple[InputEdge, ...]:
     if step.op_type is OpType.DATAGEN:
         return ()
+    if step.op_type is OpType.POSTPROC:
+        # Post-loop ops reference producers by trace key, not by an input
+        # channel/edge, so they contribute no structural graph edges.
+        return ()
     if step.op_type is OpType.FILTER:
         # Filters consume the datagen's observables implicitly (no source kwarg).
         return (InputEdge(role="source", producer=root_name, channel="observables"),)

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -182,6 +182,10 @@ class MCPipelineResult:
     step_elapsed_s: Mapping[str, float] = field(default_factory=dict)
     step_counts: Mapping[str, int] = field(default_factory=dict)
     step_failures: Mapping[str, int] = field(default_factory=dict)
+    #: Post-loop (``OpType.POSTPROC``) artifacts, keyed by step name (or
+    #: ``"<step>.<key>"`` for multi-artifact ops). Values are
+    #: :class:`~SymbolicDSGE.monte_carlo.postproc.Summary` / ``Raw`` wrappers.
+    postproc: Mapping[str, Any] = field(default_factory=dict)
 
     @property
     def succeeded(self) -> bool:

--- a/SymbolicDSGE/monte_carlo/postproc.py
+++ b/SymbolicDSGE/monte_carlo/postproc.py
@@ -1,0 +1,73 @@
+"""Typed return artifacts for post-loop (``OpType.POSTPROC``) ops.
+
+A POSTPROC op runs **once** after the replication loop, over the assembled
+across-replication ``traces`` registry, and returns one or more *tagged*
+artifacts that declare how each output is handled downstream:
+
+- :class:`Summary` — a renderable result (scalar / table / small array) that
+  belongs in the run's summary surface (its own tab in the GUI);
+- :class:`Raw` — bulk numeric data kept as data (a parquet/trace member), not
+  auto-rendered.
+
+An op may return a single artifact, a bare value (wrapped by a default policy —
+ndarray -> :class:`Raw`, anything else -> :class:`Summary`), or a ``Mapping`` of
+named outputs to emit several at once (e.g. a raw indicator array *and* a summary
+table from one op). The engine only normalizes and stores them; serialization
+and the GUI dispatch on the artifact type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, Union
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class Summary:
+    """A renderable POSTPROC artifact — gets its own summary surface.
+
+    ``value`` may be a scalar, a small ndarray, a mapping, or a (pandas)
+    DataFrame; ``render`` is an optional hint, otherwise inferred from the value.
+    """
+
+    value: Any
+    title: str | None = None
+    render: Literal["auto", "table", "scalar", "array"] = "auto"
+
+
+@dataclass(frozen=True)
+class Raw:
+    """A bulk POSTPROC artifact stored as data, not auto-rendered."""
+
+    value: NDArray[Any]
+
+
+Artifact = Union[Summary, Raw]
+
+
+def as_artifact(value: Any) -> Artifact:
+    """Wrap a bare value: ndarray -> :class:`Raw`, otherwise -> :class:`Summary`."""
+    if isinstance(value, (Summary, Raw)):
+        return value
+    if isinstance(value, np.ndarray):
+        return Raw(value=value)
+    return Summary(value=value)
+
+
+def normalize_artifacts(out: Any, step_name: str) -> dict[str, Artifact]:
+    """Normalize a POSTPROC op's return into a flat ``{key: artifact}`` map.
+
+    - a single :class:`Summary`/:class:`Raw` -> ``{step_name: artifact}``;
+    - a ``Mapping`` of named outputs -> ``{f"{step_name}.{key}": artifact}`` (so
+      one op can emit several artifacts without key collisions across steps);
+    - a bare value -> wrapped via :func:`as_artifact` under ``step_name``.
+    """
+    if isinstance(out, (Summary, Raw)):
+        return {step_name: out}
+    if isinstance(out, Mapping):
+        return {f"{step_name}.{key}": as_artifact(value) for key, value in out.items()}
+    return {step_name: as_artifact(out)}

--- a/SymbolicDSGE/monte_carlo/serialize.py
+++ b/SymbolicDSGE/monte_carlo/serialize.py
@@ -13,7 +13,7 @@ the parquet-friendly split below:
 from __future__ import annotations
 
 import copy
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 import numpy as np
@@ -84,14 +84,19 @@ _TEST_TRACE_KEYS = ("statistic_trace", "pval_trace", "status_trace")
 _REGRESSION_TRACE_KEYS = ("coef_trace", "r2_trace", "status_trace")
 
 
-def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
-    """Bulk numeric trace columns, keyed for a later parquet writer (no I/O).
+def traces_from_summaries(
+    test_summaries: Mapping[str, Any],
+    regression_summaries: Mapping[str, Any],
+) -> dict[str, NDArray[Any]]:
+    """Bulk numeric trace columns from the test/regression summaries (no I/O).
 
     Keys: per test ``"test.<name>.{statistic,pval,status}"``; per regression
-    ``"regression.<name>.{coef,r2,status}"`` (``coef`` is 2D ``n_rep x k``).
+    ``"regression.<name>.{coef,r2,status}"`` (``coef`` is 2D ``n_rep x k``). The
+    single source of truth for trace shaping — shared by :func:`result_traces`
+    (the wire) and the post-loop ``OpType.POSTPROC`` trace registry.
     """
     traces: dict[str, NDArray[Any]] = {}
-    for name, test_summary in result.test_summaries.items():
+    for name, test_summary in test_summaries.items():
         traces[f"test.{name}.statistic"] = np.asarray(
             test_summary.statistic_trace, dtype=np.float64
         )
@@ -101,7 +106,7 @@ def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
         traces[f"test.{name}.status"] = np.asarray(
             [int(status) for status in test_summary.status_trace], dtype=np.int64
         )
-    for name, reg_summary in result.regression_summaries.items():
+    for name, reg_summary in regression_summaries.items():
         traces[f"regression.{name}.coef"] = np.asarray(
             reg_summary.coef_trace, dtype=np.float64
         )
@@ -112,6 +117,11 @@ def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
             [int(status) for status in reg_summary.status_trace], dtype=np.int64
         )
     return traces
+
+
+def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
+    """Bulk numeric trace columns for a later parquet writer (no I/O)."""
+    return traces_from_summaries(result.test_summaries, result.regression_summaries)
 
 
 def result_document(result: MCPipelineResult, *, run_id: str = "") -> dict[str, Any]:

--- a/tests/monte_carlo/test_postproc.py
+++ b/tests/monte_carlo/test_postproc.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.monte_carlo import MCPipeline, MCStep, OpType, Raw, Summary
+from SymbolicDSGE.monte_carlo.operations.core import raw_data_step
+from SymbolicDSGE.monte_carlo.operations.tests import jarque_bera_test_step
+from SymbolicDSGE.monte_carlo.operations.transforms import standardize_step
+
+_REFERENCE = cast(SolvedModel, object())
+
+
+def _observables(n_rep: int = 4, T: int = 40, k: int = 2, seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).normal(size=(n_rep, T, k))
+
+
+def _run(steps: list[MCStep], *, n_rep: int = 4, fail_fast: bool = True):
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=_observables(n_rep), observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            *steps,
+        ]
+    )
+    return pipeline.run(
+        reference=_REFERENCE, n_rep=n_rep, fail_fast=fail_fast, verbosity=0
+    )
+
+
+def _postproc(name: str, func: Any, **kwargs: Any) -> MCStep:
+    return MCStep(name=name, op_type=OpType.POSTPROC, func=func, kwargs=kwargs)
+
+
+def test_postproc_runs_once_and_wraps_a_bare_scalar() -> None:
+    calls: list[int] = []
+
+    def op(*, traces, reference, dgp):
+        calls.append(1)
+        return 0.75
+
+    result = _run([_postproc("probe", op)], n_rep=5)
+
+    assert len(calls) == 1  # once per run(), not per replication
+    artifact = result.postproc["probe"]
+    assert isinstance(artifact, Summary) and artifact.value == 0.75
+
+
+def test_no_postproc_yields_empty_bucket() -> None:
+    assert _run([]).postproc == {}
+
+
+def test_traces_expose_test_pvals_with_n_successful_length() -> None:
+    captured: dict[str, Any] = {}
+
+    def op(*, traces, reference, dgp):
+        captured["keys"] = set(traces)
+        captured["pval"] = traces["test.jb.pval"]
+        return Summary(value=float(traces["test.jb.pval"].mean()))
+
+    result = _run([_postproc("probe", op)], n_rep=6)
+
+    assert "test.jb.pval" in captured["keys"]
+    assert captured["pval"].shape == (6,)
+    assert isinstance(result.postproc["probe"], Summary)
+
+
+def test_mapping_return_yields_namespaced_artifacts() -> None:
+    def op(*, traces, reference, dgp):
+        return {"sel": Raw(np.zeros(3)), "pcs": Summary(0.4)}
+
+    result = _run([_postproc("m", op)])
+
+    assert isinstance(result.postproc["m.sel"], Raw)
+    assert isinstance(result.postproc["m.pcs"], Summary)
+    assert result.postproc["m.pcs"].value == 0.4
+
+
+def test_bare_ndarray_wraps_as_raw() -> None:
+    def op(*, traces, reference, dgp):
+        return np.arange(3.0)
+
+    artifact = _run([_postproc("r", op)]).postproc["r"]
+    assert isinstance(artifact, Raw)
+    np.testing.assert_array_equal(artifact.value, np.arange(3.0))
+
+
+def test_postproc_failure_respects_fail_fast() -> None:
+    def boom(*, traces, reference, dgp):
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        _run([_postproc("b", boom)], fail_fast=True)
+
+    result = _run([_postproc("b", boom)], fail_fast=False)
+    assert result.succeeded is False
+    assert any(f.step_name == "b" and f.rep_idx == -1 for f in result.failures)
+    assert "b" not in result.postproc
+
+
+def test_postproc_receives_step_kwargs_and_can_colstack_traces() -> None:
+    # PCS-style: stack two tests' p-value traces (R x 2), argmin per row, compare
+    # to the expected index, mean = correct-selection rate.
+    def pcs(*, traces, reference, dgp, expected):
+        matrix = np.column_stack([traces["test.jb0.pval"], traces["test.jb1.pval"]])
+        selected = matrix.argmin(axis=1)
+        return Summary(value=float((selected == expected).mean()))
+
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=_observables(8), observable_names=("y", "x")),
+            jarque_bera_test_step("jb0", source="observables", column=0),
+            jarque_bera_test_step("jb1", source="observables", column=1),
+            _postproc("pcs", pcs, expected=0),
+        ]
+    )
+    result = pipeline.run(reference=_REFERENCE, n_rep=8, verbosity=0)
+
+    value = result.postproc["pcs"].value
+    assert isinstance(value, float) and 0.0 <= value <= 1.0
+
+
+def test_transform_payloads_are_stacked_into_traces() -> None:
+    captured: dict[str, Any] = {}
+
+    def op(*, traces, reference, dgp):
+        captured["has_payload"] = "payload.s" in traces
+        captured["shape"] = traces.get("payload.s", np.empty(0)).shape
+        return 1.0
+
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=_observables(5), observable_names=("y", "x")),
+            standardize_step("s", source="observables"),
+            _postproc("p", op),
+        ]
+    )
+    pipeline.run(reference=_REFERENCE, n_rep=5, verbosity=0)
+
+    assert captured["has_payload"] is True
+    assert captured["shape"][0] == 5  # stacked over replications
+
+
+def test_postproc_step_is_excluded_from_per_rep_step_counts() -> None:
+    result = _run([_postproc("probe", lambda *, traces, reference, dgp: 1.0)], n_rep=7)
+    # per-rep steps run 7 times; the postproc runs exactly once.
+    assert result.step_counts["jb"] == 7
+    assert result.step_counts["probe"] == 1


### PR DESCRIPTION
This pull request introduces a new "post-processing" (POSTPROC) step type to the Monte Carlo pipeline, allowing users to run custom analysis or artifact-generation code once after all replications are complete. It also defines a formal artifact system for POSTPROC outputs, updates the pipeline execution logic, and adds comprehensive tests for the new behavior.

The most important changes are:

**POSTPROC Step Type and Artifact System:**
* Introduced the POSTPROC step type, which runs once after the replication loop and receives all test/regression traces and transform payloads as input (`core.py`, `graph.py`). [[1]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R107-R118) [[2]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R237-R337) [[3]](diffhunk://#diff-5639e81acbff880555b7a8d1c29536480010837d81d1c670eaf8abd2d3d3f15fR174-R177) [[4]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L87-R99) [[5]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L104-R109)
* Added a new artifact system with `Summary` and `Raw` types to distinguish between renderable results and bulk data, plus normalization logic for POSTPROC outputs (`postproc.py`, `__init__.py`). [[1]](diffhunk://#diff-3ee76fd54c060bb23171220ca118ba7b4f6c7fdbb23a7c7281d61a81af281921R1-R73) [[2]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R21) [[3]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R45-R46)

**Pipeline Execution and Result Handling:**
* Refactored the pipeline execution to separate per-replication steps from POSTPROC steps, accumulate payloads, and store POSTPROC artifacts in the pipeline result (`core.py`, `mc_constructs.py`). [[1]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R107-R118) [[2]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R151-R168) [[3]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R187) [[4]](diffhunk://#diff-e478adcc2a86c09dbbaf56b71f0eaa3a18e194ab70b0fbd77d295f6152840054R185-R188)
* Updated result serialization to handle new artifact and trace logic (`serialize.py`). [[1]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L87-R99) [[2]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L104-R109) [[3]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631R122-R126)

**Testing:**
* Added comprehensive tests for POSTPROC step execution, artifact wrapping, trace exposure, error handling, and integration with the rest of the pipeline (`test_postproc.py`).

**Internal Refactoring:**
* Refactored type hints, imports, and helper functions to support the new POSTPROC logic and artifact handling (`core.py`, `serialize.py`). [[1]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9L6-R6) [[2]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R30) [[3]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L16-R16)

These changes collectively enable flexible, type-safe post-processing and artifact generation in Monte Carlo pipelines.

closes #177 