### PR TITLE
Add postproc step role and KDE builtin for trace processing

### DIFF
--- a/SymbolicDSGE/bundle/builder.py
+++ b/SymbolicDSGE/bundle/builder.py
@@ -293,7 +293,7 @@ class BundleBuilder:
                     ),
                     data,
                 )
-            elif step.step_type == "custom":
+            elif step.step_type in ("transform:custom", "postproc:custom"):
                 self._add(
                     Member(
                         path=_MC_CUSTOM_OP.format(ref=step.name),

--- a/SymbolicDSGE/monte_carlo/builder.py
+++ b/SymbolicDSGE/monte_carlo/builder.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from .catalog import (
     DATAGEN_STEP_TYPES,
     FILTER_SOURCES,
+    POSTPROC_STEP_TYPES,
     STEP_CATALOG,
     TERMINAL_STEP_TYPES,
     TRANSFORM_STEP_TYPES,
@@ -25,6 +26,7 @@ from .catalog import (
 from .core import MCPipeline
 from .mc_constructs import MCPipelineResult
 from .operations.core import raw_data_step
+from .operations.postproc import postproc_step
 from .operations.transforms import transform_step
 from .spec import NodeSpec, PipelineSpec
 
@@ -32,8 +34,12 @@ if TYPE_CHECKING:
     from ..core.solved_model import SolvedModel
 
 #: Transform-role kinds at the spec level: the catalogue transforms plus the
-#: user ``custom`` op (an ``OpType.TRANSFORM`` middle node shipped as a member).
-_TRANSFORM_KINDS = TRANSFORM_STEP_TYPES | {"custom"}
+#: user transform custom op (an ``OpType.TRANSFORM`` middle node shipped as a
+#: member).
+_TRANSFORM_KINDS = TRANSFORM_STEP_TYPES | {"transform:custom"}
+
+#: Post-loop kinds: the catalogue postproc ops plus the user postproc custom op.
+_POSTPROC_KINDS = POSTPROC_STEP_TYPES | {"postproc:custom"}
 
 #: ``source`` kinds a transform/terminal may legally link from (the structural
 #: parent edge): the root datagen, a filter, or another transform.
@@ -94,6 +100,11 @@ def validate_pipeline_spec(
         if source.step_type in TERMINAL_STEP_TYPES:
             raise ValueError(
                 f"Terminal step '{source.name}' cannot link to another step."
+            )
+        if source.step_type in _POSTPROC_KINDS or target.step_type in _POSTPROC_KINDS:
+            raise ValueError(
+                "POSTPROC steps reference producers by name, not edges; remove the "
+                f"edge {edge.source!r} -> {edge.target!r}."
             )
         if target.step_type in DATAGEN_STEP_TYPES:
             raise ValueError("The datagen step cannot have an incoming link.")
@@ -156,7 +167,15 @@ def validate_pipeline_spec(
     terminal_nodes = [
         node for node in spec.nodes if node.step_type in TERMINAL_STEP_TYPES
     ]
-    ordered = [datagen, *filter_nodes, *transform_nodes, *terminal_nodes]
+    # Post-loop ops run after everything, over the assembled across-rep traces.
+    postproc_nodes = [node for node in spec.nodes if node.step_type in _POSTPROC_KINDS]
+    ordered = [
+        datagen,
+        *filter_nodes,
+        *transform_nodes,
+        *terminal_nodes,
+        *postproc_nodes,
+    ]
 
     bound: list[NodeSpec] = []
     bound_by_id: dict[str, NodeSpec] = {}
@@ -239,8 +258,10 @@ def build_pipeline(
     for node in ordered:
         if node.step_type == "raw_data":
             steps.append(_build_raw_data(node, resources))
-        elif node.step_type == "custom":
-            steps.append(_build_custom(node, resources))
+        elif node.step_type == "transform:custom":
+            steps.append(_build_custom(node, resources, transform_step))
+        elif node.step_type == "postproc:custom":
+            steps.append(_build_custom(node, resources, postproc_step))
         else:
             definition = STEP_CATALOG.get(node.step_type)
             if definition is None:
@@ -281,8 +302,16 @@ def _build_raw_data(node: NodeSpec, resources: Mapping[str, Any]) -> Any:
     return raw_data_step(node.name, **kwargs)
 
 
-def _build_custom(node: NodeSpec, resources: Mapping[str, Any]) -> Any:
-    """Rehydrate a ``custom`` op, reattaching its callable from resources."""
+def _build_custom(
+    node: NodeSpec,
+    resources: Mapping[str, Any],
+    factory: Any,
+) -> Any:
+    """Rehydrate a custom op, reattaching its callable from resources.
+
+    ``factory`` is the step constructor for the op role (``transform_step`` for
+    ``transform:custom``, ``postproc_step`` for ``postproc:custom``).
+    """
     params = dict(node.params)
     ref = params.pop("func_ref", node.name)
     # The authoring source rides in ``code`` (compiled into the resources
@@ -294,7 +323,7 @@ def _build_custom(node: NodeSpec, resources: Mapping[str, Any]) -> Any:
             f"custom step '{node.name}' references callable '{ref}' that is not "
             "present in the supplied resources."
         )
-    return transform_step(node.name, func, **_clean_params(params))
+    return factory(node.name, func, **_clean_params(params))
 
 
 def run_pipeline(

--- a/SymbolicDSGE/monte_carlo/catalog.py
+++ b/SymbolicDSGE/monte_carlo/catalog.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from ..core.shock_generators import Shock
 from .operations.core import reference_filter_step, simulation_step
+from .operations.postproc import kde_step
 from .operations.regressions import regression_step
 from .operations.tests import (
     breusch_godfrey_test_step,
@@ -57,7 +58,7 @@ INPUT_SOURCES = [
 #: Sources produced only by a filter step (require an upstream filter link).
 FILTER_SOURCES = {"x_pred", "x_filt", "y_pred", "y_filt", "innov", "std_innov"}
 
-StepRole = Literal["datagen", "filter", "transform", "terminal"]
+StepRole = Literal["datagen", "filter", "transform", "terminal", "postproc"]
 CompileParams = Callable[[dict[str, Any], "SolvedModel | None"], dict[str, Any]]
 
 
@@ -113,13 +114,16 @@ class StepDefinition:
         """Palette grouping for the GUI step selector tabs.
 
         Derived from ``op_role`` (so new steps group automatically): datagen and
-        filter are ``"core"``, transforms ``"transforms"``, the regression step
-        ``"regressions"``, and the remaining terminals (tests) ``"tests"``.
+        filter are ``"core"``, transforms ``"transforms"``, post-loop ops
+        ``"postproc"``, the regression step ``"regressions"``, and the remaining
+        terminals (tests) ``"tests"``.
         """
         if self.op_role in ("datagen", "filter"):
             return "core"
         if self.op_role == "transform":
             return "transforms"
+        if self.op_role == "postproc":
+            return "postproc"
         if self.step_type == "regression":
             return "regressions"
         return "tests"
@@ -759,6 +763,26 @@ _STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
             FieldSpec("ddof", "Degrees of freedom", "number", 0, minimum=0),
         ),
     ),
+    # ----- post-processing -----
+    StepDefinition(
+        step_type="kde",
+        title="KDE",
+        default_name="kde",
+        description=(
+            "Gaussian kernel density estimate of an across-replication trace; "
+            "returns the raw (x, density) curve."
+        ),
+        op_role="postproc",
+        factory=kde_step,
+        fields=(
+            # ``trace`` names an across-rep trace key (e.g. "test.<name>.statistic");
+            # the selectable options are populated from the producer registry (#179).
+            FieldSpec("trace", "Trace", "select", "", required=True),
+            FieldSpec("bandwidth", "Bandwidth", "text", "scott"),
+            FieldSpec("grid_points", "Grid points", "number", 200, minimum=2),
+            FieldSpec("kernel", "Kernel", "select", "gaussian", options=("gaussian",)),
+        ),
+    ),
 )
 
 #: Step kind -> definition, insertion order matching the GUI catalogue payload.
@@ -784,6 +808,14 @@ TRANSFORM_STEP_TYPES: frozenset[str] = frozenset(
     step_type
     for step_type, definition in STEP_CATALOG.items()
     if definition.is_transform
+)
+
+#: Post-loop step kinds (run once after the replication loop over the assembled
+#: across-rep traces).
+POSTPROC_STEP_TYPES: frozenset[str] = frozenset(
+    step_type
+    for step_type, definition in STEP_CATALOG.items()
+    if definition.op_role == "postproc"
 )
 
 

--- a/SymbolicDSGE/monte_carlo/operations/__init__.py
+++ b/SymbolicDSGE/monte_carlo/operations/__init__.py
@@ -12,6 +12,6 @@ The underlying ``run_*`` op implementations are internal and live in each
 group's ``ops`` module (e.g. ``operations.core.ops.simulate_dgp``).
 """
 
-from . import core, regressions, tests, transforms
+from . import core, postproc, regressions, tests, transforms
 
-__all__ = ["core", "tests", "transforms", "regressions"]
+__all__ = ["core", "tests", "transforms", "regressions", "postproc"]

--- a/SymbolicDSGE/monte_carlo/operations/postproc/__init__.py
+++ b/SymbolicDSGE/monte_carlo/operations/postproc/__init__.py
@@ -1,0 +1,3 @@
+from .builtins import kde_step, postproc_step
+
+__all__ = ["kde_step", "postproc_step"]

--- a/SymbolicDSGE/monte_carlo/operations/postproc/builtins.py
+++ b/SymbolicDSGE/monte_carlo/operations/postproc/builtins.py
@@ -1,0 +1,43 @@
+"""Post-processing step factories (``OpType.POSTPROC``)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ...mc_constructs import MCStep, OpType
+from .ops import run_kde
+
+
+def postproc_step(
+    name: str,
+    func: Callable[..., Any],
+    *,
+    store_key: str | None = None,
+    **kwargs: Any,
+) -> MCStep:
+    """Wrap a user callable as an ``OpType.POSTPROC`` step.
+
+    Post-loop op contract: ``func(*, traces, reference, dgp, **kwargs)`` returning
+    :class:`~SymbolicDSGE.monte_carlo.postproc.Summary` / ``Raw`` artifacts (or a
+    mapping of them). Bundling additionally requires the callable to be a
+    :class:`~SymbolicDSGE.monte_carlo.custom_op.NumpyCustomFunc`; the bundle
+    builder enforces/auto-wraps that at serialization time.
+    """
+    return MCStep(
+        name=name,
+        op_type=OpType.POSTPROC,
+        func=func,
+        kwargs=kwargs,
+        store_key=store_key,
+        step_type="postproc:custom",
+    )
+
+
+def kde_step(name: str, **kwargs: Any) -> MCStep:
+    return MCStep(
+        name=name,
+        op_type=OpType.POSTPROC,
+        func=run_kde,
+        kwargs=kwargs,
+        step_type="kde",
+    )

--- a/SymbolicDSGE/monte_carlo/operations/postproc/ops.py
+++ b/SymbolicDSGE/monte_carlo/operations/postproc/ops.py
@@ -1,0 +1,58 @@
+"""Post-processing (``OpType.POSTPROC``) op implementations.
+
+Post-loop ops run once after the replication loop, over the assembled
+across-replication ``traces`` registry, and return :class:`Summary` / :class:`Raw`
+artifacts. The op contract is ``op(*, traces, reference, dgp, **kwargs)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ....core.solved_model import SolvedModel
+from ...postproc import Raw
+
+
+def run_kde(
+    *,
+    traces: Mapping[str, NDArray[Any]],
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+    trace: str,
+    bandwidth: str | float = "scott",
+    grid_points: int = 200,
+    kernel: str = "gaussian",
+) -> Raw:
+    """Gaussian kernel density estimate of an across-replication trace.
+
+    Reads ``traces[trace]`` (e.g. ``"test.<name>.statistic"``), estimates its
+    density on a uniform grid spanning the finite data range, and returns the raw
+    ``(x, density)`` curve as an ``N x 2`` array — the bulk data callers need for
+    plotting. A descriptive :class:`Summary` (moments/quantiles as a table) is
+    added once tabular artifacts land (#181).
+    """
+    from scipy.stats import gaussian_kde
+
+    del reference, dgp
+    if kernel != "gaussian":
+        raise ValueError(
+            f"KDE currently supports only the Gaussian kernel, got {kernel!r}."
+        )
+    if trace not in traces:
+        raise KeyError(f"KDE trace {trace!r} is not available in the run's traces.")
+    data = np.asarray(traces[trace], dtype=np.float64).reshape(-1)
+    data = data[np.isfinite(data)]
+    if data.size < 2:
+        raise ValueError(
+            f"KDE needs at least two finite values in trace {trace!r}, got {data.size}."
+        )
+    # scipy's stub over-narrows both args (Literal bandwidth, dataset dtype);
+    # the runtime accepts our str|float bandwidth and float64 data fine.
+    estimator = gaussian_kde(cast(Any, data), bw_method=cast(Any, bandwidth))
+    grid = np.linspace(float(data.min()), float(data.max()), int(grid_points))
+    density = np.asarray(estimator(grid), dtype=np.float64)
+    return Raw(value=np.column_stack([grid, density]))

--- a/SymbolicDSGE/monte_carlo/operations/transforms/builtins.py
+++ b/SymbolicDSGE/monte_carlo/operations/transforms/builtins.py
@@ -36,7 +36,7 @@ def transform_step(
         func=func,
         kwargs=kwargs,
         store_key=store_key,
-        step_type="custom",
+        step_type="transform:custom",
     )
 
 

--- a/SymbolicDSGE/monte_carlo/spec.py
+++ b/SymbolicDSGE/monte_carlo/spec.py
@@ -37,8 +37,12 @@ MCStepKind = Literal[
     "rolling_mean",
     "rolling_std",
     "rolling_var",
-    # custom (user-supplied op, shipped as a cloudpickle bundle member)
-    "custom",
+    # post-processing (post-loop ops over across-rep traces)
+    "kde",
+    # custom (user-supplied ops, shipped as cloudpickle bundle members); the
+    # prefix records the op role since a custom op may be a transform or a postproc.
+    "transform:custom",
+    "postproc:custom",
 ]
 
 #: Authoritative set of valid step-type strings. Must agree with the keys of

--- a/SymbolicDSGE/monte_carlo/spec_compile.py
+++ b/SymbolicDSGE/monte_carlo/spec_compile.py
@@ -99,7 +99,7 @@ def _recover_params(step: "MCStep") -> dict[str, Any]:
         params = _recover_simulation(step.kwargs)
     elif step_type == "wald":
         params = _recover_wald(step.kwargs)
-    elif step_type == "custom":
+    elif step_type in ("transform:custom", "postproc:custom"):
         params = _jsonable_params(dict(step.kwargs))
         params["func_ref"] = step.name
     else:

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -80,7 +80,7 @@ def compile_custom_resources(spec: MCPipelineSpec) -> dict[str, Any]:
     """
     resources: dict[str, Any] = {}
     for node in spec.nodes:
-        if node.step_type != "custom":
+        if node.step_type not in ("transform:custom", "postproc:custom"):
             continue
         code = node.params.get("code", "")
         if not isinstance(code, str) or not code.strip():

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -63,11 +63,12 @@ import type { MCFlowNode } from "./types";
 
 const nodeTypes = { mcStep: StepNode };
 
-// "custom" has no backend StepDefinition (it isn't GUI-authored via fields), so
-// it never appears in the catalogue payload. We inject a synthetic palette entry
-// for it under the Transforms tab; its single "param" is the op source code.
+// "transform:custom" has no backend StepDefinition (it isn't GUI-authored via
+// fields), so it never appears in the catalogue payload. We inject a synthetic
+// palette entry for it under the Transforms tab; its single "param" is the op
+// source code.
 const CUSTOM_CATALOG_ITEM: MCStepCatalogItem = {
-  step_type: "custom",
+  step_type: "transform:custom",
   title: "Custom Op",
   default_name: "custom_op",
   description: "User-defined Python transform, validated and run per replication.",
@@ -569,6 +570,7 @@ const STEP_CATEGORIES: { id: MCStepCategory; label: string }[] = [
   { id: "transforms", label: "Transforms" },
   { id: "tests", label: "Tests" },
   { id: "regressions", label: "Regressions" },
+  { id: "postproc", label: "Postproc" },
 ];
 
 // Edge colors by producer kind, so each consumer's inputs are distinguishable.
@@ -681,7 +683,7 @@ function makeNode(
   const count = existing.filter((node) => node.data.stepType === item.step_type).length;
   const name = count === 0 ? item.default_name : `${item.default_name}_${count + 1}`;
   const params =
-    item.step_type === "custom"
+    item.step_type === "transform:custom"
       ? { code: customTemplate }
       : Object.fromEntries(item.fields.map((field) => [field.key, field.default]));
   return {

--- a/sdsge-ui/frontend/src/mc/StepInspector.tsx
+++ b/sdsge-ui/frontend/src/mc/StepInspector.tsx
@@ -58,7 +58,7 @@ export function StepInspector({
     });
   };
 
-  const isCustom = node.data.stepType === "custom";
+  const isCustom = node.data.stepType === "transform:custom";
   const producers = payloadProducers.filter((name) => name !== node.data.name);
 
   return (

--- a/sdsge-ui/frontend/src/mc/StepNode.tsx
+++ b/sdsge-ui/frontend/src/mc/StepNode.tsx
@@ -32,7 +32,9 @@ const ICONS: Record<MCStepType, LucideIcon> = {
   rolling_mean: Waves,
   rolling_std: Waves,
   rolling_var: Waves,
-  custom: Code,
+  kde: Activity,
+  "transform:custom": Code,
+  "postproc:custom": Code,
 };
 
 export function StepNode({ data, selected }: NodeProps<MCFlowNode>) {

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -178,9 +178,16 @@ export type MCStepType =
   | "rolling_mean"
   | "rolling_std"
   | "rolling_var"
-  | "custom";
+  | "kde"
+  | "transform:custom"
+  | "postproc:custom";
 
-export type MCStepCategory = "core" | "transforms" | "tests" | "regressions";
+export type MCStepCategory =
+  | "core"
+  | "transforms"
+  | "tests"
+  | "regressions"
+  | "postproc";
 
 export type MCFieldType =
   | "text"

--- a/tests/bundle/test_mc_facade.py
+++ b/tests/bundle/test_mc_facade.py
@@ -82,7 +82,7 @@ def test_add_mc_ships_custom_op_member_and_loader_rebuilds(tmp_path) -> None:
     ordered = validate_pipeline_spec(loaded.mc.spec, has_reference=True, has_dgp=False)
     rebuilt = build_pipeline(ordered, resources=loaded.mc.resources)
     z_step = {s.name: s for s in rebuilt.steps}["z"]
-    assert z_step.step_type == "custom"
+    assert z_step.step_type == "transform:custom"
     assert callable(z_step.func)
 
 

--- a/tests/monte_carlo/test_catalog_builder.py
+++ b/tests/monte_carlo/test_catalog_builder.py
@@ -58,7 +58,7 @@ def test_every_source_leg_op_accepts_its_payload_key() -> None:
 
 def test_transform_step_stamps_custom_kind() -> None:
     step = transform_step("tf", lambda **_: None)
-    assert step.step_type == "custom"
+    assert step.step_type == "transform:custom"
 
 
 _FIELD_KEYS = {
@@ -81,7 +81,7 @@ def _stub_dgp(*targets: str) -> SimpleNamespace:
 def test_catalog_payload_shape_and_known_fields() -> None:
     payload = catalog_payload()
     steps = payload["steps"]
-    assert len(steps) == len(STEP_CATALOG) == 18
+    assert len(steps) == len(STEP_CATALOG) == 19
 
     for step in steps:
         assert set(step) == {
@@ -114,11 +114,13 @@ def test_catalog_entries_carry_selector_category() -> None:
     assert by_type["jarque_bera"]["category"] == "tests"
     assert by_type["wald"]["category"] == "tests"
     assert by_type["regression"]["category"] == "regressions"
+    assert by_type["kde"]["category"] == "postproc"
     assert {s["category"] for s in by_type.values()} == {
         "core",
         "transforms",
         "tests",
         "regressions",
+        "postproc",
     }
 
 
@@ -296,3 +298,63 @@ def test_build_pipeline_rejects_unknown_step_type() -> None:
     node = NodeSpec(id="x", step_type="bogus", name="x", params={})
     with pytest.raises(ValueError, match="Unsupported MC step type"):
         build_pipeline([node], dgp=_stub_dgp("u"))
+
+
+# --- POSTPROC (post-loop) kind: ordering, edges, compilation -----------------
+
+
+def test_postproc_is_ordered_last_after_terminals() -> None:
+    spec = PipelineSpec(
+        nodes=[
+            NodeSpec("sim", "simulation", "datagen", {"T": 8, "observables": True}),
+            NodeSpec("jb", "jarque_bera", "jb", {"source": "observables", "column": 0}),
+            NodeSpec("k", "kde", "kde", {"trace": "test.jb.statistic"}),
+        ],
+        edges=[EdgeSpec("sim", "jb")],
+    )
+    ordered = [
+        n.id for n in validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
+    ]
+    assert ordered == ["sim", "jb", "k"]  # postproc last, no edge needed
+
+
+def test_postproc_rejects_edges() -> None:
+    base = [
+        NodeSpec("sim", "simulation", "datagen", {"T": 8, "observables": True}),
+        NodeSpec("jb", "jarque_bera", "jb", {"source": "observables", "column": 0}),
+        NodeSpec("k", "kde", "kde", {"trace": "test.jb.statistic"}),
+    ]
+    # Edge into the postproc node (from the datagen, so the terminal-source rule
+    # doesn't fire first) is rejected: postproc is wired by trace key, not edges.
+    into = PipelineSpec(nodes=base, edges=[EdgeSpec("sim", "jb"), EdgeSpec("sim", "k")])
+    with pytest.raises(ValueError, match="reference producers by name, not edges"):
+        validate_pipeline_spec(into, has_reference=True, has_dgp=True)
+
+
+def test_kde_catalog_entry_is_postproc_with_trace_field() -> None:
+    kde = STEP_CATALOG["kde"]
+    assert kde.op_role == "postproc"
+    assert kde.category == "postproc"
+    field_keys = [f.key for f in kde.fields]
+    assert "trace" in field_keys
+    # the trace selector must NOT use a per-rep source-leg name
+    assert "source" not in field_keys
+
+
+def test_build_postproc_custom_from_resources() -> None:
+    def my_summary(*, traces, reference, dgp):
+        return 1.0
+
+    spec = PipelineSpec(
+        nodes=[
+            NodeSpec("sim", "simulation", "datagen", {"T": 8, "observables": True}),
+            NodeSpec("p", "postproc:custom", "p", {"func_ref": "p", "code": "..."}),
+        ],
+        edges=[],
+    )
+    ordered = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
+    pipeline = build_pipeline(ordered, dgp=_stub_dgp("u"), resources={"p": my_summary})
+    step = {s.name: s for s in pipeline.steps}["p"]
+    assert step.op_type is OpType.POSTPROC
+    assert step.step_type == "postproc:custom"
+    assert "code" not in step.kwargs and "func_ref" not in step.kwargs

--- a/tests/monte_carlo/test_postproc.py
+++ b/tests/monte_carlo/test_postproc.py
@@ -149,3 +149,20 @@ def test_postproc_step_is_excluded_from_per_rep_step_counts() -> None:
     # per-rep steps run 7 times; the postproc runs exactly once.
     assert result.step_counts["jb"] == 7
     assert result.step_counts["probe"] == 1
+
+
+def test_kde_builtin_runs_and_returns_raw_curve() -> None:
+    from SymbolicDSGE.monte_carlo.operations.postproc import kde_step
+
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=_observables(12), observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            kde_step("density", trace="test.jb.statistic", grid_points=64),
+        ]
+    )
+    result = pipeline.run(reference=_REFERENCE, n_rep=12, verbosity=0)
+
+    art = result.postproc["density"]
+    assert isinstance(art, Raw)
+    assert art.value.shape == (64, 2)  # (x, density)

--- a/tests/monte_carlo/test_to_spec.py
+++ b/tests/monte_carlo/test_to_spec.py
@@ -166,8 +166,38 @@ def test_to_spec_emits_custom_with_func_ref() -> None:
     spec = pipe.to_spec()
 
     tf = {n.name: n for n in spec.nodes}["tf"]
-    assert tf.step_type == "custom"
+    assert tf.step_type == "transform:custom"
     # the callable rides a separate bundle member; the spec only references it
     assert tf.params["func_ref"] == "tf"
     assert tf.params["source"] == "observables"
     assert {(e.source, e.target) for e in spec.edges} == {("dat", "tf")}
+
+
+def test_to_spec_round_trips_a_postproc_pipeline() -> None:
+    from SymbolicDSGE.monte_carlo.operations.postproc import kde_step
+
+    pipe = MCPipeline(
+        [
+            simulation_step(
+                "dgp",
+                T=8,
+                observables=True,
+                seed_increment="auto",
+                shocks={"u": Shock(T=8, dist="norm", seed=0)},
+            ),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            kde_step("kde", trace="test.jb.statistic", grid_points=50),
+        ]
+    )
+    spec1 = pipe.to_spec()
+    kde_node = {n.name: n for n in spec1.nodes}["kde"]
+    assert kde_node.step_type == "kde"
+    assert kde_node.params["trace"] == "test.jb.statistic"
+    # POSTPROC nodes carry no edges (referenced by trace key, ordered last).
+    assert all(e.target != "kde" and e.source != "kde" for e in spec1.edges)
+
+    stub_dgp = cast(SolvedModel, SimpleNamespace())
+    ordered = validate_pipeline_spec(spec1, has_reference=True, has_dgp=True)
+    assert [n.id for n in ordered] == ["dgp", "jb", "kde"]
+    rebuilt = build_pipeline(ordered, dgp=stub_dgp)
+    assert rebuilt.to_spec() == spec1  # fixed point

--- a/tests/monte_carlo/test_transforms.py
+++ b/tests/monte_carlo/test_transforms.py
@@ -603,7 +603,11 @@ def test_step_kinds_match_catalog() -> None:
     from SymbolicDSGE.monte_carlo.spec import STEP_KINDS
 
     assert frozenset(STEP_CATALOG.keys()) <= STEP_KINDS
-    assert STEP_KINDS - frozenset(STEP_CATALOG.keys()) == {"raw_data", "custom"}
+    assert STEP_KINDS - frozenset(STEP_CATALOG.keys()) == {
+        "raw_data",
+        "transform:custom",
+        "postproc:custom",
+    }
 
 
 def test_transform_pipeline_round_trips_through_bundle(tmp_path) -> None:

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -376,6 +376,7 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
         "rolling_mean",
         "rolling_std",
         "rolling_var",
+        "kde",
     }
 
     pipeline = {
@@ -1031,7 +1032,7 @@ def test_ui_backend_runs_custom_op_pipeline() -> None:
             },
             {
                 "id": "z",
-                "step_type": "custom",
+                "step_type": "transform:custom",
                 "name": "zscore",
                 "params": {"code": _UI_CUSTOM_OP},
             },
@@ -1082,7 +1083,7 @@ def test_ui_backend_rejects_invalid_custom_op_on_run() -> None:
             },
             {
                 "id": "z",
-                "step_type": "custom",
+                "step_type": "transform:custom",
                 "name": "zscore",
                 "params": {"code": 'def f(**kwargs):\n    return __import__("os")\n'},
             },


### PR DESCRIPTION
This pull request introduces a new "post-processing" (postproc) step type to the Monte Carlo pipeline system, allowing for operations that run after all replications (e.g., aggregating results across replications). It adds built-in and custom postproc step support, updates the pipeline building and validation logic, and ensures postproc steps are properly handled throughout the codebase and UI. Additionally, it refactors custom transform step handling for clarity and consistency.

**Support for post-processing (postproc) steps:**

* Added a new "postproc" step role and category, including support for built-in postproc steps like `kde` (kernel density estimate) and user-defined custom postproc steps (`postproc:custom`). (`[[1]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975R766-R785)`, `[[2]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975R813-R820)`, `[[3]](diffhunk://#diff-9322394c41257511d70d5d10fadbdc61848de72f13bec85deb80995170898184L15-R17)`, `[[4]](diffhunk://#diff-6de746a36a4abaf8fe2ca29d85f3637bbee446e6b8b1494e295dda25eab9d6c2R1-R3)`, `[[5]](diffhunk://#diff-3bf222c5e734471c358782d0725621c79de9f701506b90493c496de993bd0fd8R1-R43)`, `[[6]](diffhunk://#diff-03fb833ec5e216ac43ce4e3481c1ce02d96c2c99c14554eae83a3a835c320f65R1-R58)`, `[[7]](diffhunk://#diff-a63bcd0423e7b9cf13ec5944a083be87aba49c843a53d654be59b56f1c2c9ea8L40-R45)`, `[[8]](diffhunk://#diff-49a86825a2e5ce272e1f42186def5ef009ca6b11f92950714d8fbfcbe738c880L181-R190)`)
* Updated pipeline validation and build logic to order postproc steps after all other steps and to enforce that postproc steps do not have incoming edges (they reference producers by name). (`[[1]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbR104-R108)`, `[[2]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL159-R178)`, `[[3]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL242-R264)`)
* Added `POSTPROC_STEP_TYPES` for catalog lookups and step validation. (`[SymbolicDSGE/monte_carlo/catalog.pyR813-R820](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975R813-R820)`)

**Refactoring and consistency for custom steps:**

* Refactored custom step handling to distinguish between `transform:custom` (per-replication) and `postproc:custom` (post-loop) steps, updating all relevant code paths, including resource compilation, pipeline building, and parameter recovery. (`[[1]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbR21-R42)`, `[[2]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL242-R264)`, `[[3]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL284-R314)`, `[[4]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL297-R326)`, `[[5]](diffhunk://#diff-cd19db8e891d58918b24f71ce33d458273da61c803ad655ae2cc3bdb12d9f902L102-R102)`, `[[6]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2L83-R83)`, `[[7]](diffhunk://#diff-485cc860e95021bd1478a779c5298769386b9c878f48d09744dc7109f3e97c64L39-R39)`, `[[8]](diffhunk://#diff-d81f2818a8c71f352df09c44b8fb16ea034874fda3c486025a44c486597dd026L296-R296)`, `[[9]](diffhunk://#diff-08bad212206e2420f115acd1cd1e1093a3f61696a5285d21802278d4d0ebf054L85-R85)`)
* Updated UI types, palette, and node handling to support `transform:custom` and `postproc:custom` step types, and to add a "Postproc" tab in the pipeline editor. (`[[1]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221L66-R71)`, `[[2]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R573)`, `[[3]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221L684-R686)`, `[[4]](diffhunk://#diff-d6c1c50d1c4200cf9cbd4961d31638d9a75270c75b134d8eddc9d2861a27cefaL61-R61)`, `[[5]](diffhunk://#diff-644536dc898c87b7a3bdbb777f6d40c077d4d7cde5f08876ad32576bc133abe2L35-R37)`, `[[6]](diffhunk://#diff-49a86825a2e5ce272e1f42186def5ef009ca6b11f92950714d8fbfcbe738c880L181-R190)`)

**Other improvements:**

* Updated the step category logic to group postproc steps under a new "postproc" category in the UI and backend. (`[[1]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L116-R126)`, `[[2]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R573)`, `[[3]](diffhunk://#diff-49a86825a2e5ce272e1f42186def5ef009ca6b11f92950714d8fbfcbe738c880L181-R190)`)
* Added the built-in `kde` postproc step and its implementation, which computes a kernel density estimate over an across-replication trace. (`[[1]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975R21)`, `[[2]](diffhunk://#diff-3bf222c5e734471c358782d0725621c79de9f701506b90493c496de993bd0fd8R1-R43)`, `[[3]](diffhunk://#diff-03fb833ec5e216ac43ce4e3481c1ce02d96c2c99c14554eae83a3a835c320f65R1-R58)`, `[[4]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975R766-R785)`, `[[5]](diffhunk://#diff-644536dc898c87b7a3bdbb777f6d40c077d4d7cde5f08876ad32576bc133abe2L35-R37)`, `[[6]](diffhunk://#diff-a63bcd0423e7b9cf13ec5944a083be87aba49c843a53d654be59b56f1c2c9ea8L40-R45)`)

These changes collectively enable flexible, user-extensible post-processing of Monte Carlo simulation results and clarify the distinction between per-replication and post-loop custom operations.

closes #178 