### PR TITLE
Add trace registry and validation for POSTPROC nodes

### DIFF
--- a/SymbolicDSGE/monte_carlo/builder.py
+++ b/SymbolicDSGE/monte_carlo/builder.py
@@ -29,6 +29,7 @@ from .operations.core import raw_data_step
 from .operations.postproc import postproc_step
 from .operations.transforms import transform_step
 from .spec import NodeSpec, PipelineSpec
+from .traces import available_traces
 
 if TYPE_CHECKING:
     from ..core.solved_model import SolvedModel
@@ -169,6 +170,7 @@ def validate_pipeline_spec(
     ]
     # Post-loop ops run after everything, over the assembled across-rep traces.
     postproc_nodes = [node for node in spec.nodes if node.step_type in _POSTPROC_KINDS]
+    _validate_postproc_trace_refs(postproc_nodes, available_traces(spec))
     ordered = [
         datagen,
         *filter_nodes,
@@ -192,6 +194,37 @@ def validate_pipeline_spec(
         bound_by_id[node.id] = bound_node
         prior_names.add(bound_node.name)
     return bound
+
+
+def _validate_postproc_trace_refs(
+    postproc_nodes: Sequence[NodeSpec], registry: Sequence[str]
+) -> None:
+    """Validate that each POSTPROC node's declared ``trace`` references resolve.
+
+    Catalogue postproc steps mark trace-selector fields with ``type == "trace"``;
+    their values must name a trace the pipeline produces. Custom postproc ops
+    reference traces in opaque code, so they're not statically validated.
+    """
+    available = set(registry)
+    for node in postproc_nodes:
+        definition = STEP_CATALOG.get(node.step_type)
+        if definition is None:
+            continue
+        for field in definition.fields:
+            if field.type != "trace":
+                continue
+            ref = node.params.get(field.key)
+            if not ref:
+                raise ValueError(
+                    f"POSTPROC step '{node.name}' must select a trace for "
+                    f"'{field.key}' (available: {sorted(available)})."
+                )
+            if ref not in available:
+                raise ValueError(
+                    f"POSTPROC step '{node.name}' field '{field.key}' references "
+                    f"trace {ref!r}, which no step in the pipeline produces "
+                    f"(available: {sorted(available)})."
+                )
 
 
 def _payload_dep_ids(node: NodeSpec, name_to_id: Mapping[str, str]) -> set[str]:
@@ -447,7 +480,7 @@ def _bind_consumer_payload(
     if payload_legs:
         if has_transform_parent:
             assert parent is not None
-            for _source_key, payload_key in payload_legs:
+            for _, payload_key in payload_legs:
                 params.setdefault(payload_key, parent.name)
         return
 

--- a/SymbolicDSGE/monte_carlo/catalog.py
+++ b/SymbolicDSGE/monte_carlo/catalog.py
@@ -775,9 +775,10 @@ _STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
         op_role="postproc",
         factory=kde_step,
         fields=(
-            # ``trace`` names an across-rep trace key (e.g. "test.<name>.statistic");
-            # the selectable options are populated from the producer registry (#179).
-            FieldSpec("trace", "Trace", "select", "", required=True),
+            # A ``"trace"`` field references an across-rep trace key (e.g.
+            # "test.<name>.statistic"); validated against the pipeline's producible
+            # traces, and (GUI, #184) offered from that registry.
+            FieldSpec("trace", "Trace", "trace", "", required=True),
             FieldSpec("bandwidth", "Bandwidth", "text", "scott"),
             FieldSpec("grid_points", "Grid points", "number", 200, minimum=2),
             FieldSpec("kernel", "Kernel", "select", "gaussian", options=("gaussian",)),

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -329,10 +329,12 @@ def _stack_payload_columns(
 
     Only keys whose per-rep arrays share a shape across replications are stacked
     (a transform whose output length varies per rep is skipped)."""
+    from .traces import payload_trace_key
+
     out: dict[str, np.ndarray] = {}
     for name, arrays in columns.items():
         if arrays and len({array.shape for array in arrays}) == 1:
-            out[f"payload.{name}"] = np.stack(arrays)
+            out[payload_trace_key(name)] = np.stack(arrays)
     return out
 
 

--- a/SymbolicDSGE/monte_carlo/operations/core/ops.py
+++ b/SymbolicDSGE/monte_carlo/operations/core/ops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Mapping, Sequence, Any, Callable
+from typing import Literal, Mapping, Sequence
 
 import numpy as np
 from numpy import float64, ndarray

--- a/SymbolicDSGE/monte_carlo/serialize.py
+++ b/SymbolicDSGE/monte_carlo/serialize.py
@@ -21,6 +21,7 @@ from numpy.typing import NDArray
 
 from ..regression.ols import OLSResult
 from .mc_constructs import MCContext, MCPipelineResult
+from .traces import regression_trace_keys, test_trace_keys
 
 
 def serialize_pipeline_result(
@@ -97,23 +98,19 @@ def traces_from_summaries(
     """
     traces: dict[str, NDArray[Any]] = {}
     for name, test_summary in test_summaries.items():
-        traces[f"test.{name}.statistic"] = np.asarray(
+        keys = test_trace_keys(name)
+        traces[keys["statistic"]] = np.asarray(
             test_summary.statistic_trace, dtype=np.float64
         )
-        traces[f"test.{name}.pval"] = np.asarray(
-            test_summary.pval_trace, dtype=np.float64
-        )
-        traces[f"test.{name}.status"] = np.asarray(
+        traces[keys["pval"]] = np.asarray(test_summary.pval_trace, dtype=np.float64)
+        traces[keys["status"]] = np.asarray(
             [int(status) for status in test_summary.status_trace], dtype=np.int64
         )
     for name, reg_summary in regression_summaries.items():
-        traces[f"regression.{name}.coef"] = np.asarray(
-            reg_summary.coef_trace, dtype=np.float64
-        )
-        traces[f"regression.{name}.r2"] = np.asarray(
-            reg_summary.r2_trace, dtype=np.float64
-        )
-        traces[f"regression.{name}.status"] = np.asarray(
+        keys = regression_trace_keys(name)
+        traces[keys["coef"]] = np.asarray(reg_summary.coef_trace, dtype=np.float64)
+        traces[keys["r2"]] = np.asarray(reg_summary.r2_trace, dtype=np.float64)
+        traces[keys["status"]] = np.asarray(
             [int(status) for status in reg_summary.status_trace], dtype=np.int64
         )
     return traces

--- a/SymbolicDSGE/monte_carlo/traces.py
+++ b/SymbolicDSGE/monte_carlo/traces.py
@@ -1,0 +1,64 @@
+"""Across-replication trace addressing.
+
+The post-loop (``OpType.POSTPROC``) phase exposes every producer's across-rep
+output as a keyed ndarray (a *trace*). This module is the single source of truth
+for those key strings and for enumerating, from a pipeline *spec* alone, which
+trace keys a run will produce — so a POSTPROC op's trace references can be
+offered in the GUI and validated before the (potentially long) run.
+
+Key format:
+
+- tests -> ``test.<name>.{statistic,pval,status}``
+- regressions -> ``regression.<name>.{coef,r2,status}``
+- transforms -> ``payload.<name>`` (the step's stacked per-rep ndarray output)
+
+``serialize.traces_from_summaries`` and the engine's payload stacking build the
+runtime registry from these same primitives, so the static view here can't drift
+from what a run actually emits.
+"""
+
+from __future__ import annotations
+
+from .catalog import TERMINAL_STEP_TYPES, TRANSFORM_STEP_TYPES
+from .spec import PipelineSpec
+
+_TEST_SUBKEYS = ("statistic", "pval", "status")
+_REGRESSION_SUBKEYS = ("coef", "r2", "status")
+
+
+def test_trace_keys(name: str) -> dict[str, str]:
+    """Trace keys a test step named ``name`` produces, by sub-channel."""
+    return {sub: f"test.{name}.{sub}" for sub in _TEST_SUBKEYS}
+
+
+def regression_trace_keys(name: str) -> dict[str, str]:
+    """Trace keys a regression step named ``name`` produces, by sub-channel."""
+    return {sub: f"regression.{name}.{sub}" for sub in _REGRESSION_SUBKEYS}
+
+
+def payload_trace_key(name: str) -> str:
+    """Trace key for a transform's stacked per-rep payload."""
+    return f"payload.{name}"
+
+
+def trace_keys_for(step_type: str, name: str) -> list[str]:
+    """The across-rep trace keys a producer of ``step_type`` named ``name`` emits."""
+    if step_type == "regression":
+        return list(regression_trace_keys(name).values())
+    if step_type in TERMINAL_STEP_TYPES:  # remaining terminals are tests
+        return list(test_trace_keys(name).values())
+    if step_type in TRANSFORM_STEP_TYPES or step_type == "transform:custom":
+        return [payload_trace_key(name)]
+    return []  # datagen / filter / postproc produce no consumable trace
+
+
+def available_traces(spec: PipelineSpec) -> list[str]:
+    """Every across-rep trace key the pipeline's producers will emit (in node order).
+
+    The set a POSTPROC op may reference; used to populate the GUI trace picker and
+    to validate trace references before a run.
+    """
+    keys: list[str] = []
+    for node in spec.nodes:
+        keys.extend(trace_keys_for(node.step_type, node.name))
+    return keys

--- a/tests/monte_carlo/test_catalog_builder.py
+++ b/tests/monte_carlo/test_catalog_builder.py
@@ -358,3 +358,86 @@ def test_build_postproc_custom_from_resources() -> None:
     assert step.op_type is OpType.POSTPROC
     assert step.step_type == "postproc:custom"
     assert "code" not in step.kwargs and "func_ref" not in step.kwargs
+
+
+# --- #179 trace registry + POSTPROC trace-reference validation ---------------
+
+from SymbolicDSGE.monte_carlo.traces import available_traces  # noqa: E402
+
+
+def test_available_traces_enumerates_producer_keys() -> None:
+    spec = PipelineSpec(
+        nodes=[
+            NodeSpec("sim", "simulation", "sim", {"T": 8, "observables": True}),
+            NodeSpec("f", "filter", "f", {}),
+            NodeSpec("s", "standardize", "s", {"source": "observables"}),
+            NodeSpec("jb", "jarque_bera", "jb", {"source": "observables", "column": 0}),
+            NodeSpec(
+                "reg",
+                "regression",
+                "reg",
+                {"y_source": "observables", "X_source": "observables"},
+            ),
+        ],
+        edges=[],
+    )
+    assert set(available_traces(spec)) == {
+        "test.jb.statistic",
+        "test.jb.pval",
+        "test.jb.status",
+        "regression.reg.coef",
+        "regression.reg.r2",
+        "regression.reg.status",
+        "payload.s",  # transform output
+    }
+    # datagen / filter produce no consumable trace.
+
+
+def _kde_spec(trace_params: dict) -> PipelineSpec:
+    return PipelineSpec(
+        nodes=[
+            NodeSpec("sim", "simulation", "sim", {"T": 8, "observables": True}),
+            NodeSpec("jb", "jarque_bera", "jb", {"source": "observables", "column": 0}),
+            NodeSpec("k", "kde", "k", trace_params),
+        ],
+        edges=[EdgeSpec("sim", "jb")],
+    )
+
+
+def test_kde_valid_trace_reference_passes() -> None:
+    ordered = validate_pipeline_spec(
+        _kde_spec({"trace": "test.jb.statistic"}), has_reference=True, has_dgp=True
+    )
+    assert [n.id for n in ordered] == ["sim", "jb", "k"]
+
+
+def test_kde_bogus_trace_reference_raises_listing_available() -> None:
+    with pytest.raises(ValueError, match="no step in the pipeline produces"):
+        validate_pipeline_spec(
+            _kde_spec({"trace": "test.ghost.pval"}), has_reference=True, has_dgp=True
+        )
+
+
+def test_kde_missing_trace_reference_raises() -> None:
+    with pytest.raises(ValueError, match="must select a trace"):
+        validate_pipeline_spec(_kde_spec({}), has_reference=True, has_dgp=True)
+
+
+def test_postproc_custom_trace_refs_not_statically_validated() -> None:
+    # A custom postproc references traces in opaque code; it must validate even
+    # though we can't statically know which keys it reads.
+    spec = PipelineSpec(
+        nodes=[
+            NodeSpec("sim", "simulation", "sim", {"T": 8, "observables": True}),
+            NodeSpec("jb", "jarque_bera", "jb", {"source": "observables", "column": 0}),
+            NodeSpec("p", "postproc:custom", "p", {"func_ref": "p", "code": "..."}),
+        ],
+        edges=[EdgeSpec("sim", "jb")],
+    )
+    ordered = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
+    assert [n.id for n in ordered] == ["sim", "jb", "p"]
+
+
+def test_kde_trace_field_is_typed_trace() -> None:
+    trace_field = next(f for f in STEP_CATALOG["kde"].fields if f.key == "trace")
+    assert trace_field.type == "trace"

--- a/tests/monte_carlo/test_postproc.py
+++ b/tests/monte_carlo/test_postproc.py
@@ -166,3 +166,29 @@ def test_kde_builtin_runs_and_returns_raw_curve() -> None:
     art = result.postproc["density"]
     assert isinstance(art, Raw)
     assert art.value.shape == (64, 2)  # (x, density)
+
+
+def test_runtime_traces_match_available_registry() -> None:
+    # The static registry (#179) must equal the keys a run actually produces.
+    from SymbolicDSGE.monte_carlo.operations.postproc import postproc_step
+    from SymbolicDSGE.monte_carlo.traces import available_traces
+
+    captured: dict[str, set] = {}
+
+    def probe(*, traces, reference, dgp):
+        captured["keys"] = set(traces)
+        return 0.0
+
+    pipe = MCPipeline(
+        [
+            raw_data_step(
+                "dat", observables=_observables(5), observable_names=("y", "x")
+            ),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            standardize_step("s", source="observables"),
+            postproc_step("probe", probe),
+        ]
+    )
+    pipe.run(reference=_REFERENCE, n_rep=5, verbosity=0)
+
+    assert captured["keys"] == set(available_traces(pipe.to_spec()))


### PR DESCRIPTION
This pull request introduces a new centralized trace key registry for across-replication outputs in the Monte Carlo pipeline, ensuring that trace keys are consistently defined, discoverable, and validated both at runtime and statically from the pipeline specification. It standardizes trace key construction, enables static validation of post-processing steps referencing traces, and updates the GUI and serialization logic to use this registry. Comprehensive tests are added to confirm correctness and alignment between static and runtime trace registries.

**Trace key registry and validation:**

* Added the `SymbolicDSGE/monte_carlo/traces.py` module as the single source of truth for all trace key formats, with functions to enumerate available traces from a pipeline spec and to construct trace keys for tests, regressions, and transforms. (`[SymbolicDSGE/monte_carlo/traces.pyR1-R64](diffhunk://#diff-8a1f6929e2798c616723c95cd4e422a8b3318925d375b2622594dd519ba24457R1-R64)`)
* Updated `validate_pipeline_spec` in `builder.py` to statically validate that all POSTPROC nodes reference valid, available traces, raising clear errors for missing or invalid references. (`[[1]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbR173)`, `[[2]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbR199-R229)`)
* Changed the `kde` step's `trace` field type to `"trace"` in the catalog, enabling GUIs to offer valid trace options and facilitating validation. (`[SymbolicDSGE/monte_carlo/catalog.pyL778-R781](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L778-R781)`)

**Standardization and codebase updates:**

* Updated serialization logic and payload stacking to construct and reference trace keys using the new registry functions, ensuring all runtime trace keys match the static registry. (`[[1]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631R24)`, `[[2]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631L100-R113)`, `[[3]](diffhunk://#diff-22f23ddd46125e3b5af93d5c3e39041765662c41daab5e76447031e7bf20b3a9R332-R337)`)
* Minor code cleanup and refactoring for clarity and type correctness. (`[[1]](diffhunk://#diff-b6b74e6236e6b5c82d618dd32f557d7ff025e91bc34d7d3bd691aac6ae86b6d5L3-R3)`, `[[2]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL450-R483)`)

**Testing and verification:**

* Added tests to confirm that the static registry matches runtime trace outputs, that validation errors are raised for missing/invalid trace references, and that custom postproc steps are handled appropriately. (`[[1]](diffhunk://#diff-cac51d24b4677e1e6c371be777fb997ee8f8b7695d9929a353351e132cec14beR361-R443)`, `[[2]](diffhunk://#diff-76132d27886547d44b6d4d0518dc11af901a2be32346c2a3461637f2c4f56870R169-R194)`)

These changes ensure robust, user-friendly, and future-proof handling of across-replication trace addressing in the Monte Carlo pipeline.

closes #179 