### PR TITLE
Add CI wheel matrix, sdist & publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest      # manylinux + musllinux x86_64
-          - ubuntu-24.04-arm   # manylinux + musllinux aarch64 (public-repo runner)
+          - ubuntu-latest      # manylinux x86_64
+          - ubuntu-24.04-arm   # manylinux aarch64 (public-repo runner)
           - windows-latest     # win_amd64
-          - macos-13           # x86_64
+          - macos-15-intel     # x86_64 (macos-13 is retired; this is the current Intel label)
           - macos-latest       # arm64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
-name: Publish to PyPI & Draft Release
+name: Wheels, Publish & Release
 
 on:
+  pull_request:
   push:
     tags:
       - "v*"
@@ -12,14 +13,93 @@ on:
         type: string
 
 permissions:
-  contents: write     # create release + upload assets
-  id-token: write     # PyPI Trusted Publishing
+  contents: read
 
 jobs:
+  build_wheels:
+    name: Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest      # manylinux + musllinux x86_64
+          - ubuntu-24.04-arm   # manylinux + musllinux aarch64 (public-repo runner)
+          - windows-latest     # win_amd64
+          - macos-13           # x86_64
+          - macos-latest       # arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # UI assets ship in the wheel via package-data; they are identical across
+      # platforms and irrelevant to validating the native build, so only build
+      # them for real (tag/dispatch) wheels, not PR validation runs.
+      - name: Set up Python
+        if: github.event_name != 'pull_request'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Set up Node
+        if: github.event_name != 'pull_request'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: sdsge-ui/frontend/package-lock.json
+      - name: Build frontend into package
+        if: github.event_name != 'pull_request'
+        run: python scripts/build_frontend.py
+
+      # Reads [tool.cibuildwheel] from pyproject; builds + per-platform tests.
+      - name: Build & test wheels
+        uses: pypa/cibuildwheel@v4.1.0
+
+      - name: Upload wheels
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v7
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: sdsge-ui/frontend/package-lock.json
+      - name: Build frontend into package
+        run: python scripts/build_frontend.py
+      - name: Build sdist
+        run: uv build --sdist
+      - name: Upload sdist
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
   publish:
+    name: Publish & Release
+    needs: [build_wheels, build_sdist]
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi
-
+    permissions:
+      contents: write     # create release + upload assets
+      id-token: write     # PyPI Trusted Publishing
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,21 +126,19 @@ jobs:
           TAG_NAME: ${{ steps.vars.outputs.tag }}
         run: python hook_scripts/check_version_match.py
 
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: Download wheels
+        uses: actions/download-artifact@v4
         with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: sdsge-ui/frontend/package-lock.json
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
 
-      - name: Build frontend into package
-        run: python scripts/build_frontend.py
-
-      - name: Build distributions
-        run: uv build
-
+      - uses: astral-sh/setup-uv@v7
       - name: Publish to PyPI
         run: uv publish
 

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ SymbolicDSGE/ui/_static/
 #   the _*.c pattern only catches generated files.
 *.pyd
 SymbolicDSGE/_ckernels/**/_*.c
+
+# cibuildwheel output
+wheelhouse/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,11 @@ markers = [
 
 [tool.cibuildwheel]
 build = "cp311-* cp312-* cp313-* cp314-*"
-# 64-bit only (drop 32-bit i686/win32); both manylinux and musllinux are built
-# on Linux. No -march=native anywhere, so wheels run on baseline ISA.
-skip = "*_i686 *-win32"
+# 64-bit only (drop 32-bit i686/win32). Skip musllinux: numba/llvmlite ship no
+# musl wheels, so the dep chain builds llvmlite from source there and fails
+# (needs LLVM) -- the package can't run on Alpine regardless, so don't ship
+# unusable musl wheels. No -march=native anywhere (baseline ISA).
+skip = "*_i686 *-win32 *-musllinux*"
 # Validate each platform: confirm the wheel loads and the native kernels match
 # the numba reference. All CPythons are built; runtime-test one per platform
 # (the C is Python-version-agnostic, only the generated Cython glue differs) to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,16 @@ addopts = "--import-mode=importlib"
 markers = [
     "sr: tests that require the optional symbolic-regression dependency",
 ]
+
+[tool.cibuildwheel]
+build = "cp311-* cp312-* cp313-* cp314-*"
+# 64-bit only (drop 32-bit i686/win32); both manylinux and musllinux are built
+# on Linux. No -march=native anywhere, so wheels run on baseline ISA.
+skip = "*_i686 *-win32"
+# Validate each platform: confirm the wheel loads and the native kernels match
+# the numba reference. All CPythons are built; runtime-test one per platform
+# (the C is Python-version-agnostic, only the generated Cython glue differs) to
+# bound the per-wheel dependency install.
+test-requires = "pytest"
+test-command = "python -m pytest {project}/tests/ckernels -q"
+test-skip = "cp311-* cp312-*"


### PR DESCRIPTION
Revamps the GitHub Actions publish workflow: renamed to 'Wheels, Publish & Release', adds pull_request trigger, and splits work into build_wheels (matrix across OSes) and build_sdist jobs. Frontend build runs only for non-PR/tag publishing; wheels are produced with pypa/cibuildwheel and uploaded as artifacts, then the publish job downloads those artifacts and the sdist before running uv publish. Adjusts job permissions so publish job has contents/id-token write while other jobs use read, and changes artifact handling to merge per-platform wheels. Also adds wheelhouse/ to .gitignore and a [tool.cibuildwheel] section to pyproject.toml to configure builds, tests, and skip patterns.

closes #209 