### PR TITLE
Add PandasCustomFunc and update custom operation handling

### DIFF
--- a/SymbolicDSGE/bundle/builder.py
+++ b/SymbolicDSGE/bundle/builder.py
@@ -409,17 +409,31 @@ class BundleBuilder:
 
 
 def _custom_op_blob(step: MCStep) -> bytes:
-    """Wrap a custom step's callable as a NumpyCustomFunc and cloudpickle it.
+    """Wrap a custom step's callable in the phase wrapper and cloudpickle it.
 
     Wrapping enforces the author-side contract (top-level def, safe namespace)
     and snapshots the source + captured globals, so the receiver can audit the
-    op at load. Already-wrapped callables pass through idempotently.
+    op at load. Post-loop (POSTPROC) ops get the looser pandas namespace; every
+    other phase gets numpy. An already-wrapped callable passes through; a pandas
+    wrapper outside the post-loop phase is rejected.
     """
     import cloudpickle
 
-    from ..monte_carlo.custom_op import NumpyCustomFunc
+    from ..monte_carlo.custom_op import (
+        CustomFunc,
+        CustomOpValidationError,
+        NumpyCustomFunc,
+        PandasCustomFunc,
+    )
+    from ..monte_carlo.mc_constructs import OpType
 
-    wrapped = NumpyCustomFunc(step.func)
+    wrapper = PandasCustomFunc if step.op_type is OpType.POSTPROC else NumpyCustomFunc
+    if isinstance(step.func, PandasCustomFunc) and wrapper is NumpyCustomFunc:
+        raise CustomOpValidationError(
+            f"{step.name!r}: a PandasCustomFunc is only allowed in a post-loop "
+            f"(POSTPROC) step, not a {step.op_type.value!r} step."
+        )
+    wrapped = step.func if isinstance(step.func, CustomFunc) else wrapper(step.func)
     return cast(bytes, cloudpickle.dumps(wrapped))
 
 

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -17,7 +17,13 @@ from .catalog import (
     catalog_payload,
 )
 from .core import MCPipeline
-from .custom_op import NumpyCustomFunc, custom_operation
+from .custom_op import (
+    CustomFunc,
+    NumpyCustomFunc,
+    PandasCustomFunc,
+    numpy_operation,
+    pandas_operation,
+)
 from .postproc import Raw, Summary
 from .mc_constructs import (
     MCContext,
@@ -40,8 +46,11 @@ __all__ = [
     "MCContext",
     "MCData",
     "OpType",
-    "custom_operation",
+    "numpy_operation",
+    "pandas_operation",
+    "CustomFunc",
     "NumpyCustomFunc",
+    "PandasCustomFunc",
     "Summary",
     "Raw",
     # graph spec (serialization / bundle)

--- a/SymbolicDSGE/monte_carlo/custom_op.py
+++ b/SymbolicDSGE/monte_carlo/custom_op.py
@@ -43,7 +43,8 @@ import operator
 import statistics
 import textwrap
 from collections.abc import Mapping
-from typing import Any, Callable
+from functools import lru_cache
+from typing import Any, Callable, cast
 
 import numpy as np
 
@@ -183,6 +184,76 @@ DENIED_ATTRIBUTES: dict[str, frozenset[str]] = {
     "np": _NUMPY_DENIED,
 }
 
+#: Captured-global value types accepted beyond scalars/immutable containers.
+_NUMPY_VALUE_TYPES: tuple[type, ...] = (np.ndarray, np.generic, np.dtype)
+
+#: The numpy namespace config consumed by :class:`CustomFunc` — the bundle of
+#: allow/deny lists a subclass supplies. :class:`PandasCustomFunc` builds its own
+#: by extending these (see :func:`_pandas_namespace`).
+_NUMPY_NAMESPACE: dict[str, Any] = {
+    "safe_modules": SAFE_MODULES,
+    "denied_attributes": DENIED_ATTRIBUTES,
+    "extra_value_types": _NUMPY_VALUE_TYPES,
+    "namespace_kind": "numpy",
+}
+
+#: Pandas module-level footguns: I/O readers/writers and the eval surface. Same
+#: module-root reach as :data:`_NUMPY_DENIED` (catches ``pd.read_csv``, not a
+#: ``df.to_csv()`` method on a local — author hygiene, not a sandbox).
+_PANDAS_DENIED: frozenset[str] = frozenset(
+    {
+        "read_csv",
+        "read_table",
+        "read_fwf",
+        "read_excel",
+        "read_parquet",
+        "read_pickle",
+        "read_feather",
+        "read_hdf",
+        "read_orc",
+        "read_json",
+        "read_html",
+        "read_xml",
+        "read_sql",
+        "read_sql_query",
+        "read_sql_table",
+        "read_gbq",
+        "read_stata",
+        "read_spss",
+        "read_sas",
+        "read_clipboard",
+        "ExcelFile",
+        "HDFStore",
+        "eval",
+        "io",
+        "compat",
+        "test",
+        "testing",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _pandas_namespace() -> dict[str, Any]:
+    """The pandas namespace config: the numpy lists extended with pandas.
+
+    Lazily imports pandas (cached) so merely importing this module — which is on
+    the core import path — never pulls in pandas; the cost is paid only when a
+    :class:`PandasCustomFunc` is actually constructed.
+    """
+    import pandas as pd
+
+    return {
+        "safe_modules": {**SAFE_MODULES, "pandas": pd, "pd": pd},
+        "denied_attributes": {
+            **DENIED_ATTRIBUTES,
+            "pandas": _PANDAS_DENIED,
+            "pd": _PANDAS_DENIED,
+        },
+        "extra_value_types": (*_NUMPY_VALUE_TYPES, pd.DataFrame, pd.Series, pd.Index),
+        "namespace_kind": "pandas",
+    }
+
 
 # ---- Exception -----------------------------------------------------------
 
@@ -224,19 +295,22 @@ def _extract_source(func: Callable[..., Any]) -> str:
 # ---- AST validation ------------------------------------------------------
 
 
-def _is_custom_operation_decorator(node: ast.expr) -> bool:
-    """Recognize the ``@custom_operation`` marker.
+_OPERATION_MARKERS: frozenset[str] = frozenset({"numpy_operation", "pandas_operation"})
 
-    A function decorated with :func:`custom_operation` carries that decorator in
-    its captured source (``inspect.getsource`` includes decorator lines), so the
-    validator must tolerate this one marker while still rejecting every other
-    decorator. Matched by trailing name so ``@custom_operation`` and
-    ``@sd.custom_operation`` both pass.
+
+def _is_operation_decorator(node: ast.expr) -> bool:
+    """Recognize the ``@numpy_operation`` / ``@pandas_operation`` markers.
+
+    A function decorated with one of these carries the decorator in its captured
+    source (``inspect.getsource`` includes decorator lines), so the validator
+    must tolerate these markers while still rejecting every other decorator.
+    Matched by trailing name so ``@numpy_operation`` and ``@sd.numpy_operation``
+    both pass.
     """
     if isinstance(node, ast.Name):
-        return node.id == "custom_operation"
+        return node.id in _OPERATION_MARKERS
     if isinstance(node, ast.Attribute):
-        return node.attr == "custom_operation"
+        return node.attr in _OPERATION_MARKERS
     return False
 
 
@@ -289,11 +363,11 @@ class _Validator(ast.NodeVisitor):
 
     def validate(self, tree: ast.FunctionDef) -> None:
         for decorator in tree.decorator_list:
-            if not _is_custom_operation_decorator(decorator):
+            if not _is_operation_decorator(decorator):
                 self._fail(
                     "decorated functions cannot be wrapped (other than the "
-                    "@custom_operation marker). Apply @custom_operation as the "
-                    "only decorator, or remove decorators."
+                    "@numpy_operation / @pandas_operation marker). Apply one as "
+                    "the only decorator, or remove decorators."
                 )
         args = tree.args
         for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
@@ -506,12 +580,17 @@ def _capture_globals(
     global_loads: Mapping[str, ast.AST],
     attribute_loads: list[tuple[str, tuple[str, ...]]],
     func_name: str,
+    *,
+    safe_modules: Mapping[str, Any],
+    denied_attributes: Mapping[str, frozenset[str]],
+    extra_value_types: tuple[type, ...],
 ) -> dict[str, Any]:
     """Resolve referenced names against the function's globals + safe namespace.
 
     Returns a snapshot dict keyed by name. Each value passes the safe-value
-    check (numpy / scalar / immutable container / :class:`NumpyCustomFunc`
-    helper). Raises :class:`CustomOpValidationError` on anything else.
+    check (the namespace's value types / scalar / immutable container /
+    :class:`CustomFunc` helper) per the supplied allow/deny lists. Raises
+    :class:`CustomOpValidationError` on anything else.
     """
     captured: dict[str, Any] = {}
     func_globals = getattr(func, "__globals__", {})
@@ -519,7 +598,7 @@ def _capture_globals(
 
     # Attribute-chain deny-list check (per-module).
     for root, chain in attribute_loads:
-        denied = DENIED_ATTRIBUTES.get(root)
+        denied = denied_attributes.get(root)
         if denied is None:
             continue
         for attr in chain:
@@ -536,12 +615,18 @@ def _capture_globals(
         if name in DENIED_BUILTINS:
             raise CustomOpValidationError(
                 f"{func_name!r}: name `{name}` is in the explicit deny list "
-                "of builtins. NumpyCustomFunc forbids reflective and I/O "
+                "of builtins. Custom ops forbid reflective and I/O "
                 "primitives by design."
             )
         if name in func_globals:
             value = func_globals[name]
-            _validate_captured_value(name, value, func_name)
+            _validate_captured_value(
+                name,
+                value,
+                func_name,
+                safe_modules=safe_modules,
+                extra_value_types=extra_value_types,
+            )
             captured[name] = value
             continue
         if name in builtin_attrs:
@@ -556,28 +641,39 @@ def _capture_globals(
     return captured
 
 
-def _validate_captured_value(name: str, value: Any, func_name: str) -> None:
+def _validate_captured_value(
+    name: str,
+    value: Any,
+    func_name: str,
+    *,
+    safe_modules: Mapping[str, Any],
+    extra_value_types: tuple[type, ...],
+) -> None:
     """Reject globals whose runtime type isn't in the safe-value set.
 
-    Modules are accepted only when they match one of :data:`SAFE_MODULES`
-    by identity (so a re-bound ``np = some_other_module`` is caught).
-    Containers are walked recursively up to a bounded depth.
+    Modules are accepted only when they match the namespace's ``safe_modules``
+    by identity (so a re-bound ``np = some_other_module`` is caught). Containers
+    are walked recursively up to a bounded depth.
     """
     if inspect.ismodule(value):
-        if name not in SAFE_MODULES or SAFE_MODULES[name] is not value:
+        if name not in safe_modules or safe_modules[name] is not value:
             mod_name = getattr(value, "__name__", "<unknown>")
             raise CustomOpValidationError(
                 f"{func_name!r}: global `{name}` resolves to module "
                 f"`{mod_name}`, which is not in the safe-module set."
             )
         return
-    if isinstance(value, NumpyCustomFunc):
+    if isinstance(value, CustomFunc):
         return
-    _validate_value_recursive(name, value, func_name)
+    _validate_value_recursive(name, value, func_name, extra_value_types)
 
 
 def _validate_value_recursive(
-    name: str, value: Any, func_name: str, _depth: int = 0
+    name: str,
+    value: Any,
+    func_name: str,
+    extra_value_types: tuple[type, ...],
+    _depth: int = 0,
 ) -> None:
     if _depth > 20:
         raise CustomOpValidationError(
@@ -586,46 +682,51 @@ def _validate_value_recursive(
         )
     if isinstance(value, _SAFE_SCALAR_TYPES):
         return
-    if isinstance(value, (np.ndarray, np.generic, np.dtype)):
+    if isinstance(value, extra_value_types):
         return
-    if isinstance(value, NumpyCustomFunc):
+    if isinstance(value, CustomFunc):
         return
     if isinstance(value, (tuple, list, frozenset, set)):
         for item in value:
-            _validate_value_recursive(name, item, func_name, _depth + 1)
+            _validate_value_recursive(
+                name, item, func_name, extra_value_types, _depth + 1
+            )
         return
     if isinstance(value, Mapping):
         for k, v in value.items():
-            _validate_value_recursive(name, k, func_name, _depth + 1)
-            _validate_value_recursive(name, v, func_name, _depth + 1)
+            _validate_value_recursive(name, k, func_name, extra_value_types, _depth + 1)
+            _validate_value_recursive(name, v, func_name, extra_value_types, _depth + 1)
         return
     raise CustomOpValidationError(
         f"{func_name!r}: captured global `{name}` has unsupported type "
-        f"`{type(value).__name__}`. Allowed: numpy types, scalars, strings, "
-        "bytes, immutable containers, and NumpyCustomFunc helpers."
+        f"`{type(value).__name__}`. Allowed: the namespace's value types, "
+        "scalars, strings, bytes, immutable containers, and CustomFunc helpers."
     )
 
 
 # ---- The wrapper ---------------------------------------------------------
 
 
-class NumpyCustomFunc:
-    """Opt-in wrapper validating a numerical function at definition time.
+class CustomFunc:
+    """Opt-in wrapper validating a function against a supplied safe namespace.
 
-    Construction snapshot:
+    Holds *all* the wrap-time validation logic; the namespace allow/deny lists
+    (``safe_modules`` / ``denied_attributes`` / ``extra_value_types``) are
+    supplied by a subclass — :class:`NumpyCustomFunc` and :class:`PandasCustomFunc`
+    are horizontal siblings that differ only in those lists. Construction:
 
     - extracts ``inspect.getsource(func)`` (refuses if unavailable);
     - parses + walks the AST against the safe namespace contract;
     - resolves every referenced global against ``func.__globals__`` and the
-      safe namespace, snapshotting accepted values into
+      supplied namespace, snapshotting accepted values into
       :attr:`captured_globals`.
 
     After construction the instance is callable as the original function. The
     snapshotted state survives :mod:`cloudpickle` round-trips, which is what
     lets a custom op travel inside a ``.sdsge`` bundle alongside its source.
 
-    Calling ``NumpyCustomFunc(already_wrapped)`` returns the existing instance
-    state (idempotent) so chained wrappings don't re-validate.
+    Wrapping an already-wrapped instance copies its validated state across
+    (idempotent) so chained wrappings don't re-validate.
     """
 
     __slots__ = (
@@ -634,6 +735,7 @@ class NumpyCustomFunc:
         "_captured_globals",
         "_name",
         "_safe_namespace_version",
+        "_namespace_kind",
     )
 
     # Typed mirrors of __slots__ so mypy can resolve attribute reads inside
@@ -643,20 +745,31 @@ class NumpyCustomFunc:
     _captured_globals: dict[str, Any]
     _name: str
     _safe_namespace_version: int
+    _namespace_kind: str
 
-    def __init__(self, func: Callable[..., Any] | NumpyCustomFunc) -> None:
-        if isinstance(func, NumpyCustomFunc):
-            # Idempotent — copy the validated state across.
+    def __init__(
+        self,
+        func: Callable[..., Any] | CustomFunc,
+        *,
+        safe_modules: Mapping[str, Any],
+        denied_attributes: Mapping[str, frozenset[str]],
+        extra_value_types: tuple[type, ...],
+        namespace_kind: str,
+    ) -> None:
+        if isinstance(func, CustomFunc):
+            # Idempotent — copy the validated state across (its original kind).
             self._func = func._func
             self._source = func._source
             self._captured_globals = func._captured_globals
             self._name = func._name
             self._safe_namespace_version = func._safe_namespace_version
+            self._namespace_kind = func._namespace_kind
             return
 
+        cls_name = type(self).__name__
         if not callable(func):
             raise CustomOpValidationError(
-                "NumpyCustomFunc expected a callable, got " f"{type(func).__name__}."
+                f"{cls_name} expected a callable, got {type(func).__name__}."
             )
 
         func_name = getattr(func, "__name__", None) or repr(func)
@@ -669,7 +782,7 @@ class NumpyCustomFunc:
         if qualname != func_name:
             raise CustomOpValidationError(
                 f"{func_name!r}: qualified name `{qualname}` indicates a "
-                "nested function or method. NumpyCustomFunc requires a "
+                f"nested function or method. {cls_name} requires a "
                 "top-level def."
             )
 
@@ -714,6 +827,9 @@ class NumpyCustomFunc:
             validator.global_loads,
             validator.attribute_loads,
             func_name,
+            safe_modules=safe_modules,
+            denied_attributes=denied_attributes,
+            extra_value_types=extra_value_types,
         )
 
         self._func = func
@@ -721,6 +837,7 @@ class NumpyCustomFunc:
         self._captured_globals = captured
         self._name = func_name
         self._safe_namespace_version = SAFE_NAMESPACE_VERSION
+        self._namespace_kind = namespace_kind
 
     # ----- read-only accessors -----
 
@@ -744,10 +861,34 @@ class NumpyCustomFunc:
         """Version of the safe-namespace contract enforced at wrap time."""
         return self._safe_namespace_version
 
+    @property
+    def namespace_kind(self) -> str:
+        """Which namespace this op was validated under (``"numpy"``/``"pandas"``)."""
+        return self._namespace_kind
+
     # ----- alternate constructor -----
 
     @classmethod
-    def from_source(cls, source: str) -> "NumpyCustomFunc":
+    def from_source(cls, source: str) -> "CustomFunc":
+        """Build a wrapper from source *text* under this class's namespace.
+
+        Overridden by the concrete siblings to supply their allow/deny lists;
+        the base has no namespace of its own.
+        """
+        raise NotImplementedError(
+            "Use NumpyCustomFunc.from_source / PandasCustomFunc.from_source."
+        )
+
+    @classmethod
+    def _from_source(
+        cls,
+        source: str,
+        *,
+        safe_modules: Mapping[str, Any],
+        denied_attributes: Mapping[str, frozenset[str]],
+        extra_value_types: tuple[type, ...],
+        namespace_kind: str,
+    ) -> "CustomFunc":
         """Build a wrapper from source *text* rather than a live function.
 
         The constructor recovers source via ``inspect.getsource``, which needs a
@@ -755,8 +896,8 @@ class NumpyCustomFunc:
         typed into a web editor and ``exec``'d. This validates the supplied text
         directly (same AST contract) and executes it in the safe namespace to
         obtain the callable, snapshotting the original text as :attr:`source` for
-        receiver-side audit. A leading ``@custom_operation`` marker is accepted
-        and treated as a no-op (the result is wrapped here regardless).
+        receiver-side audit. A leading ``@numpy_operation`` / ``@pandas_operation``
+        marker is accepted and treated as a no-op (the result is wrapped here).
 
         Raises :class:`CustomOpValidationError` on a parse error, a structure
         other than a single top-level ``def``, a safe-namespace violation, or an
@@ -780,9 +921,13 @@ class NumpyCustomFunc:
         validator = _Validator(func_name)
         validator.validate(func_def)
 
-        # `custom_operation` is neutralized so a decorated template execs to the
-        # bare function (its own getsource-based wrap would fail on exec'd code).
-        namespace: dict[str, Any] = {**SAFE_MODULES, "custom_operation": lambda f: f}
+        # The operation markers are neutralized so a decorated template execs to
+        # the bare function (its getsource-based wrap would fail on exec'd code).
+        namespace: dict[str, Any] = {
+            **safe_modules,
+            "numpy_operation": lambda f: f,
+            "pandas_operation": lambda f: f,
+        }
         try:
             exec(compile(tree, "<custom_op>", "exec"), namespace)  # noqa: S102
         except Exception as exc:
@@ -791,7 +936,13 @@ class NumpyCustomFunc:
             ) from exc
         func = namespace[func_name]
         captured = _capture_globals(
-            func, validator.global_loads, validator.attribute_loads, func_name
+            func,
+            validator.global_loads,
+            validator.attribute_loads,
+            func_name,
+            safe_modules=safe_modules,
+            denied_attributes=denied_attributes,
+            extra_value_types=extra_value_types,
         )
 
         instance = object.__new__(cls)
@@ -800,6 +951,7 @@ class NumpyCustomFunc:
         instance._captured_globals = captured
         instance._name = func_name
         instance._safe_namespace_version = SAFE_NAMESPACE_VERSION
+        instance._namespace_kind = namespace_kind
         return instance
 
     # ----- runtime surface -----
@@ -808,18 +960,51 @@ class NumpyCustomFunc:
         return self._func(*args, **kwargs)
 
     def __repr__(self) -> str:
-        return f"NumpyCustomFunc({self._name})"
+        return f"{type(self).__name__}({self._name})"
 
 
-def custom_operation(func: Callable[..., Any]) -> NumpyCustomFunc:
-    """Decorator marking a numerical function as a shippable custom op.
+class NumpyCustomFunc(CustomFunc):
+    """Custom op restricted to the numpy/math/statistics/operator namespace.
+
+    The per-replication (and default) contract. Use for transforms and any op
+    that runs inside the replication loop.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, func: Callable[..., Any] | CustomFunc) -> None:
+        super().__init__(func, **_NUMPY_NAMESPACE)
+
+    @classmethod
+    def from_source(cls, source: str) -> "NumpyCustomFunc":
+        return cast("NumpyCustomFunc", cls._from_source(source, **_NUMPY_NAMESPACE))
+
+
+class PandasCustomFunc(CustomFunc):
+    """Custom op whose namespace additionally exposes pandas (as ``pd``).
+
+    The looser post-loop (``OpType.POSTPROC``) contract — a summary op may build
+    a DataFrame. Pandas is referenced (``import`` stays banned, like ``np``); a
+    pandas-enabled op outside the post-loop phase is rejected by the pipeline.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, func: Callable[..., Any] | CustomFunc) -> None:
+        super().__init__(func, **_pandas_namespace())
+
+    @classmethod
+    def from_source(cls, source: str) -> "PandasCustomFunc":
+        return cast("PandasCustomFunc", cls._from_source(source, **_pandas_namespace()))
+
+
+def numpy_operation(func: Callable[..., Any]) -> NumpyCustomFunc:
+    """Decorator marking a numerical function as a shippable numpy custom op.
 
     Equivalent to wrapping with :class:`NumpyCustomFunc`, but as a decorator it
-    documents intent at the definition site — a reviewer reading the code sees
-    the op is destined for a ``.sdsge`` bundle — and guarantees the function is
-    validated and snapshotted up front rather than (auto-)wrapped later::
+    documents intent at the definition site and validates/snapshots up front::
 
-        @custom_operation
+        @numpy_operation
         def zscore(*, context, **kwargs):
             arr = context.require_data().observables
             return (arr - arr.mean(axis=0)) / arr.std(axis=0)
@@ -828,3 +1013,14 @@ def custom_operation(func: Callable[..., Any]) -> NumpyCustomFunc:
     handed straight to ``transform_step`` (or any custom-op factory).
     """
     return NumpyCustomFunc(func)
+
+
+def pandas_operation(func: Callable[..., Any]) -> PandasCustomFunc:
+    """Decorator marking a post-loop op as a shippable pandas custom op.
+
+    The pandas sibling of :func:`numpy_operation`: the body may reference ``pd``
+    in addition to the numpy namespace. Intended for ``OpType.POSTPROC`` summary
+    ops (e.g. one returning a DataFrame); using it on a per-replication step is
+    rejected when the pipeline is built.
+    """
+    return PandasCustomFunc(func)

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -16,6 +16,7 @@ from ..kalman.filter import FilterResult
 from ..regression.enums import RegressionStatus
 from ..regression.ols import MCRegressionResult
 from ..regression.result import RegressionResult
+from .custom_op import PandasCustomFunc
 
 NDF = NDArray[float64]
 NDB = NDArray[np.bool_]
@@ -154,6 +155,18 @@ class MCStep:
             raise ValueError("MCStep name must be non-empty.")
         object.__setattr__(self, "op_type", OpType(self.op_type))
         object.__setattr__(self, "kwargs", dict(self.kwargs))
+        # The pandas namespace is a post-loop-only privilege: a PandasCustomFunc
+        # in a per-rep step would reference pandas inside the replication loop,
+        # which the looser contract is not meant to sanction.
+        if (
+            isinstance(self.func, PandasCustomFunc)
+            and self.op_type is not OpType.POSTPROC
+        ):
+            raise ValueError(
+                f"MCStep {self.name!r}: a PandasCustomFunc is only allowed in a "
+                "post-loop (POSTPROC) step, not a "
+                f"{self.op_type.value!r} step."
+            )
 
     @property
     def output_key(self) -> str:

--- a/SymbolicDSGE/monte_carlo/operations/postproc/builtins.py
+++ b/SymbolicDSGE/monte_carlo/operations/postproc/builtins.py
@@ -20,8 +20,9 @@ def postproc_step(
     Post-loop op contract: ``func(*, traces, reference, dgp, **kwargs)`` returning
     :class:`~SymbolicDSGE.monte_carlo.postproc.Summary` / ``Raw`` artifacts (or a
     mapping of them). Bundling additionally requires the callable to be a
-    :class:`~SymbolicDSGE.monte_carlo.custom_op.NumpyCustomFunc`; the bundle
-    builder enforces/auto-wraps that at serialization time.
+    :class:`~SymbolicDSGE.monte_carlo.custom_op.CustomFunc`; the bundle builder
+    enforces/auto-wraps post-loop ops under the pandas namespace (so a returned
+    DataFrame's builder code may reference ``pd``) at serialization time.
     """
     return MCStep(
         name=name,

--- a/SymbolicDSGE/monte_carlo/operations/transforms/builtins.py
+++ b/SymbolicDSGE/monte_carlo/operations/transforms/builtins.py
@@ -27,7 +27,7 @@ def transform_step(
     ``MCData``-returning data ops). Bundling such a step additionally requires
     the callable to be a
     :class:`~SymbolicDSGE.monte_carlo.custom_op.NumpyCustomFunc` (use
-    ``@custom_operation`` or pass one); the bundle builder enforces and
+    ``@numpy_operation`` or pass one); the bundle builder enforces and
     auto-wraps that at serialization time.
     """
     return MCStep(

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -17,8 +17,10 @@ from SymbolicDSGE.monte_carlo import catalog_payload
 from SymbolicDSGE.monte_carlo import run_pipeline as _run_pipeline
 from SymbolicDSGE.monte_carlo import validate_pipeline_spec as _validate_pipeline_spec
 from SymbolicDSGE.monte_carlo.custom_op import (
+    CustomFunc,
     CustomOpValidationError,
     NumpyCustomFunc,
+    PandasCustomFunc,
 )
 from SymbolicDSGE.monte_carlo.serialize import (
     serialize_pipeline_result as serialize_pipeline_result,
@@ -28,7 +30,7 @@ from .mc_schemas import MCPipelineSpec
 
 #: Pre-fill for the custom-op Monaco editor. numpy is available as ``np`` inside
 #: the safe namespace, so no imports are needed (and the validator rejects them).
-MC_CUSTOM_OP_TEMPLATE = '''@custom_operation
+MC_CUSTOM_OP_TEMPLATE = '''@numpy_operation
 def transform(*, context, reference, dgp, rep_idx, **kwargs):
     """Custom Monte-Carlo transform. Runs once per replication."""
     # numpy is available as `np` (no imports needed). Read this replication's
@@ -58,14 +60,22 @@ def mc_custom_op_template() -> dict[str, str]:
     return {"template": MC_CUSTOM_OP_TEMPLATE}
 
 
-def validate_custom_op(code: str) -> dict[str, Any]:
+def _custom_func_class(step_type: str) -> type[CustomFunc]:
+    """The wrapper class for a custom step kind: pandas for post-loop, else numpy."""
+    return PandasCustomFunc if step_type == "postproc:custom" else NumpyCustomFunc
+
+
+def validate_custom_op(
+    code: str, *, step_type: str = "transform:custom"
+) -> dict[str, Any]:
     """Validate a single custom-op source for live editor feedback.
 
     Returns ``{"valid": True, "name": ...}`` or ``{"valid": False, "error": ...}``
-    (a 200 either way) so the editor can render the message inline.
+    (a 200 either way) so the editor can render the message inline. ``step_type``
+    selects the namespace (``"postproc:custom"`` gets the pandas namespace).
     """
     try:
-        func = NumpyCustomFunc.from_source(code)
+        func = _custom_func_class(step_type).from_source(code)
     except CustomOpValidationError as exc:
         return {"valid": False, "error": str(exc)}
     return {"valid": True, "name": func.name}
@@ -74,9 +84,11 @@ def validate_custom_op(code: str) -> dict[str, Any]:
 def compile_custom_resources(spec: MCPipelineSpec) -> dict[str, Any]:
     """Compile each ``custom`` node's source into a callable, keyed by node name.
 
-    Feeds ``build_pipeline``/``run_pipeline`` via their ``resources`` seam. Raises
-    ``ValueError`` (node-scoped) on missing or invalid source so the validate/run
-    endpoints report which step failed.
+    Feeds ``build_pipeline``/``run_pipeline`` via their ``resources`` seam. The
+    namespace is phase-based: ``postproc:custom`` nodes compile under the pandas
+    namespace, ``transform:custom`` under numpy. Raises ``ValueError``
+    (node-scoped) on missing or invalid source so the validate/run endpoints
+    report which step failed.
     """
     resources: dict[str, Any] = {}
     for node in spec.nodes:
@@ -86,7 +98,7 @@ def compile_custom_resources(spec: MCPipelineSpec) -> dict[str, Any]:
         if not isinstance(code, str) or not code.strip():
             raise ValueError(f"Custom step '{node.name}' has no source code.")
         try:
-            resources[node.name] = NumpyCustomFunc.from_source(code)
+            resources[node.name] = _custom_func_class(node.step_type).from_source(code)
         except CustomOpValidationError as exc:
             raise ValueError(f"Custom step '{node.name}': {exc}") from exc
     return resources

--- a/tests/bundle/test_mc_facade.py
+++ b/tests/bundle/test_mc_facade.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from typing import cast
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from SymbolicDSGE.bundle import BundleBuilder, build_from
 from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.monte_carlo import MCPipeline, build_pipeline, validate_pipeline_spec
-from SymbolicDSGE.monte_carlo.custom_op import NumpyCustomFunc
+from SymbolicDSGE.monte_carlo.custom_op import (
+    CustomOpValidationError,
+    NumpyCustomFunc,
+    PandasCustomFunc,
+)
 from SymbolicDSGE.monte_carlo.operations.core import raw_data_step
 from SymbolicDSGE.monte_carlo.operations.postproc import postproc_step
 from SymbolicDSGE.monte_carlo.operations.tests import jarque_bera_test_step
@@ -20,6 +25,12 @@ def zscore(*, context, **kwargs):
     """Top-level custom op (NumpyCustomFunc-eligible)."""
     arr = context.require_data().observables
     return (arr - arr.mean(axis=0)) / arr.std(axis=0)
+
+
+def pval_table(*, traces, reference, dgp):
+    """Top-level pandas post-loop op returning a DataFrame (references `pd`)."""
+    pvals = traces["test.jb.pval"]
+    return pd.DataFrame({"rep": np.arange(pvals.size), "pval": pvals})
 
 
 def selection_rate(*, traces, reference, dgp):
@@ -163,6 +174,41 @@ def test_add_mc_ships_postproc_table_and_wire_round_trips(tmp_path) -> None:
     assert (
         wire["postproc"] == serialize_pipeline_result(result, run_id="r1")["postproc"]
     )
+
+
+def test_add_mc_ships_pandas_postproc_op_under_pandas_namespace(tmp_path) -> None:
+    observables = np.random.default_rng(5).normal(size=(6, 20, 2))
+    pipe = MCPipeline(
+        [
+            raw_data_step("dat", observables=observables, observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            postproc_step("ptab", pval_table),  # plain func -> auto-wrapped at ship
+        ]
+    )
+    result = pipe.run(reference=cast(SolvedModel, object()), n_rep=6, verbosity=0)
+
+    target = (
+        BundleBuilder(created_by="mc-test")
+        .add_mc(pipe, result=result, run_id="r1")
+        .write(tmp_path / "pandas_pp.sdsge")
+    )
+
+    loaded = build_from(target)
+    assert loaded.mc is not None
+    # The post-loop op was wrapped under the pandas namespace and round-trips.
+    func = loaded.mc.resources["ptab"]
+    assert isinstance(func, PandasCustomFunc)
+    out = func(traces={"test.jb.pval": np.array([0.1, 0.2])}, reference=None, dgp=None)
+    assert isinstance(out, pd.DataFrame)
+    # The DataFrame artifact also lands as a table member.
+    assert any(m.kind == "mc_postproc_table" for m in loaded.manifest.members)
+
+
+def test_pandas_wrapper_rejected_outside_postproc() -> None:
+    # A PandasCustomFunc on a per-rep transform is rejected at pipeline build.
+    wrapped = PandasCustomFunc(pval_table)
+    with pytest.raises((ValueError, CustomOpValidationError), match="POSTPROC"):
+        transform_step("bad", wrapped, source="observables")
 
 
 def test_add_mc_rejects_unshippable_custom_op(tmp_path) -> None:

--- a/tests/test_custom_op.py
+++ b/tests/test_custom_op.py
@@ -15,11 +15,16 @@ import cloudpickle
 import numpy as np
 import pytest
 
+import pandas as pd
+
 from SymbolicDSGE.monte_carlo.custom_op import (
+    CustomFunc,
     CustomOpValidationError,
     NumpyCustomFunc,
+    PandasCustomFunc,
     SAFE_NAMESPACE_VERSION,
-    custom_operation,
+    numpy_operation,
+    pandas_operation,
 )
 
 WEIGHTS = np.array([1.0, 2.0, 3.0])
@@ -31,7 +36,7 @@ def _identity_decorator(func):
     return func
 
 
-@custom_operation
+@numpy_operation
 def _decorated_log_diff(arr):
     return np.diff(np.log(arr + 1.0))
 
@@ -417,18 +422,18 @@ def test_cloudpickle_round_trip_preserves_helper_recursion() -> None:
     )
 
 
-# ---- @custom_operation decorator ----------------------------------------
+# ---- @numpy_operation decorator ----------------------------------------
 
 
-def test_custom_operation_decorator_produces_numpy_custom_func() -> None:
+def test_numpy_operation_decorator_produces_numpy_custom_func() -> None:
     assert isinstance(_decorated_log_diff, NumpyCustomFunc)
     arr = np.array([1.0, 3.0, 7.0])
     np.testing.assert_allclose(_decorated_log_diff(arr), np.diff(np.log(arr + 1.0)))
     # The marker decorator stays in the captured source (intent for reviewers).
-    assert "@custom_operation" in _decorated_log_diff.source
+    assert "@numpy_operation" in _decorated_log_diff.source
 
 
-def test_custom_operation_decorated_func_round_trips() -> None:
+def test_numpy_operation_decorated_func_round_trips() -> None:
     restored = cloudpickle.loads(cloudpickle.dumps(_decorated_log_diff))
     arr = np.array([1.0, 3.0, 7.0])
     np.testing.assert_allclose(restored(arr), _decorated_log_diff(arr))
@@ -442,7 +447,7 @@ def test_non_marker_decorator_is_still_rejected() -> None:
 
 # --- from_source (UI / web-editor path) -----------------------------------
 
-_FROM_SOURCE_OK = """@custom_operation
+_FROM_SOURCE_OK = """@numpy_operation
 def standardize_cols(*, context, reference, dgp, rep_idx, **kwargs):
     arr = np.asarray(kwargs["x"], dtype=float)
     return (arr - arr.mean(axis=0)) / arr.std(axis=0)
@@ -452,8 +457,8 @@ def standardize_cols(*, context, reference, dgp, rep_idx, **kwargs):
 def test_from_source_validates_execs_and_runs() -> None:
     func = NumpyCustomFunc.from_source(_FROM_SOURCE_OK)
     assert func.name == "standardize_cols"
-    # The @custom_operation marker is preserved in the audit source.
-    assert "@custom_operation" in func.source
+    # The @numpy_operation marker is preserved in the audit source.
+    assert "@numpy_operation" in func.source
     out = func(
         context=None, reference=None, dgp=None, rep_idx=0, x=np.array([1.0, 2, 3])
     )
@@ -484,3 +489,62 @@ def test_from_source_rejects_unsafe_names() -> None:
 def test_from_source_reports_syntax_errors() -> None:
     with pytest.raises(CustomOpValidationError, match="did not parse"):
         NumpyCustomFunc.from_source("def f(**kwargs)\n    return 1\n")
+
+
+# ---- PandasCustomFunc (post-loop pandas namespace) -----------------------
+
+
+@pandas_operation
+def _summary_table(*, traces, reference, dgp, **kwargs):
+    return pd.DataFrame({"stat": ["mean"], "value": [float(np.mean(traces["x"]))]})
+
+
+def test_pandas_operation_produces_pandas_custom_func() -> None:
+    assert isinstance(_summary_table, PandasCustomFunc)
+    assert isinstance(_summary_table, CustomFunc)
+    assert _summary_table.namespace_kind == "pandas"
+    out = _summary_table(traces={"x": np.array([1.0, 3.0])}, reference=None, dgp=None)
+    assert isinstance(out, pd.DataFrame)
+    assert out.loc[0, "value"] == 2.0
+
+
+def test_pandas_op_round_trips_through_cloudpickle() -> None:
+    restored = cloudpickle.loads(cloudpickle.dumps(_summary_table))
+    assert isinstance(restored, PandasCustomFunc)
+    assert restored.namespace_kind == "pandas"
+    out = restored(traces={"x": np.array([2.0, 4.0])}, reference=None, dgp=None)
+    assert out.loc[0, "value"] == 3.0
+
+
+def test_numpy_namespace_rejects_pandas_reference() -> None:
+    # The per-rep numpy contract has no `pd`; the same op fails under it.
+    with pytest.raises(CustomOpValidationError):
+        NumpyCustomFunc(_summary_table._func)
+
+
+def _reads_csv(*, traces, reference, dgp, **kwargs):
+    return pd.read_csv("x.csv")
+
+
+def test_pandas_io_footgun_is_denied() -> None:
+    with pytest.raises(CustomOpValidationError, match="read_csv"):
+        PandasCustomFunc(_reads_csv)
+
+
+_PANDAS_FROM_SOURCE = """@pandas_operation
+def describe(*, traces, reference, dgp, **kwargs):
+    return pd.DataFrame({"v": [float(np.sum(traces["x"]))]})
+"""
+
+
+def test_from_source_pandas_validates_and_runs() -> None:
+    func = PandasCustomFunc.from_source(_PANDAS_FROM_SOURCE)
+    assert isinstance(func, PandasCustomFunc)
+    assert "@pandas_operation" in func.source
+    out = func(traces={"x": np.array([1.0, 2.0, 3.0])}, reference=None, dgp=None)
+    assert out.loc[0, "v"] == 6.0
+
+
+def test_pandas_source_rejected_by_numpy_from_source() -> None:
+    with pytest.raises(CustomOpValidationError):
+        NumpyCustomFunc.from_source(_PANDAS_FROM_SOURCE)

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -983,7 +983,7 @@ def test_ui_backend_binds_filter_dependencies_from_graph_edges() -> None:
         validate_pipeline_spec(direct, has_reference=True, has_dgp=True)
 
 
-_UI_CUSTOM_OP = """@custom_operation
+_UI_CUSTOM_OP = """@numpy_operation
 def zscore(*, context, reference, dgp, rep_idx, **kwargs):
     arr = np.asarray(context.require_data().observables, dtype=float)
     return (arr - arr.mean(axis=0)) / arr.std(axis=0)
@@ -995,7 +995,7 @@ def test_ui_backend_custom_op_template_and_validate() -> None:
 
     template = client.get("/api/mc/custom/template")
     assert template.status_code == 200
-    assert "@custom_operation" in template.json()["template"]
+    assert "@numpy_operation" in template.json()["template"]
 
     ok = client.post("/api/mc/custom/validate", json={"code": _UI_CUSTOM_OP})
     assert ok.status_code == 200


### PR DESCRIPTION
This pull request refactors and generalizes the custom operation wrapper system for the Monte Carlo module, enabling both NumPy and Pandas-based custom operations with improved safety and flexibility. The main changes introduce a `CustomFunc` base class, from which `NumpyCustomFunc` and the new `PandasCustomFunc` inherit, and update the namespace validation logic to be more extensible. The API is also updated to use explicit `numpy_operation` and `pandas_operation` decorators.

**Custom operation system refactor and extension:**

* Introduced a `CustomFunc` base class, refactored `NumpyCustomFunc` to inherit from it, and added a new `PandasCustomFunc` for post-processing steps, each with their own safe namespace configurations. The wrapper now validates functions against the correct namespace, and the system supports both NumPy and Pandas operations. (`[[1]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L589-R729)`, `[[2]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355R738)`, `[[3]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L646-R772)`, `[[4]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355R864-R900)`, `[[5]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L783-R930)`)
* Updated logic for wrapping and validating custom operations in `_custom_op_blob`, enforcing that Pandas-based wrappers can only be used in post-processing steps, and raising an error otherwise. (`[SymbolicDSGE/bundle/builder.pyL412-R436](diffhunk://#diff-d81f2818a8c71f352df09c44b8fb16ea034874fda3c486025a44c486597dd026L412-R436)`)

**Namespace and validation improvements:**

* Created extensible, cached namespace configurations for both NumPy and Pandas, including allow/deny lists for modules and attributes, and extended the types of values that can be safely captured as globals. (`[SymbolicDSGE/monte_carlo/custom_op.pyR187-R256](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355R187-R256)`)
* Refactored global validation and capture logic to use the supplied namespace configuration, enabling future extensibility and ensuring correct enforcement for both operation types. (`[[1]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355R583-R601)`, `[[2]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L539-R629)`, `[[3]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L559-R676)`, `[[4]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L589-R729)`)

**API and decorator changes:**

* Replaced the `custom_operation` decorator with explicit `numpy_operation` and `pandas_operation` decorators, and updated AST validation and error messages to match. (`[[1]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5L20-R26)`, `[[2]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5L43-R53)`, `[[3]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L227-R313)`, `[[4]](diffhunk://#diff-ed0cabbdf77f0d0cbe186d26b6164446d9e9cf0d0457609eeb41f022bf9c5355L292-R370)`)

closes #182 