### PR TITLE
Add post-loop (postproc) ops and UI support

### DIFF
--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -33,6 +33,7 @@ from .mc_constructs import (
     OpType,
 )
 from .spec import EdgeSpec, MCStepKind, NodeSpec, PipelineSpec
+from .traces import available_traces
 
 __all__ = [
     # pipeline + execution
@@ -58,6 +59,7 @@ __all__ = [
     "NodeSpec",
     "EdgeSpec",
     "MCStepKind",
+    "available_traces",
     # catalogue
     "STEP_CATALOG",
     "StepDefinition",

--- a/SymbolicDSGE/ui/app.py
+++ b/SymbolicDSGE/ui/app.py
@@ -11,6 +11,7 @@ from SymbolicDSGE.core.solved_model import SolvedModel
 from .mc import (
     build_pipeline,
     compile_custom_resources,
+    mc_available_traces,
     mc_catalog,
     mc_custom_op_template,
     run_pipeline,
@@ -71,7 +72,11 @@ def create_app(
 
     @app.post("/api/mc/custom/validate")
     def monte_carlo_custom_validate(request: MCCustomOpRequest) -> dict[str, Any]:
-        return validate_custom_op(request.code)
+        return validate_custom_op(request.code, step_type=request.step_type)
+
+    @app.post("/api/mc/traces")
+    def monte_carlo_traces(request: MCPipelineSpec) -> dict[str, list[str]]:
+        return mc_available_traces(request)
 
     @app.get("/api/estimation/catalog")
     def get_estimation_catalog() -> dict[str, Any]:

--- a/SymbolicDSGE/ui/mc.py
+++ b/SymbolicDSGE/ui/mc.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.monte_carlo import MCPipelineResult, NodeSpec
+from SymbolicDSGE.monte_carlo import available_traces as _available_traces
 from SymbolicDSGE.monte_carlo import build_pipeline as build_pipeline
 from SymbolicDSGE.monte_carlo import catalog_payload
 from SymbolicDSGE.monte_carlo import run_pipeline as _run_pipeline
@@ -58,6 +59,15 @@ def mc_catalog() -> dict[str, Any]:
 def mc_custom_op_template() -> dict[str, str]:
     """The starter source served to the custom-op editor."""
     return {"template": MC_CUSTOM_OP_TEMPLATE}
+
+
+def mc_available_traces(spec: MCPipelineSpec) -> dict[str, list[str]]:
+    """The across-rep trace keys the pipeline's producers will emit.
+
+    Feeds the post-loop trace picker (a ``type="trace"`` field) so a POSTPROC op
+    can select which test/regression/transform producer it consumes.
+    """
+    return {"traces": _available_traces(spec.to_core())}
 
 
 def _custom_func_class(step_type: str) -> type[CustomFunc]:

--- a/SymbolicDSGE/ui/mc_schemas.py
+++ b/SymbolicDSGE/ui/mc_schemas.py
@@ -35,6 +35,11 @@ class MCRunRequest(BaseModel):
 
 
 class MCCustomOpRequest(BaseModel):
-    """A single custom-op source submission for live editor validation."""
+    """A single custom-op source submission for live editor validation.
+
+    ``step_type`` selects the validation namespace: ``postproc:custom`` validates
+    under the pandas namespace, everything else under numpy.
+    """
 
     code: str = Field(min_length=1)
+    step_type: MCStepKind = "transform:custom"

--- a/sdsge-ui/frontend/src/api.ts
+++ b/sdsge-ui/frontend/src/api.ts
@@ -9,6 +9,7 @@ import type {
   MCCatalog,
   MCPipelineResult,
   MCPipelineSpec,
+  MCStepType,
   Role,
   SessionSummary,
   ShockGeneration,
@@ -141,11 +142,21 @@ export function getMCCustomTemplate(): Promise<{ template: string }> {
 
 export function validateCustomOp(
   code: string,
+  stepType: MCStepType = "transform:custom",
 ): Promise<{ valid: boolean; name?: string; error?: string }> {
   return requestJson<{ valid: boolean; name?: string; error?: string }>(
     "/api/mc/custom/validate",
-    { method: "POST", body: JSON.stringify({ code }) },
+    { method: "POST", body: JSON.stringify({ code, step_type: stepType }) },
   );
+}
+
+export function fetchAvailableTraces(
+  pipeline: MCPipelineSpec,
+): Promise<{ traces: string[] }> {
+  return requestJson<{ traces: string[] }>("/api/mc/traces", {
+    method: "POST",
+    body: JSON.stringify(pipeline),
+  });
 }
 
 export function validateMCPipeline(

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -33,6 +33,7 @@ import {
 } from "react";
 import type { DragEvent, PointerEvent } from "react";
 import {
+  fetchAvailableTraces,
   getMCCatalog,
   getMCCustomTemplate,
   runMCPipeline,
@@ -75,6 +76,32 @@ const CUSTOM_CATALOG_ITEM: MCStepCatalogItem = {
   category: "transforms",
   fields: [],
 };
+
+// Post-loop sibling of CUSTOM_CATALOG_ITEM: a user-authored summary op run once
+// after the replication loop (pandas namespace; may return a DataFrame).
+const POSTPROC_CUSTOM_CATALOG_ITEM: MCStepCatalogItem = {
+  step_type: "postproc:custom",
+  title: "Custom Postproc",
+  default_name: "postproc_op",
+  description: "User-defined post-loop summary op over the across-rep traces.",
+  category: "postproc",
+  fields: [],
+};
+
+// Starter source for a custom post-loop op. The pandas namespace applies, so the
+// body may reference `pd` (and `np`); `import` stays banned, like `np`.
+const POSTPROC_CUSTOM_TEMPLATE = `@pandas_operation
+def postproc_op(*, traces, reference, dgp):
+    """Post-loop summary over the across-rep traces. Runs once after the loop.
+
+    \`traces\` maps producer keys (e.g. "test.<name>.pval", "regression.<name>.coef",
+    "payload.<name>") to length-R ndarrays. Return a scalar (-> Summary), an
+    ndarray (-> Raw), a DataFrame (-> table), or a dict of several. \`pd\` and
+    \`np\` are available (no imports).
+    """
+    pvals = traces["test.example.pval"]
+    return pd.DataFrame({"rep": np.arange(pvals.size), "pval": pvals})
+`;
 
 export default function MCPipelineView({
   hidden,
@@ -127,7 +154,11 @@ function MCPipelineBuilder({
         customTemplateRef.current = tmpl.template;
         const value: MCCatalog = {
           ...rawCatalog,
-          steps: [...rawCatalog.steps, CUSTOM_CATALOG_ITEM],
+          steps: [
+            ...rawCatalog.steps,
+            CUSTOM_CATALOG_ITEM,
+            POSTPROC_CUSTOM_CATALOG_ITEM,
+          ],
         };
         setCatalog(value);
         const [workspace, persistedResult] = await Promise.all([
@@ -165,6 +196,27 @@ function MCPipelineBuilder({
     .filter((node) => node.data.catalog.category === "transforms")
     .map((node) => node.data.name);
   const pipeline = useMemo(() => toPipelineSpec(nodes, edges), [nodes, edges]);
+
+  // The producible across-rep traces a POSTPROC op can consume. Refreshed from
+  // the backend registry whenever the pipeline's producers change (debounced),
+  // so the trace picker stays in sync without duplicating the key format here.
+  const [availableTraces, setAvailableTraces] = useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      fetchAvailableTraces(pipeline)
+        .then((result) => {
+          if (!cancelled) setAvailableTraces(result.traces);
+        })
+        .catch(() => {
+          if (!cancelled) setAvailableTraces([]);
+        });
+    }, 200);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [pipeline]);
 
   // Color edges by their producer's kind so a node's inputs are readable at a
   // glance (datagen / filter / transform) without opening the inspector.
@@ -450,6 +502,7 @@ function MCPipelineBuilder({
           onDelete={deleteNode}
           theme={theme}
           payloadProducers={payloadProducers}
+          availableTraces={availableTraces}
         />
       ),
     },
@@ -685,7 +738,9 @@ function makeNode(
   const params =
     item.step_type === "transform:custom"
       ? { code: customTemplate }
-      : Object.fromEntries(item.fields.map((field) => [field.key, field.default]));
+      : item.step_type === "postproc:custom"
+        ? { code: POSTPROC_CUSTOM_TEMPLATE }
+        : Object.fromEntries(item.fields.map((field) => [field.key, field.default]));
   return {
     id: `${item.step_type}-${crypto.randomUUID()}`,
     type: "mcStep",

--- a/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
+++ b/sdsge-ui/frontend/src/mc/MCResultPanel.tsx
@@ -1,14 +1,45 @@
-import { useState } from "react";
+import {
+  Chart as ChartJS,
+  BarController,
+  BarElement,
+  CategoryScale,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  ScatterController,
+  Tooltip,
+} from "chart.js";
+import { Bar, Line, Scatter } from "react-chartjs-2";
+import { useMemo, useState } from "react";
 import type {
   MCPipelineResult,
+  MCPostprocArtifact,
   MCRegressionSummary,
   MCTraceSummary,
 } from "../types";
 
-type SummaryTab = "performance" | "tests" | "regressions";
+// Idempotent — App.tsx already registers the scales/plugins globally; we add the
+// controllers/elements the postproc charts need (bar + line + scatter) so the
+// combined density-over-histogram view renders regardless of load order.
+ChartJS.register(
+  BarController,
+  BarElement,
+  LineController,
+  LineElement,
+  PointElement,
+  ScatterController,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+);
+
+const POSTPROC_TAB_PREFIX = "pp:";
 
 export function MCResultPanel({ result }: { result: MCPipelineResult | null }) {
-  const [tab, setTab] = useState<SummaryTab>("performance");
+  const [tab, setTab] = useState<string>("performance");
   if (result === null) {
     return (
       <div className="mc-empty">
@@ -16,6 +47,10 @@ export function MCResultPanel({ result }: { result: MCPipelineResult | null }) {
       </div>
     );
   }
+  const postproc = Object.entries(result.postproc ?? {});
+  const activePostproc =
+    tab.startsWith(POSTPROC_TAB_PREFIX) &&
+    (result.postproc ?? {})[tab.slice(POSTPROC_TAB_PREFIX.length)];
   return (
     <div className="mc-summary">
       <nav className="mc-summary-tabs">
@@ -28,11 +63,26 @@ export function MCResultPanel({ result }: { result: MCPipelineResult | null }) {
         <SummaryTabButton active={tab === "regressions"} onClick={() => setTab("regressions")}>
           Regressions ({Object.keys(result.regression_summaries).length})
         </SummaryTabButton>
+        {postproc.map(([key, artifact]) => (
+          <SummaryTabButton
+            key={key}
+            active={tab === `${POSTPROC_TAB_PREFIX}${key}`}
+            onClick={() => setTab(`${POSTPROC_TAB_PREFIX}${key}`)}
+          >
+            {artifact.title || key}
+          </SummaryTabButton>
+        ))}
       </nav>
       <div className="mc-summary-body">
         {tab === "performance" && <PerformanceSummary result={result} />}
         {tab === "tests" && <TestSummary result={result} />}
         {tab === "regressions" && <RegressionSummary result={result} />}
+        {activePostproc && (
+          <PostprocArtifactView
+            name={tab.slice(POSTPROC_TAB_PREFIX.length)}
+            artifact={activePostproc}
+          />
+        )}
       </div>
     </div>
   );
@@ -381,4 +431,346 @@ function formatDf(value: number | Array<number | null> | null): string {
     return value.length === 0 ? "N/A" : value.map(format).join(", ");
   }
   return format(value);
+}
+
+// ---- POSTPROC artifact surfaces (#184) ----------------------------------
+
+function PostprocArtifactView({
+  name,
+  artifact,
+}: {
+  name: string;
+  artifact: MCPostprocArtifact;
+}) {
+  if (artifact.artifact === "scalar") {
+    return <ScalarArtifactView name={name} artifact={artifact} />;
+  }
+  if (artifact.artifact === "table") {
+    return <TableArtifactView name={name} artifact={artifact} />;
+  }
+  return <ArrayArtifactView name={name} artifact={artifact} />;
+}
+
+function ScalarArtifactView({
+  name,
+  artifact,
+}: {
+  name: string;
+  artifact: MCPostprocArtifact;
+}) {
+  return (
+    <div className="mc-summary-section">
+      <div className="mc-metric-grid">
+        <Metric label={artifact.title || name} value={formatCell(artifact.value)} />
+      </div>
+    </div>
+  );
+}
+
+function TableArtifactView({
+  name,
+  artifact,
+}: {
+  name: string;
+  artifact: MCPostprocArtifact;
+}) {
+  const { headers, rows } = tableArtifactRows(artifact);
+  return (
+    <div className="mc-summary-section">
+      <FoldableTable
+        title={artifact.title || name}
+        headers={headers}
+        rows={rows}
+        csvName={name}
+        defaultOpen
+      />
+    </div>
+  );
+}
+
+type ArrayView = "line" | "histogram" | "scatter";
+
+function ArrayArtifactView({
+  name,
+  artifact,
+}: {
+  name: string;
+  artifact: MCPostprocArtifact;
+}) {
+  const rows = useMemo(() => toNumericRows(artifact.value), [artifact.value]);
+  const width = rows.length > 0 ? rows[0].length : 0;
+  const isCurve = width === 2; // (x, y) curve, e.g. a KDE density
+  // KDE / curves default to the density line; 1-D arrays to a histogram.
+  const [view, setView] = useState<ArrayView>(isCurve ? "line" : "histogram");
+
+  const points = useMemo<{ x: number; y: number }[]>(
+    () =>
+      isCurve
+        ? rows.map((r) => ({ x: r[0], y: r[1] }))
+        : rows.map((r, i) => ({ x: i, y: r[0] ?? Number.NaN })),
+    [rows, isCurve],
+  );
+  const bins = useMemo(
+    () =>
+      isCurve
+        ? binCurve(points, 20)
+        : histogram(points.map((p) => p.y), 20),
+    [points, isCurve],
+  );
+
+  const headers = width <= 1 ? ["i", "value"] : ["i", ...range(width).map((j) => `c${j}`)];
+  const tableRows: unknown[][] = rows.map((r, i) =>
+    width <= 1 ? [i, r[0]] : [i, ...r],
+  );
+
+  return (
+    <div className="mc-summary-section">
+      <div className="mc-postproc-views">
+        {(["line", "histogram", "scatter"] as ArrayView[]).map((option) => (
+          <button
+            key={option}
+            className={view === option ? "active" : ""}
+            onClick={() => setView(option)}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+      <div className="mc-postproc-chart" style={{ height: 280 }}>
+        {view === "line" && (
+          <Line data={lineData(artifact.title || name, points)} options={CHART_OPTIONS} />
+        )}
+        {view === "scatter" && (
+          <Scatter
+            data={scatterData(artifact.title || name, points)}
+            options={CHART_OPTIONS}
+          />
+        )}
+        {view === "histogram" && (
+          <Bar data={barData(name, bins)} options={BAR_OPTIONS} />
+        )}
+      </div>
+      <FoldableTable
+        title="Data"
+        headers={headers}
+        rows={tableRows}
+        csvName={name}
+        defaultOpen={false}
+      />
+    </div>
+  );
+}
+
+function FoldableTable({
+  title,
+  headers,
+  rows,
+  csvName,
+  defaultOpen,
+}: {
+  title: string;
+  headers: (string | number)[];
+  rows: unknown[][];
+  csvName: string;
+  defaultOpen: boolean;
+}) {
+  return (
+    <details open={defaultOpen} className="mc-foldable-table">
+      <summary>
+        <span>{title}</span>
+        <button
+          className="secondary"
+          onClick={(event) => {
+            event.preventDefault();
+            downloadCsv(csvName, headers, rows);
+          }}
+        >
+          Export CSV
+        </button>
+      </summary>
+      <div className="mc-table-scroll">
+        <table className="mc-summary-table">
+          <thead>
+            <tr>
+              {headers.map((header) => (
+                <th key={String(header)}>{String(header)}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{formatCell(cell)}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+// ---- artifact data helpers ----------------------------------------------
+
+const CHART_OPTIONS = {
+  responsive: true,
+  maintainAspectRatio: false,
+  animation: false as const,
+  plugins: { legend: { display: true } },
+  scales: { x: { type: "linear" as const } },
+};
+
+const BAR_OPTIONS = {
+  responsive: true,
+  maintainAspectRatio: false,
+  animation: false as const,
+  plugins: { legend: { display: false } },
+};
+
+function lineData(label: string, points: { x: number; y: number }[]) {
+  return {
+    datasets: [
+      {
+        label,
+        data: points,
+        borderColor: "#4f46e5",
+        backgroundColor: "rgb(79 70 229 / 14%)",
+        borderWidth: 1.5,
+        pointRadius: 0,
+        fill: false,
+      },
+    ],
+  };
+}
+
+function scatterData(label: string, points: { x: number; y: number }[]) {
+  return {
+    datasets: [
+      { label, data: points, backgroundColor: "#4f46e5", pointRadius: 3 },
+    ],
+  };
+}
+
+function barData(label: string, bins: { center: number; value: number }[]) {
+  return {
+    labels: bins.map((b) => b.center.toPrecision(3)),
+    datasets: [
+      {
+        label,
+        data: bins.map((b) => b.value),
+        backgroundColor: "rgb(79 70 229 / 55%)",
+      },
+    ],
+  };
+}
+
+// Flatten an artifact `value` (1-D or 2-D nested arrays) into rows of numbers.
+function toNumericRows(value: unknown): number[][] {
+  if (!Array.isArray(value)) return [];
+  if (value.length === 0) return [];
+  if (Array.isArray(value[0])) {
+    return (value as unknown[][]).map((row) => row.map(toNumber));
+  }
+  return (value as unknown[]).map((v) => [toNumber(v)]);
+}
+
+function toNumber(value: unknown): number {
+  return typeof value === "number" ? value : Number(value);
+}
+
+// Equal-width histogram of scalar values -> 20 bin centers + counts.
+function histogram(values: number[], binCount: number): { center: number; value: number }[] {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return [];
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  if (min === max) return [{ center: min, value: finite.length }];
+  const width = (max - min) / binCount;
+  const counts = new Array<number>(binCount).fill(0);
+  for (const v of finite) {
+    const idx = Math.min(binCount - 1, Math.floor((v - min) / width));
+    counts[idx] += 1;
+  }
+  return counts.map((value, i) => ({ center: min + (i + 0.5) * width, value }));
+}
+
+// Bin an (x, y) curve into 20 x-bins, bar height = mean y in the bin.
+function binCurve(
+  points: { x: number; y: number }[],
+  binCount: number,
+): { center: number; value: number }[] {
+  const xs = points.map((p) => p.x).filter(Number.isFinite);
+  if (xs.length === 0) return [];
+  const min = Math.min(...xs);
+  const max = Math.max(...xs);
+  if (min === max) return [{ center: min, value: mean(points.map((p) => p.y)) }];
+  const width = (max - min) / binCount;
+  const sums = new Array<number>(binCount).fill(0);
+  const counts = new Array<number>(binCount).fill(0);
+  for (const p of points) {
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    const idx = Math.min(binCount - 1, Math.floor((p.x - min) / width));
+    sums[idx] += p.y;
+    counts[idx] += 1;
+  }
+  return sums.map((sum, i) => ({
+    center: min + (i + 0.5) * width,
+    value: counts[i] > 0 ? sum / counts[i] : 0,
+  }));
+}
+
+function tableArtifactRows(artifact: MCPostprocArtifact): {
+  headers: string[];
+  rows: unknown[][];
+} {
+  const columns = artifact.columns ?? [];
+  const data = artifact.data ?? {};
+  const labeled = artifact.index?.kind === "labeled";
+  const indexHeader = artifact.index?.name || "index";
+  const headers = labeled ? [indexHeader, ...columns] : columns;
+  const nRows = columns.length > 0 ? (data[columns[0]]?.length ?? 0) : 0;
+  const rows: unknown[][] = [];
+  for (let i = 0; i < nRows; i += 1) {
+    const body = columns.map((column) => data[column]?.[i]);
+    rows.push(labeled ? [data["__index__"]?.[i], ...body] : body);
+  }
+  return { headers, rows };
+}
+
+function downloadCsv(name: string, headers: (string | number)[], rows: unknown[][]): void {
+  const escape = (value: unknown): string => {
+    const text = value == null ? "" : String(value);
+    return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+  };
+  const lines = [
+    headers.map(escape).join(","),
+    ...rows.map((row) => row.map(escape).join(",")),
+  ];
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${name}.csv`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function formatCell(value: unknown): string {
+  if (value == null) return "--";
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? format(value) : "--";
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+function range(n: number): number[] {
+  return Array.from({ length: n }, (_, i) => i);
+}
+
+function mean(values: number[]): number {
+  const finite = values.filter(Number.isFinite);
+  return finite.length === 0 ? 0 : finite.reduce((a, b) => a + b, 0) / finite.length;
 }

--- a/sdsge-ui/frontend/src/mc/StepInspector.tsx
+++ b/sdsge-ui/frontend/src/mc/StepInspector.tsx
@@ -4,7 +4,7 @@ import { Check, TriangleAlert, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { validateCustomOp } from "../api";
 import { registerPythonLsp } from "../lsp/registerPythonLsp";
-import type { MCFieldSpec } from "../types";
+import type { MCFieldSpec, MCStepType } from "../types";
 import type { MCFlowNode } from "./types";
 
 // Input legs whose value is a dependency source (a "select" with INPUT_SOURCES
@@ -33,12 +33,14 @@ export function StepInspector({
   onDelete,
   theme,
   payloadProducers,
+  availableTraces,
 }: {
   node: MCFlowNode | null;
   onChange: (node: MCFlowNode) => void;
   onDelete: (id: string) => void;
   theme: "light" | "dark";
   payloadProducers: string[];
+  availableTraces: string[];
 }) {
   if (node === null) {
     return (
@@ -58,7 +60,9 @@ export function StepInspector({
     });
   };
 
-  const isCustom = node.data.stepType === "transform:custom";
+  const isCustom =
+    node.data.stepType === "transform:custom" ||
+    node.data.stepType === "postproc:custom";
   const producers = payloadProducers.filter((name) => name !== node.data.name);
 
   return (
@@ -91,6 +95,7 @@ export function StepInspector({
       {isCustom ? (
         <CustomOpEditor
           nodeId={node.id}
+          stepType={node.data.stepType}
           code={String(node.data.params.code ?? "")}
           theme={theme}
           onChange={(value) => updateParam("code", value)}
@@ -120,6 +125,7 @@ export function StepInspector({
                   key={key}
                   field={field}
                   value={node.data.params[field.key] ?? field.default}
+                  availableTraces={availableTraces}
                   onChange={(value) => updateParam(field.key, value)}
                 />
               );
@@ -183,11 +189,13 @@ function SourceLegEditor({
 
 function CustomOpEditor({
   nodeId,
+  stepType,
   code,
   theme,
   onChange,
 }: {
   nodeId: string;
+  stepType: MCStepType;
   code: string;
   theme: "light" | "dark";
   onChange: (value: string) => void;
@@ -198,7 +206,7 @@ function CustomOpEditor({
   async function validate() {
     setBusy(true);
     try {
-      const result = await validateCustomOp(code);
+      const result = await validateCustomOp(code, stepType);
       setStatus(
         result.valid
           ? { ok: true, message: `Valid op: ${result.name ?? ""}` }
@@ -264,12 +272,35 @@ function CustomOpEditor({
 function FieldEditor({
   field,
   value,
+  availableTraces,
   onChange,
 }: {
   field: MCFieldSpec;
   value: unknown;
+  availableTraces: string[];
   onChange: (value: unknown) => void;
 }) {
+  if (field.type === "trace") {
+    const current = String(value ?? "");
+    // Offer the pipeline's producible traces; keep a stale selection visible.
+    const options =
+      current && !availableTraces.includes(current)
+        ? [current, ...availableTraces]
+        : availableTraces;
+    return (
+      <label>
+        {field.label}
+        <select value={current} onChange={(event) => onChange(event.target.value)}>
+          <option value="">— select trace —</option>
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
   if (field.type === "boolean") {
     return (
       <label className="switch-row">

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1712,6 +1712,53 @@ button.mc-palette-tab.active .mc-palette-tab-count {
   color: #4338ca;
 }
 
+/* POSTPROC artifact surfaces (#184) */
+.mc-summary-tabs {
+  flex-wrap: wrap;
+}
+
+.mc-postproc-views {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.mc-postproc-views button {
+  background: transparent;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  color: #64748b;
+  font-size: 11px;
+  padding: 3px 9px;
+  text-transform: capitalize;
+}
+
+.mc-postproc-views button.active {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}
+
+.mc-postproc-chart {
+  margin-bottom: 10px;
+  position: relative;
+}
+
+.mc-foldable-table {
+  margin-top: 6px;
+}
+
+.mc-foldable-table > summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 10px;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+
 .mc-summary-body {
   flex: 1;
   min-height: 0;

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -194,6 +194,7 @@ export type MCFieldType =
   | "number"
   | "boolean"
   | "select"
+  | "trace"
   | "number_list"
   | "number_matrix"
   | "text_list";
@@ -325,4 +326,21 @@ export interface MCPipelineResult {
   test_summaries: Record<string, MCTestSummary>;
   regression_summaries: Record<string, MCRegressionSummary>;
   data_summaries: Record<string, MCDataSummary>;
+  postproc?: Record<string, MCPostprocArtifact>;
+}
+
+// A post-loop (POSTPROC) artifact, one per summary surface. `scalar` carries an
+// inline `value`; `array` an `value` (1-D or N-D nested arrays); `table` a
+// columnar `data` map plus `columns`/`dtypes`/`index` metadata.
+export interface MCPostprocArtifact {
+  kind: "summary" | "raw";
+  artifact: "scalar" | "array" | "table";
+  title?: string | null;
+  render?: string;
+  value?: unknown;
+  shape?: number[];
+  columns?: string[];
+  dtypes?: Record<string, string>;
+  index?: { kind: string; name: string | null };
+  data?: Record<string, unknown[]>;
 }

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -419,6 +419,96 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
     assert fetched.json()["run_id"] == body["run_id"]
 
 
+def _solve_reference(client: TestClient) -> None:
+    for role in ("reference", "dgp"):  # simulation datagen needs a solved dgp
+        loaded = client.post(
+            "/api/model/load-yaml", json={"role": role, "path": "MODELS/test.yaml"}
+        )
+        assert loaded.status_code == 200
+        solved = client.post(
+            "/api/model/solve",
+            json={"role": role, "compile_kwargs": {"n_state": 3, "n_exog": 2}},
+        )
+        assert solved.status_code == 200
+
+
+_POSTPROC_PIPELINE = {
+    "nodes": [
+        {
+            "id": "sim",
+            "step_type": "simulation",
+            "name": "datagen",
+            "params": {"T": 8, "observables": True, "distribution": "norm", "seed": 10},
+        },
+        {
+            "id": "jb",
+            "step_type": "jarque_bera",
+            "name": "jb",
+            "params": {"source": "observables", "column": 0},
+        },
+        {
+            "id": "k",
+            "step_type": "kde",
+            "name": "density",
+            "params": {"trace": "test.jb.statistic", "grid_points": 16},
+        },
+    ],
+    "edges": [{"source": "sim", "target": "jb"}],
+}
+
+
+def test_ui_backend_run_payload_includes_postproc_artifacts() -> None:
+    client = TestClient(create_app())
+    _solve_reference(client)
+
+    run = client.post(
+        "/api/run/mc",
+        json={"pipeline": _POSTPROC_PIPELINE, "n_rep": 4, "fail_fast": True},
+    )
+    assert run.status_code == 200
+    postproc = run.json()["postproc"]
+    # KDE emits an array curve and a descriptives table, each its own surface.
+    curve = postproc["density.curve"]
+    assert curve["artifact"] == "array" and curve["shape"] == [16, 2]
+    assert len(curve["value"]) == 16
+    table = postproc["density.descriptives"]
+    assert table["artifact"] == "table"
+    assert "statistic" in table["columns"]
+    assert table["data"]["statistic"][0] == "count"
+
+
+def test_ui_backend_available_traces_endpoint() -> None:
+    client = TestClient(create_app())
+    traces = client.post("/api/mc/traces", json=_POSTPROC_PIPELINE)
+    assert traces.status_code == 200
+    keys = traces.json()["traces"]
+    assert "test.jb.statistic" in keys
+    assert "test.jb.pval" in keys
+
+
+_PANDAS_OP_SRC = '''@pandas_operation
+def summarize(*, traces, reference, dgp):
+    """Post-loop table op referencing pd."""
+    return pd.DataFrame({"a": [1.0]})
+'''
+
+
+def test_ui_backend_custom_validate_is_phase_aware() -> None:
+    client = TestClient(create_app())
+    # A pandas post-loop op validates under the postproc namespace ...
+    ok = client.post(
+        "/api/mc/custom/validate",
+        json={"code": _PANDAS_OP_SRC, "step_type": "postproc:custom"},
+    )
+    assert ok.status_code == 200 and ok.json()["valid"] is True
+    # ... but the same source is rejected under the per-rep transform namespace.
+    bad = client.post(
+        "/api/mc/custom/validate",
+        json={"code": _PANDAS_OP_SRC, "step_type": "transform:custom"},
+    )
+    assert bad.status_code == 200 and bad.json()["valid"] is False
+
+
 def test_ui_backend_accepts_fanout_and_rejects_terminal_forward_links() -> None:
     client = TestClient(create_app())
     for role in ("reference", "dgp"):


### PR DESCRIPTION
This pull request adds support for post-loop (postproc) custom operations in the Monte Carlo pipeline, enabling users to define and visualize custom summary operations that run after the replication loop. It introduces new API endpoints, UI components, and backend logic to handle postproc custom ops, including trace selection and artifact visualization. The most important changes are grouped below.

**Backend and API support for postproc custom operations:**

* Added `available_traces` to the Monte Carlo module and exposed it via API so the frontend can dynamically fetch available traces for postproc operations (`SymbolicDSGE/monte_carlo/__init__.py`, `SymbolicDSGE/ui/app.py`, `SymbolicDSGE/ui/mc.py`) [[1]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R36) [[2]](diffhunk://#diff-511634b7d1555c50c0a4555ee2d48a8bbcd11d6130c782db3272a507b2a8dbb5R62) [[3]](diffhunk://#diff-ab330c3711f58a4d9c0a683a67f7fcc549c14ceb5477d2f7fcc78cf5de11edb1R14) [[4]](diffhunk://#diff-ab330c3711f58a4d9c0a683a67f7fcc549c14ceb5477d2f7fcc78cf5de11edb1L74-R79) [[5]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R15) [[6]](diffhunk://#diff-0385169212dde7552c392e518499c590c92e06d49d9a7d514d93160e3afb29e2R64-R72).
* Updated the custom op validation API to accept a `step_type`, allowing the backend to validate postproc custom ops in the correct namespace (pandas vs numpy) (`SymbolicDSGE/ui/mc_schemas.py`, `sdsge-ui/frontend/src/api.ts`) [[1]](diffhunk://#diff-a0029617192ca36e8deb11bd497ed27865ff30d12894607e81db996c16022d2eL38-R45) [[2]](diffhunk://#diff-04761262cd28314dba2bf7030040b8a9c8379b1239a0f2e3059401ca2b44014bR12) [[3]](diffhunk://#diff-04761262cd28314dba2bf7030040b8a9c8379b1239a0f2e3059401ca2b44014bR145-R161).

**UI and pipeline builder enhancements:**

* Added new catalog and template entries for postproc custom operations, allowing users to add post-loop custom ops to their pipeline and providing starter code in the pandas namespace (`sdsge-ui/frontend/src/mc/MCPipelineView.tsx`) [[1]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R80-R105) [[2]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221L130-R161) [[3]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R741-R742).
* Implemented dynamic fetching of available traces for postproc ops, ensuring the trace picker stays in sync with pipeline changes (`sdsge-ui/frontend/src/mc/MCPipelineView.tsx`) [[1]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R36) [[2]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R200-R220) [[3]](diffhunk://#diff-23679cd3db6a29904e0d3319c57b11ebeb7063d2b27a7364251b81a4b11c9221R505).

**Visualization and artifact rendering:**

* Extended the results panel to display postproc artifacts (scalars, tables, arrays) in new tabs, with rich views for tables and interactive plots for arrays, including CSV export functionality (`sdsge-ui/frontend/src/mc/MCResultPanel.tsx`) [[1]](diffhunk://#diff-ff749fc9b59ac3e12d13843f2d130a0cd09f44ee4a90384632e9e12de10b938aL1-R53) [[2]](diffhunk://#diff-ff749fc9b59ac3e12d13843f2d130a0cd09f44ee4a90384632e9e12de10b938aR66-R85) [[3]](diffhunk://#diff-ff749fc9b59ac3e12d13843f2d130a0cd09f44ee4a90384632e9e12de10b938aR435-R776).

These changes together enable flexible, user-defined post-loop analyses in Monte Carlo pipelines, with seamless integration into the UI and results visualization.

closes #184 