### PR TITLE
Add parquet serialization for arbitrary-shape POSTPROC arrays

### DIFF
--- a/SymbolicDSGE/bundle/builder.py
+++ b/SymbolicDSGE/bundle/builder.py
@@ -34,7 +34,11 @@ from ..estimation.spec import (
 )
 from ..monte_carlo.core import MCPipeline
 from ..monte_carlo.mc_constructs import MCPipelineResult, MCStep
-from ..monte_carlo.serialize import result_document, result_traces
+from ..monte_carlo.serialize import (
+    result_document,
+    result_postproc_arrays,
+    result_traces,
+)
 from ..monte_carlo.spec import PipelineSpec
 from ..monte_carlo.spec_compile import raw_data_arrays
 from .container import write_bundle
@@ -60,6 +64,11 @@ _MC_TRACE_PARQUET = "montecarlo/traces.parquet"
 _MC_TRACE_CSV = "montecarlo/traces.csv"
 _MC_RAW_DATA = "montecarlo/data/{ref}.parquet"
 _MC_CUSTOM_OP = "montecarlo/custom/{ref}.pkl"
+_MC_POSTPROC = "montecarlo/postproc/{ref}.parquet"
+
+#: Single-array column name inside a postproc parquet member (avoids dotted
+#: artifact names colliding with the ``"{name}.{j}"`` 2-D column expansion).
+_POSTPROC_COL = "a"
 
 
 def _library_version() -> str:
@@ -131,7 +140,7 @@ class BundleBuilder:
 
     def add_estimation(
         self,
-        source: EstimationSpec | "Estimator",
+        source: EstimationSpec | "Estimator",  # pyright: ignore
         *,
         result: (
             OptimizationResult
@@ -270,7 +279,28 @@ class BundleBuilder:
                     path = _MC_TRACE_CSV
                     data = trace_to_csv(traces)
                 self._add(Member(path=path, kind="mc_trace"), data)
+            self._add_postproc_arrays(result)
         return self
+
+    def _add_postproc_arrays(self, result: MCPipelineResult) -> None:
+        """Ship bulk POSTPROC ndarray artifacts as shape-manifest parquet members.
+
+        Each artifact is an arbitrary-shape payload (e.g. a KDE ``N x 2`` curve),
+        so — unlike the uniform-length ``mc_trace`` columns — they cannot share
+        one column block; each rides its own member with its shape recorded in the
+        member options for restore. Scalar artifacts stay inline in the result
+        document.
+        """
+        for index, (name, arr) in enumerate(result_postproc_arrays(result).items()):
+            data, _ = arrays_to_parquet({_POSTPROC_COL: arr})
+            self._add(
+                Member(
+                    path=_MC_POSTPROC.format(ref=index),
+                    kind="mc_postproc",
+                    options={"name": name, "shape": list(arr.shape)},
+                ),
+                data,
+            )
 
     def _add_mc_resources(self, pipeline: MCPipeline) -> None:
         """Ship the bulk side-channels a live pipeline references by key.
@@ -284,7 +314,7 @@ class BundleBuilder:
                 arrays = raw_data_arrays(step.kwargs)
                 if not arrays:
                     continue
-                data, _shapes = arrays_to_parquet(arrays)
+                data, _ = arrays_to_parquet(arrays)
                 self._add(
                     Member(
                         path=_MC_RAW_DATA.format(ref=step.name),

--- a/SymbolicDSGE/bundle/loader.py
+++ b/SymbolicDSGE/bundle/loader.py
@@ -61,12 +61,13 @@ class LoadedMC:
     document: dict[str, Any] | None = None
     traces: dict[str, NDArray[Any]] | None = None
     resources: dict[str, Any] = field(default_factory=dict)
+    postproc_arrays: dict[str, NDArray[Any]] = field(default_factory=dict)
 
     def wire(self) -> dict[str, Any] | None:
         """Re-merge document + traces into the UI wire shape, when both exist."""
         if self.document is None or self.traces is None:
             return None
-        return pipeline_result_wire(self.document, self.traces)
+        return pipeline_result_wire(self.document, self.traces, self.postproc_arrays)
 
 
 @dataclass
@@ -198,9 +199,37 @@ def _load_mc(archive: BundleArchive, manifest: Manifest) -> LoadedMC | None:
     if trace_members:
         traces = collapse_columns(_load_columns(archive, trace_members[0]))
 
+    postproc_arrays = _load_mc_postproc(archive, manifest)
     resources = _load_mc_resources(archive, manifest, spec)
 
-    return LoadedMC(spec=spec, document=document, traces=traces, resources=resources)
+    return LoadedMC(
+        spec=spec,
+        document=document,
+        traces=traces,
+        resources=resources,
+        postproc_arrays=postproc_arrays,
+    )
+
+
+def _load_mc_postproc(
+    archive: BundleArchive, manifest: Manifest
+) -> dict[str, NDArray[Any]]:
+    """Restore bulk POSTPROC ndarray artifacts, keyed by artifact name.
+
+    Each member holds one shape-manifest array under the fixed ``"a"`` column;
+    its name and shape ride the member options. An all-NaN array is dropped to
+    nothing by the Parquet encoder, so a missing column is rebuilt as a NaN array
+    of the recorded shape (matching the wire's null-trace convention)."""
+    out: dict[str, NDArray[Any]] = {}
+    for member in manifest.members_by_kind("mc_postproc"):
+        name = str(member.options.get("name", ""))
+        shape = tuple(int(d) for d in member.options.get("shape", []))
+        raw = archive.read(member.path)
+        try:
+            out[name] = arrays_from_parquet(raw, {"a": shape})["a"]
+        except KeyError:
+            out[name] = np.full(shape, np.nan)
+    return out
 
 
 def _load_mc_resources(

--- a/SymbolicDSGE/bundle/manifest.py
+++ b/SymbolicDSGE/bundle/manifest.py
@@ -32,6 +32,7 @@ MemberKind = Literal[
     "mc_trace",
     "mc_raw_data",
     "mc_custom_op",
+    "mc_postproc",
 ]
 MEMBER_KINDS: frozenset[str] = frozenset(get_args(MemberKind))
 

--- a/SymbolicDSGE/monte_carlo/serialize.py
+++ b/SymbolicDSGE/monte_carlo/serialize.py
@@ -21,7 +21,12 @@ from numpy.typing import NDArray
 
 from ..regression.ols import OLSResult
 from .mc_constructs import MCContext, MCPipelineResult
+from .postproc import Raw, Summary
 from .traces import regression_trace_keys, test_trace_keys
+
+#: Scalar artifact-value types that ride the JSON document inline; ndarray values
+#: go to the parquet side-channel, anything else is a tabular artifact (#181).
+_SCALAR_TYPES = (bool, int, float, str, np.integer, np.floating, np.bool_)
 
 
 def serialize_pipeline_result(
@@ -77,6 +82,10 @@ def serialize_pipeline_result(
             for name, summary in result.regression_summaries.items()
         },
         "data_summaries": _summarize_context_data(result.contexts or ()),
+        "postproc": {
+            name: _serialize_artifact(artifact)
+            for name, artifact in result.postproc.items()
+        },
     }
 
 
@@ -121,6 +130,71 @@ def result_traces(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
     return traces_from_summaries(result.test_summaries, result.regression_summaries)
 
 
+def _artifact_array(artifact: Raw | Summary) -> NDArray[Any] | None:
+    """The ndarray a POSTPROC artifact carries as bulk data, or ``None``.
+
+    ``Raw`` is always bulk; a ``Summary`` is bulk only when its value is an
+    ndarray (a scalar Summary rides the JSON document inline).
+    """
+    if isinstance(artifact, Raw):
+        return np.asarray(artifact.value)
+    if isinstance(artifact, Summary) and isinstance(artifact.value, np.ndarray):
+        return artifact.value
+    return None
+
+
+def _serialize_artifact(artifact: Raw | Summary) -> dict[str, Any]:
+    """Wire entry for one POSTPROC artifact (arrays inlined for the UI wire).
+
+    Scalars live inline; ndarrays carry a ``shape`` + inlined ``value`` (the
+    ``value`` is stripped by :func:`result_document` and re-merged from the
+    parquet side-channel). Tabular/DataFrame artifacts are out of scope (#181).
+    """
+    if isinstance(artifact, Raw):
+        arr = np.asarray(artifact.value)
+        return {
+            "kind": "raw",
+            "artifact": "array",
+            "shape": list(arr.shape),
+            "value": _json_value(arr),
+        }
+    entry: dict[str, Any] = {
+        "kind": "summary",
+        "title": artifact.title,
+        "render": artifact.render,
+    }
+    value = artifact.value
+    if isinstance(value, np.ndarray):
+        entry["artifact"] = "array"
+        entry["shape"] = list(value.shape)
+        entry["value"] = _json_value(value)
+    elif value is None or isinstance(value, _SCALAR_TYPES):
+        entry["artifact"] = "scalar"
+        entry["value"] = _json_value(value)
+    else:
+        raise TypeError(
+            f"POSTPROC Summary value of type {type(value).__name__!r} is not a "
+            "scalar or ndarray; tabular/DataFrame artifacts are not yet "
+            "serializable (#181)."
+        )
+    return entry
+
+
+def result_postproc_arrays(result: MCPipelineResult) -> dict[str, NDArray[Any]]:
+    """The bulk ndarray POSTPROC artifacts, keyed by artifact name (no I/O).
+
+    Unlike :func:`result_traces` (uniform ``R``-length columns), these are
+    arbitrary-shape *payloads* (e.g. a KDE ``N x 2`` curve), each serialized to
+    its own shape-manifest parquet member by the bundle builder.
+    """
+    out: dict[str, NDArray[Any]] = {}
+    for name, artifact in result.postproc.items():
+        arr = _artifact_array(artifact)
+        if arr is not None:
+            out[name] = arr
+    return out
+
+
 def result_document(result: MCPipelineResult, *, run_id: str = "") -> dict[str, Any]:
     """JSON-safe metadata + summaries with the bulk trace arrays removed.
 
@@ -133,14 +207,20 @@ def result_document(result: MCPipelineResult, *, run_id: str = "") -> dict[str, 
     for entry in document["regression_summaries"].values():
         for key in _REGRESSION_TRACE_KEYS:
             entry.pop(key, None)
+    for entry in document["postproc"].values():
+        if entry.get("artifact") == "array":  # bulk -> parquet side-channel
+            entry.pop("value", None)
     return document
 
 
 def pipeline_result_wire(
-    document: dict[str, Any], traces: dict[str, NDArray[Any]]
+    document: dict[str, Any],
+    traces: dict[str, NDArray[Any]],
+    postproc_arrays: Mapping[str, NDArray[Any]] | None = None,
 ) -> dict[str, Any]:
     """Re-merge a trace-free :func:`result_document` with :func:`result_traces`
-    into the canonical UI wire shape (used for hydration).
+    (and :func:`result_postproc_arrays`) into the canonical UI wire shape (used
+    for hydration).
 
     A float trace column that is degenerate across *every* replication (e.g. a
     test that returns an undefined-variance NaN statistic in all reps) is dropped
@@ -148,8 +228,19 @@ def pipeline_result_wire(
     column is reconstructed here as a null-filled trace of the summary's length —
     which is exactly what the canonical wire reports for an all-NaN trace — so
     hydration stays robust instead of raising ``KeyError`` on the missing key.
+    The same null-from-``shape`` fallback applies to a dropped POSTPROC array.
     """
+    arrays = postproc_arrays or {}
     wire = copy.deepcopy(document)
+    for name, entry in wire.get("postproc", {}).items():
+        if entry.get("artifact") != "array":
+            continue  # scalar value already inline in the document
+        arr = arrays.get(name)
+        if arr is not None:
+            entry["value"] = _json_value(arr)
+        else:
+            shape = tuple(int(d) for d in entry.get("shape", []))
+            entry["value"] = _json_value(np.full(shape, np.nan)) if shape else None
     for name, entry in wire["test_summaries"].items():
         n = int(entry.get("n", 0))
         entry["statistic_trace"] = _trace_or_null(traces, f"test.{name}.statistic", n)

--- a/tests/bundle/test_mc_facade.py
+++ b/tests/bundle/test_mc_facade.py
@@ -1,20 +1,33 @@
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import pytest
 
 from SymbolicDSGE.bundle import BundleBuilder, build_from
+from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.monte_carlo import MCPipeline, build_pipeline, validate_pipeline_spec
 from SymbolicDSGE.monte_carlo.custom_op import NumpyCustomFunc
 from SymbolicDSGE.monte_carlo.operations.core import raw_data_step
+from SymbolicDSGE.monte_carlo.operations.postproc import postproc_step
 from SymbolicDSGE.monte_carlo.operations.tests import jarque_bera_test_step
 from SymbolicDSGE.monte_carlo.operations.transforms import transform_step
+from SymbolicDSGE.monte_carlo.serialize import serialize_pipeline_result
 
 
 def zscore(*, context, **kwargs):
     """Top-level custom op (NumpyCustomFunc-eligible)."""
     arr = context.require_data().observables
     return (arr - arr.mean(axis=0)) / arr.std(axis=0)
+
+
+def selection_rate(*, traces, reference, dgp):
+    """Top-level postproc op: bare values auto-wrap (scalar -> Summary, array ->
+    Raw), so the op body references no captured types."""
+    pval = traces["test.jb.pval"]
+    indicator = (pval < 0.5).astype(float)
+    return {"rate": float(indicator.mean()), "flags": indicator}
 
 
 def _raw_data_pipeline() -> MCPipeline:
@@ -84,6 +97,39 @@ def test_add_mc_ships_custom_op_member_and_loader_rebuilds(tmp_path) -> None:
     z_step = {s.name: s for s in rebuilt.steps}["z"]
     assert z_step.step_type == "transform:custom"
     assert callable(z_step.func)
+
+
+def test_add_mc_ships_postproc_artifacts_and_wire_round_trips(tmp_path) -> None:
+    observables = np.random.default_rng(2).normal(size=(4, 20, 2))
+    pipe = MCPipeline(
+        [
+            raw_data_step("dat", observables=observables, observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            postproc_step("post", selection_rate),
+        ]
+    )
+    result = pipe.run(reference=cast(SolvedModel, object()), n_rep=4, verbosity=0)
+
+    target = (
+        BundleBuilder(created_by="mc-test")
+        .add_mc(pipe, result=result, run_id="r1")
+        .write(tmp_path / "pp.sdsge")
+    )
+
+    loaded = build_from(target)
+    assert loaded.mc is not None
+    # The bulk array artifact rides its own shape-manifest parquet member.
+    assert any(m.kind == "mc_postproc" for m in loaded.manifest.members)
+    np.testing.assert_array_equal(
+        loaded.mc.postproc_arrays["post.flags"], result.postproc["post.flags"].value
+    )
+
+    # document (scalar inline) + parquet array re-merge to the live wire shape.
+    wire = loaded.mc.wire()
+    assert wire is not None
+    assert (
+        wire["postproc"] == serialize_pipeline_result(result, run_id="r1")["postproc"]
+    )
 
 
 def test_add_mc_rejects_unshippable_custom_op(tmp_path) -> None:

--- a/tests/monte_carlo/test_postproc.py
+++ b/tests/monte_carlo/test_postproc.py
@@ -53,6 +53,48 @@ def test_no_postproc_yields_empty_bucket() -> None:
     assert _run([]).postproc == {}
 
 
+def test_pcs_end_to_end_scalar_and_selection_vector() -> None:
+    # PCS (Probability of Correct Selection): across reps, the test with the
+    # smallest p-value is "selected"; PCS is the rate at which that index matches
+    # the expected one. A worked example, not a built-in — its meaning depends on
+    # the upstream tests, so the engine doesn't define it.
+    from SymbolicDSGE.monte_carlo.serialize import result_traces
+
+    n_rep = 6
+    pval_keys = ["test.jb_y.pval", "test.jb_x.pval"]
+
+    def selection(*, traces, reference, dgp, expected):
+        mat = np.column_stack([traces[k] for k in pval_keys])
+        return Raw((mat.argmin(axis=1) == expected).astype(float))
+
+    def pcs(*, traces, reference, dgp, expected):
+        mat = np.column_stack([traces[k] for k in pval_keys])
+        return float((mat.argmin(axis=1) == expected).mean())
+
+    pipeline = MCPipeline(
+        [
+            raw_data_step(observables=_observables(n_rep), observable_names=("y", "x")),
+            jarque_bera_test_step("jb_y", source="observables", column=0),
+            jarque_bera_test_step("jb_x", source="observables", column=1),
+            _postproc("sel", selection, expected=0),
+            _postproc("pcs", pcs, expected=0),
+        ]
+    )
+    result = pipeline.run(reference=_REFERENCE, n_rep=n_rep, verbosity=0)
+
+    # Recompute independently from the stored traces (same arrays the op saw).
+    mat = np.column_stack([result_traces(result)[k] for k in pval_keys])
+    indicator = (mat.argmin(axis=1) == 0).astype(float)
+    expected_pcs = float(indicator.mean())
+
+    assert result.postproc["pcs"].value == pytest.approx(expected_pcs)
+    np.testing.assert_array_equal(result.postproc["sel"].value, indicator)
+    # PCS is exactly the across-rep mean = sum / len of the 0/1 selection vector.
+    assert result.postproc["pcs"].value == pytest.approx(
+        indicator.sum() / len(indicator)
+    )
+
+
 def test_traces_expose_test_pvals_with_n_successful_length() -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/monte_carlo/test_serialize.py
+++ b/tests/monte_carlo/test_serialize.py
@@ -17,12 +17,32 @@ from SymbolicDSGE.monte_carlo import (
 from SymbolicDSGE.monte_carlo.operations.core import raw_data_step
 from SymbolicDSGE.monte_carlo.operations.regressions import regression_step
 from SymbolicDSGE.monte_carlo.operations.tests import jarque_bera_test_step
+from SymbolicDSGE.monte_carlo.postproc import Raw, Summary
 from SymbolicDSGE.monte_carlo.serialize import (
     pipeline_result_wire,
     result_document,
+    result_postproc_arrays,
     result_traces,
     serialize_pipeline_result,
 )
+
+
+def _postproc_result() -> MCPipelineResult:
+    """A bare result carrying a scalar Summary plus 1-D and 2-D array artifacts."""
+    return MCPipelineResult(
+        n_rep=5,
+        n_successful=5,
+        test_summaries={},
+        test_results=None,
+        payloads=None,
+        contexts=None,
+        postproc={
+            "pcs": Summary(value=0.6, title="PCS"),
+            "selection": Raw(value=np.array([0.0, 1.0, 0.0, 1.0, 0.0])),
+            "density": Raw(value=np.arange(8.0).reshape(4, 2)),
+            "moments": Summary(value=np.array([1.0, 2.0]), render="array"),
+        },
+    )
 
 
 def _run_demo_pipeline(n_rep: int = 3) -> MCPipelineResult:
@@ -114,6 +134,82 @@ def test_wire_reconstructs_dropped_all_nan_trace_columns() -> None:
     assert entry["pval_trace"] == [None, None, None]
     # status (integer-valued) survives and is unchanged.
     assert len(entry["status_trace"]) == 3
+
+
+def test_postproc_scalar_inline_array_to_traces() -> None:
+    result = _postproc_result()
+    document = result_document(result, run_id="r1")
+    arrays = result_postproc_arrays(result)
+
+    # Scalars (and their metadata) stay inline in the document.
+    pcs = document["postproc"]["pcs"]
+    assert pcs == {
+        "kind": "summary",
+        "title": "PCS",
+        "render": "auto",
+        "artifact": "scalar",
+        "value": 0.6,
+    }
+    # Array artifacts keep metadata but the bulk value is stripped to parquet.
+    density = document["postproc"]["density"]
+    assert density == {"kind": "raw", "artifact": "array", "shape": [4, 2]}
+    assert "value" not in document["postproc"]["selection"]
+    assert "value" not in document["postproc"]["moments"]
+
+    # Only the ndarray artifacts (Raw + array-valued Summary) become payloads.
+    assert set(arrays) == {"selection", "density", "moments"}
+    assert arrays["density"].shape == (4, 2)
+    json.dumps(document)
+
+
+def test_postproc_wire_round_trips_scalar_and_arrays() -> None:
+    result = _postproc_result()
+    wire = serialize_pipeline_result(result, run_id="r1")
+    recombined = pipeline_result_wire(
+        result_document(result, run_id="r1"),
+        result_traces(result),
+        result_postproc_arrays(result),
+    )
+    assert recombined == wire
+    assert recombined["postproc"]["pcs"]["value"] == 0.6
+    assert recombined["postproc"]["density"]["value"] == [
+        [0.0, 1.0],
+        [2.0, 3.0],
+        [4.0, 5.0],
+        [6.0, 7.0],
+    ]
+
+
+def test_postproc_wire_reconstructs_dropped_all_nan_array() -> None:
+    # An all-NaN Raw becomes an all-null column the Parquet encoder drops;
+    # hydration rebuilds it as a NaN array of the recorded shape (-> JSON null).
+    result = MCPipelineResult(
+        n_rep=3,
+        n_successful=3,
+        test_summaries={},
+        test_results=None,
+        payloads=None,
+        contexts=None,
+        postproc={"empty": Raw(value=np.full(3, np.nan))},
+    )
+    document = result_document(result, run_id="r1")
+    wire = pipeline_result_wire(document, {}, {})  # array dropped -> absent
+    assert wire["postproc"]["empty"]["value"] == [None, None, None]
+
+
+def test_postproc_summary_rejects_non_scalar_value() -> None:
+    # Tabular/DataFrame Summary values are out of scope until #181.
+    result = MCPipelineResult(
+        n_rep=1,
+        n_successful=1,
+        test_summaries={},
+        test_results=None,
+        payloads=None,
+        contexts=None,
+        postproc={"table": Summary(value={"a": [1, 2]})},
+    )
+    with pytest.raises(TypeError, match="#181"):
+        serialize_pipeline_result(result, run_id="r1")
 
 
 def test_pipeline_spec_round_trips() -> None:


### PR DESCRIPTION
This pull request adds robust support for serializing, storing, and round-tripping arbitrary-shaped POSTPROC array artifacts in Monte Carlo pipeline results. POSTPROC artifacts that are arrays are now saved as separate shape-manifested Parquet members in the bundle, while scalar artifacts remain inline in the result document. The loader and wire serialization logic have been updated to seamlessly re-merge these artifacts, ensuring lossless hydration and robust handling of missing or all-NaN arrays. Comprehensive tests are included to validate the new behavior.

**POSTPROC artifact serialization and storage:**

- POSTPROC array artifacts are now extracted from `MCPipelineResult` and stored as individual Parquet members in the bundle, each with its own shape and name metadata. Scalar artifacts remain inline in the result document. (`SymbolicDSGE/bundle/builder.py`, `result_postproc_arrays`, `arrays_to_parquet`, `result_document`) [[1]](diffhunk://#diff-d81f2818a8c71f352df09c44b8fb16ea034874fda3c486025a44c486597dd026L37-R41) [[2]](diffhunk://#diff-d81f2818a8c71f352df09c44b8fb16ea034874fda3c486025a44c486597dd026R67-R71) [[3]](diffhunk://#diff-d81f2818a8c71f352df09c44b8fb16ea034874fda3c486025a44c486597dd026R282-R304) [[4]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631R133-R197) [[5]](diffhunk://#diff-e242cc976792af2f3703c98489df40d81610b33ea46f1fd3189e1b5a79549631R210-R243)
- The bundle manifest and loader have been extended to recognize and correctly restore these POSTPROC Parquet members, reconstructing missing all-NaN arrays as needed for robust hydration. (`SymbolicDSGE/bundle/manifest.py`, `SymbolicDSGE/bundle/loader.py`) [[1]](diffhunk://#diff-38cbbd700cc4b8a42f01ee5a4860010e7e860aebd6800a49b0945263770099e7R35) [[2]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR64-R70) [[3]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR202-R232)

**Wire format and serialization improvements:**

- The wire format (`pipeline_result_wire`) now merges POSTPROC arrays from the Parquet side-channel, ensuring the UI receives complete artifacts, and reconstructs missing arrays as all-NaN when necessary. (`SymbolicDSGE/monte_carlo/serialize.py`)
- Serialization logic for POSTPROC artifacts distinguishes between scalar and array artifacts, raising errors for unsupported types (e.g., DataFrames), and includes shape and metadata for arrays. (`SymbolicDSGE/monte_carlo/serialize.py`)

**Testing and validation:**

- Extensive new and updated tests validate that POSTPROC artifacts (both scalars and arrays) are correctly serialized, stored, loaded, and round-tripped through the wire format, including edge cases like all-NaN arrays and error handling for unsupported types. (`tests/bundle/test_mc_facade.py`, `tests/monte_carlo/test_postproc.py`, `tests/monte_carlo/test_serialize.py`) [[1]](diffhunk://#diff-08bad212206e2420f115acd1cd1e1093a3f61696a5285d21802278d4d0ebf054R25-R32) [[2]](diffhunk://#diff-08bad212206e2420f115acd1cd1e1093a3f61696a5285d21802278d4d0ebf054R102-R134) [[3]](diffhunk://#diff-76132d27886547d44b6d4d0518dc11af901a2be32346c2a3461637f2c4f56870R56-R97) [[4]](diffhunk://#diff-002d7e128d89c24b49b58d2111e7b21b7054b36ec14860654b4e5254b0c1a324R139-R214)

closes #180 