### PR TITLE
Support round-trip processing for custom ops in bundles and update docs

### DIFF
--- a/SymbolicDSGE/bundle/loader.py
+++ b/SymbolicDSGE/bundle/loader.py
@@ -53,8 +53,14 @@ class LoadedMC:
 
     ``resources`` reattaches the bulk side-channels the spec references by key:
     each ``raw_data`` ``data_ref`` maps to its restored ``{name: ndarray}`` arrays
-    and each ``custom`` ``func_ref`` to its callable. Pass it straight to
-    :func:`SymbolicDSGE.monte_carlo.build_pipeline` to rebuild a runnable pipeline.
+    and each ``custom`` ``func_ref`` (transform *or* post-loop) to its callable.
+    Pass it straight to :func:`SymbolicDSGE.monte_carlo.build_pipeline` to rebuild
+    a runnable pipeline.
+
+    Recovered run artifacts of a POSTPROC phase: ``postproc_arrays`` (bulk ndarray
+    artifacts) and ``postproc_tables`` (tabular/DataFrame artifacts as columnar
+    dicts); scalar artifacts ride inline in ``document``. :meth:`wire` re-merges
+    all three back into the canonical UI wire shape.
     """
 
     spec: PipelineSpec

--- a/tests/bundle/test_mc_facade.py
+++ b/tests/bundle/test_mc_facade.py
@@ -33,6 +33,19 @@ def pval_table(*, traces, reference, dgp):
     return pd.DataFrame({"rep": np.arange(pvals.size), "pval": pvals})
 
 
+def summary_bundle(*, traces, reference, dgp, threshold):
+    """Post-loop op emitting all three artifact kinds: scalar, array, table."""
+    pvals = traces["test.jb.pval"]
+    flags = (pvals < threshold).astype(float)
+    return {
+        "pcs": float(flags.mean()),  # scalar -> Summary (document)
+        "flags": flags,  # array -> Raw (mc_postproc)
+        "table": pd.DataFrame(  # DataFrame -> Summary table (mc_postproc_table)
+            {"rep": np.arange(pvals.size), "pval": pvals}
+        ),
+    }
+
+
 def selection_rate(*, traces, reference, dgp):
     """Top-level postproc op: bare values auto-wrap (scalar -> Summary, array ->
     Raw), so the op body references no captured types."""
@@ -202,6 +215,66 @@ def test_add_mc_ships_pandas_postproc_op_under_pandas_namespace(tmp_path) -> Non
     assert isinstance(out, pd.DataFrame)
     # The DataFrame artifact also lands as a table member.
     assert any(m.kind == "mc_postproc_table" for m in loaded.manifest.members)
+
+
+def test_postproc_custom_op_full_round_trip(tmp_path) -> None:
+    # Acceptance (#183): a pipeline with a custom POSTPROC op emitting scalar +
+    # array + table artifacts writes to .sdsge and reloads to an equivalent
+    # runnable pipeline whose re-run reproduces the recovered artifacts.
+    observables = np.random.default_rng(7).normal(size=(8, 25, 2))
+    pipe = MCPipeline(
+        [
+            raw_data_step("dat", observables=observables, observable_names=("y", "x")),
+            jarque_bera_test_step("jb", source="observables", column=0),
+            postproc_step("sum", summary_bundle, threshold=0.5),
+        ]
+    )
+    ref = cast(SolvedModel, object())
+    result = pipe.run(reference=ref, n_rep=8, verbosity=0)
+
+    target = (
+        BundleBuilder(created_by="mc-test")
+        .add_mc(pipe, result=result, run_id="r1")
+        .write(tmp_path / "pp_full.sdsge")
+    )
+    loaded = build_from(target)
+    assert loaded.mc is not None
+
+    # All three artifact channels plus the custom-op blob shipped.
+    kinds = {m.kind for m in loaded.manifest.members}
+    assert {"mc_custom_op", "mc_postproc", "mc_postproc_table"} <= kinds
+
+    # The post-loop op rehydrated under the pandas namespace, kwargs preserved.
+    func = loaded.mc.resources["sum"]
+    assert isinstance(func, PandasCustomFunc)
+
+    # Recovered artifacts (document + parquet members) == the live wire.
+    assert (
+        loaded.mc.wire()["postproc"]
+        == serialize_pipeline_result(result, run_id="r1")["postproc"]
+    )
+    assert loaded.mc.postproc_tables["sum.table"]["pval"] == list(
+        result.postproc["sum.table"].value["pval"]
+    )
+
+    # Rebuild from spec + resources -> equivalent runnable pipeline.
+    ordered = validate_pipeline_spec(loaded.mc.spec, has_reference=True, has_dgp=False)
+    rebuilt = build_pipeline(ordered, resources=loaded.mc.resources)
+    assert [s.step_type for s in rebuilt.steps] == [
+        "raw_data",
+        "jarque_bera",
+        "postproc:custom",
+    ]
+
+    # Re-running reproduces every artifact (deterministic replayed data).
+    rerun = rebuilt.run(reference=ref, n_rep=8, verbosity=0)
+    assert rerun.postproc["sum.pcs"].value == result.postproc["sum.pcs"].value
+    np.testing.assert_array_equal(
+        rerun.postproc["sum.flags"].value, result.postproc["sum.flags"].value
+    )
+    assert list(rerun.postproc["sum.table"].value["pval"]) == list(
+        result.postproc["sum.table"].value["pval"]
+    )
 
 
 def test_pandas_wrapper_rejected_outside_postproc() -> None:

--- a/tests/monte_carlo/test_to_spec.py
+++ b/tests/monte_carlo/test_to_spec.py
@@ -173,6 +173,30 @@ def test_to_spec_emits_custom_with_func_ref() -> None:
     assert {(e.source, e.target) for e in spec.edges} == {("dat", "tf")}
 
 
+def test_to_spec_emits_postproc_custom_with_func_ref_and_kwargs() -> None:
+    from SymbolicDSGE.monte_carlo.operations.postproc import postproc_step
+
+    def my_summary(*, traces, reference, dgp, threshold):
+        return float(threshold)
+
+    pipe = MCPipeline(
+        [
+            raw_data_step("dat", observables=np.zeros((4, 5, 3))),
+            jarque_bera_test_step("jb", source="observables"),
+            postproc_step("sum", my_summary, threshold=0.5),
+        ]
+    )
+    spec = pipe.to_spec()
+
+    node = {n.name: n for n in spec.nodes}["sum"]
+    assert node.step_type == "postproc:custom"
+    # callable rides a bundle member; op kwargs survive as plain spec params
+    assert node.params["func_ref"] == "sum"
+    assert node.params["threshold"] == 0.5
+    # POSTPROC nodes are referenced by trace key, not edges.
+    assert all(e.source != "sum" and e.target != "sum" for e in spec.edges)
+
+
 def test_to_spec_round_trips_a_postproc_pipeline() -> None:
     from SymbolicDSGE.monte_carlo.operations.postproc import kde_step
 


### PR DESCRIPTION
This pull request enhances support for custom post-processing (POSTPROC) steps in Monte Carlo pipelines, ensuring that pipelines with custom POSTPROC operations emitting scalars, arrays, and tables are correctly serialized, deserialized, and re-executed with full artifact fidelity. It introduces a comprehensive test for full round-trip persistence and execution, clarifies documentation, and adds coverage for POSTPROC custom step specification.

**Improvements to POSTPROC custom step support:**

* Added an acceptance test (`test_postproc_custom_op_full_round_trip`) that verifies a pipeline with a custom POSTPROC op emitting scalar, array, and table artifacts can be saved, loaded, and re-run with all artifacts preserved and the custom op rehydrated under the correct namespace (`tests/bundle/test_mc_facade.py`).
* Added a test (`test_to_spec_emits_postproc_custom_with_func_ref_and_kwargs`) to ensure that POSTPROC custom steps are correctly represented in pipeline specs, with function references and keyword arguments preserved (`tests/monte_carlo/test_to_spec.py`).

**New utilities and documentation:**

* Introduced `summary_bundle`, a utility POSTPROC function that emits all three artifact types (scalar, array, table) for testing and demonstration purposes (`tests/bundle/test_mc_facade.py`).
* Clarified the documentation for `LoadedMC` to describe the recovery and merging of POSTPROC artifacts, including bulk arrays, tables, and scalars (`SymbolicDSGE/bundle/loader.py`).

closes #183