### PR TITLE
Add publish input and gate publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,13 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      publish:
+        description: "Publish to PyPI + draft release (leave off to only build & test wheels in isolation)"
+        type: boolean
+        default: false
       tag:
-        description: "Existing tag to publish (e.g. v0.5.0 or v0.5.0b1)"
-        required: true
+        description: "Existing tag to publish (required only when 'publish' is checked)"
+        required: false
         type: string
 
 permissions:
@@ -26,8 +30,7 @@ jobs:
           - ubuntu-latest      # manylinux x86_64
           - ubuntu-24.04-arm   # manylinux aarch64 (public-repo runner)
           - windows-latest     # win_amd64
-          - macos-15-intel     # x86_64 (macos-13 is retired; this is the current Intel label)
-          - macos-latest       # arm64
+          - macos-latest       # arm64 only (numba ships no x86_64 macOS wheels since 0.63)
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,7 +97,7 @@ jobs:
   publish:
     name: Publish & Release
     needs: [build_wheels, build_sdist]
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish)
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
Add a boolean workflow_dispatch input 'publish' (default false) to control whether to publish to PyPI and create a draft release. Make the 'tag' input optional (required only when publish is checked). Update macOS runner comment to indicate arm64-only and remove the explicit Intel label. Change the publish job condition so manual dispatches only trigger publishing when inputs.publish is true, allowing builds/tests to run without publishing.

closes #212 