### PR TITLE
Implement native Kalman filter C backend and update headers

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -1,6 +1,7 @@
 #ifndef SDSGE_COMMON_H
 #define SDSGE_COMMON_H
 
+#include <math.h>
 #include <stdint.h>
 
 /* Shared low-level definitions for SymbolicDSGE native kernels.
@@ -11,9 +12,9 @@
  * buffers -- no CPython or NumPy API. */
 
 /* Architecture-agnostic numeric types. Use these everywhere instead of bare
- * `long`/`int`/`double` so width and indexing semantics are identical across the
- * whole wheel matrix -- notably `long` is 32-bit on Windows (LLP64) but 64-bit
- * on Linux/macOS (LP64). All counts and indices are i64. */
+ * `long`/`int`/`double` so width and indexing semantics are identical across
+ * the whole wheel matrix -- notably `long` is 32-bit on Windows (LLP64) but
+ * 64-bit on Linux/macOS (LP64). All counts and indices are i64. */
 typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;
@@ -28,11 +29,11 @@ typedef double f64;
 /* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
  * differently by MSVC). */
 #if defined(__GNUC__) || defined(__clang__)
-#  define SDSGE_RESTRICT __restrict__
+#define SDSGE_RESTRICT __restrict__
 #elif defined(_MSC_VER)
-#  define SDSGE_RESTRICT __restrict
+#define SDSGE_RESTRICT __restrict
 #else
-#  define SDSGE_RESTRICT
+#define SDSGE_RESTRICT
 #endif
 
 #endif /* SDSGE_COMMON_H */

--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -26,6 +26,10 @@ typedef uint64_t u64;
 typedef float f32;
 typedef double f64;
 
+/* 2*pi as the nearest IEEE-754 double (== 2.0 * numpy's pi, exactly); shared by
+ * the kalman / distribution / transform kernels. */
+#define TWO_PI 6.283185307179586
+
 /* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
  * differently by MSVC). */
 #if defined(__GNUC__) || defined(__clang__)

--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -9,11 +9,11 @@
  * Numeric primitives reused across subsystems (matmul, cholesky, triangular
  * solves, dot products) will live alongside this header in sdsge_linalg.{c,h}
  * once the kalman port lands. Everything here is plain C operating on f64*
- * buffers -- no CPython or NumPy API. */
+ * buffers; no CPython or NumPy API. */
 
 /* Architecture-agnostic numeric types. Use these everywhere instead of bare
  * `long`/`int`/`double` so width and indexing semantics are identical across
- * the whole wheel matrix -- notably `long` is 32-bit on Windows (LLP64) but
+ * the whole wheel matrix; notably `long` is 32-bit on Windows (LLP64) but
  * 64-bit on Linux/macOS (LP64). All counts and indices are i64. */
 typedef int8_t i8;
 typedef int16_t i16;

--- a/SymbolicDSGE/_ckernels/kalman/__init__.py
+++ b/SymbolicDSGE/_ckernels/kalman/__init__.py
@@ -1,1 +1,8 @@
-"""Native kalman kernels (placeholder)."""
+"""Native kalman kernels (linear filter hot loop).
+
+Re-exports the compiled ``_kalman`` extension. If it is not built, importing
+this module raises ``ImportError`` and the consumer (``SymbolicDSGE.kalman``)
+falls back to its numba kernels.
+"""
+
+from ._kalman import kalman_hot_loop as kalman_hot_loop

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -1,6 +1,168 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-"""Cython shim for the kalman native kernels (placeholder).
+"""Cython shim for the linear Kalman filter hot loop.
 
-Declare the C prototypes with ``cdef extern from "kalman.h"`` and add one ``def``
-wrapper per entrypoint that maps NumPy memoryviews to ``double*``.
+Allocates the history output arrays, marshals the NumPy buffers into the C
+kf_inputs/kf_outputs structs, runs kf_hot_loop under nogil, and translates the
+status code back into the exceptions KalmanFilter.run already handles. The
+public signature and return shape match the numba `_kalman_hot_loop` so the two
+are interchangeable at the call site.
 """
+
+import numpy as np
+from numpy.linalg import LinAlgError
+
+from libc.stdint cimport int64_t
+
+
+cdef extern from "kalman.h":
+    int KF_OK
+    int KF_ERR_MATRIX_CONDITION
+    int KF_ERR_ALLOC
+
+    ctypedef struct kf_inputs:
+        int64_t n
+        int64_t m
+        int64_t k
+        int64_t T
+        double *A
+        double *B
+        double *C
+        double *d
+        double *Q
+        double *R
+        double *y
+        double *x0
+        double *P0
+        int symmetrize
+        double jitter
+        int return_shocks
+        int store_history
+
+    ctypedef struct kf_outputs:
+        double *x_pred
+        double *x_filt
+        double *P_pred
+        double *P_filt
+        double *y_pred
+        double *y_filt
+        double *innov
+        double *std_innov
+        double *S
+        double *eps_hat
+        double *loglik
+
+    int kf_hot_loop(const kf_inputs *inp, kf_outputs *outp) nogil
+
+
+def kalman_hot_loop(
+    int64_t T,
+    nmk,
+    double[:, ::1] A,
+    double[:, ::1] B,
+    double[:, ::1] C,
+    double[::1] d,
+    double[:, ::1] Q,
+    double[:, ::1] R,
+    double[:, ::1] y,
+    double[::1] x0,
+    double[:, ::1] P0,
+    bint symmetrize,
+    double jitter,
+    bint return_shocks=False,
+    bint store_history=True,
+):
+    """Run the linear Kalman filter; mirrors numba `_kalman_hot_loop`.
+
+    Returns ``(KF_OK, (0.0, 0.0, 0.0), out)`` where ``out`` is the history tuple
+    + loglik. Raises ``numpy.linalg.LinAlgError`` on a non-PD innovation
+    covariance (so KalmanFilter.run's existing ``except`` maps it to
+    ``MatrixConditionError``).
+    """
+    cdef int64_t n = nmk[0]
+    cdef int64_t m = nmk[1]
+    cdef int64_t k = nmk[2]
+
+    cdef int64_t hist_T = T if store_history else 0
+    cdef int64_t shock_T = T if (return_shocks and store_history) else 0
+
+    x_pred = np.zeros((hist_T, n), dtype=np.float64)
+    x_filt = np.zeros((hist_T, n), dtype=np.float64)
+    P_pred = np.zeros((hist_T, n, n), dtype=np.float64)
+    P_filt = np.zeros((hist_T, n, n), dtype=np.float64)
+    y_pred = np.zeros((hist_T, m), dtype=np.float64)
+    y_filt = np.zeros((hist_T, m), dtype=np.float64)
+    innov = np.zeros((hist_T, m), dtype=np.float64)
+    std_innov = np.zeros((hist_T, m), dtype=np.float64)
+    S = np.zeros((hist_T, m, m), dtype=np.float64)
+    eps_hat = np.zeros((shock_T, k), dtype=np.float64)
+    cdef double loglik = 0.0
+
+    cdef double[:, ::1] x_pred_mv = x_pred
+    cdef double[:, ::1] x_filt_mv = x_filt
+    cdef double[:, :, ::1] P_pred_mv = P_pred
+    cdef double[:, :, ::1] P_filt_mv = P_filt
+    cdef double[:, ::1] y_pred_mv = y_pred
+    cdef double[:, ::1] y_filt_mv = y_filt
+    cdef double[:, ::1] innov_mv = innov
+    cdef double[:, ::1] std_innov_mv = std_innov
+    cdef double[:, :, ::1] S_mv = S
+    cdef double[:, ::1] eps_hat_mv = eps_hat
+
+    cdef kf_inputs inp
+    inp.n = n
+    inp.m = m
+    inp.k = k
+    inp.T = T
+    inp.A = &A[0, 0]
+    inp.B = &B[0, 0]
+    inp.C = &C[0, 0]
+    inp.d = &d[0]
+    inp.Q = &Q[0, 0]
+    inp.R = &R[0, 0]
+    inp.y = &y[0, 0] if T > 0 else NULL
+    inp.x0 = &x0[0]
+    inp.P0 = &P0[0, 0]
+    inp.symmetrize = symmetrize
+    inp.jitter = jitter
+    inp.return_shocks = return_shocks
+    inp.store_history = store_history
+
+    cdef kf_outputs outp
+    outp.x_pred = &x_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.x_filt = &x_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.P_pred = &P_pred_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.P_filt = &P_filt_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.y_pred = &y_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.y_filt = &y_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.innov = &innov_mv[0, 0] if hist_T > 0 else NULL
+    outp.std_innov = &std_innov_mv[0, 0] if hist_T > 0 else NULL
+    outp.S = &S_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.eps_hat = &eps_hat_mv[0, 0] if shock_T > 0 else NULL
+    outp.loglik = &loglik
+
+    cdef int status
+    with nogil:
+        status = kf_hot_loop(&inp, &outp)
+
+    if status == KF_ERR_MATRIX_CONDITION:
+        raise LinAlgError("Innovation covariance is not positive definite.")
+    if status == KF_ERR_ALLOC:
+        raise MemoryError("kf_hot_loop: scratch allocation failed.")
+
+    return (
+        KF_OK,
+        (0.0, 0.0, 0.0),
+        (
+            x_pred,
+            x_filt,
+            P_pred,
+            P_filt,
+            y_pred,
+            y_filt,
+            innov,
+            std_innov,
+            S,
+            eps_hat,
+            loglik,
+        ),
+    )

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -1,3 +1,261 @@
 #include "kalman.h"
+#include <math.h>
 
-/* Placeholder for kalman native kernels. */
+void kf_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
+    const i64 total = r * c;
+    for (i64 i = 0; i < total; ++i)
+        out[i] = 0.0;
+}
+
+void kf_sym_inplace(f64 *SDSGE_RESTRICT P, i64 n) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = i + 1; j < n; ++j) {
+            f64 avg = 0.5 * (P[i * n + j] + P[j * n + i]);
+            P[i * n + j] = avg;
+            P[j * n + i] = avg;
+        }
+    }
+}
+
+void kf_matmul(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+               f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[k * m + j];
+            out[i * m + j] = s;
+        }
+    }
+}
+
+void kf_matmul_abt(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                   f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[j * p + k];
+            out[i * m + j] = s;
+        }
+    }
+}
+
+void kf_matmul_abt_plus_c(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                          const f64 *SDSGE_RESTRICT C, f64 *SDSGE_RESTRICT out,
+                          i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[j * p + k];
+            out[i * m + j] = s + C[i * m + j];
+        }
+    }
+}
+
+void kf_matvec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
+               f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = 0.0;
+        for (i64 j = 0; j < m; ++j)
+            s += A[i * m + j] * x[j];
+        out[i] = s;
+    }
+}
+
+void kf_matvec_plus_vec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
+                        const f64 *SDSGE_RESTRICT b, f64 *SDSGE_RESTRICT out,
+                        i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = b[i];
+        for (i64 j = 0; j < m; ++j)
+            s += A[i * m + j] * x[j];
+        out[i] = s;
+    }
+}
+
+void kf_row_minus_vec(const f64 *SDSGE_RESTRICT A, i64 row,
+                      const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT out, i64 m) {
+    const f64 *Arow = A + row * m;
+    for (i64 j = 0; j < m; ++j)
+        out[j] = Arow[j] - x[j];
+}
+
+f64 kf_dot(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b, i64 n) {
+    f64 s = 0.0;
+    for (i64 i = 0; i < n; ++i)
+        s += a[i] * b[i];
+    return s;
+}
+
+f64 kf_logdet_from_chol(const f64 *SDSGE_RESTRICT L, i64 n) {
+    f64 s = 0.0;
+    for (i64 i = 0; i < n; ++i)
+        s += log(L[i * n + i]);
+    return 2.0 * s;
+}
+
+int kf_chol_shifted(const f64 *SDSGE_RESTRICT S, f64 jitter,
+                    f64 *SDSGE_RESTRICT L, i64 n) {
+    kf_zero_mat(L, n, n);
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j <= i; ++j) {
+            f64 s = S[i * n + j];
+            if (i == j && jitter > 0.0)
+                s += jitter;
+            for (i64 k = 0; k < j; ++k)
+                s -= L[i * n + k] * L[j * n + k];
+            if (i == j) {
+                if (s <= 0.0)
+                    return KF_ERR_MATRIX_CONDITION;
+                L[i * n + j] = sqrt(s);
+            } else {
+                L[i * n + j] = s / L[j * n + j];
+            }
+        }
+    }
+    return KF_OK;
+}
+
+void kf_forward_subst(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT b,
+                      f64 *SDSGE_RESTRICT out, i64 n) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = 0.0;
+        for (i64 j = 0; j < i; ++j)
+            s += L[i * n + j] * out[j];
+        out[i] = (b[i] - s) / L[i * n + i];
+    }
+}
+
+void kf_backward_subst_chol_t(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT b,
+                              f64 *SDSGE_RESTRICT out, i64 n) {
+    for (i64 i = n - 1; i >= 0; --i) {
+        f64 s = 0.0;
+        for (i64 j = i + 1; j < n; ++j)
+            s += L[j * n + i] * out[j];
+        out[i] = (b[i] - s) / L[i * n + i];
+    }
+}
+
+void kf_chol_solve_row(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT B,
+                       i64 row, f64 *SDSGE_RESTRICT fbuf, f64 *SDSGE_RESTRICT bbuf,
+                       f64 *SDSGE_RESTRICT out, i64 n) {
+    const f64 *Brow = B + row * n;
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = 0.0;
+        for (i64 j = 0; j < i; ++j)
+            s += L[i * n + j] * fbuf[j];
+        fbuf[i] = (Brow[i] - s) / L[i * n + i];
+    }
+    for (i64 i = n - 1; i >= 0; --i) {
+        f64 s = 0.0;
+        for (i64 j = i + 1; j < n; ++j)
+            s += L[j * n + i] * bbuf[j];
+        bbuf[i] = (fbuf[i] - s) / L[i * n + i];
+    }
+    f64 *outrow = out + row * n;
+    for (i64 i = 0; i < n; ++i)
+        outrow[i] = bbuf[i];
+}
+
+void kf_predict_cov(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT P_prev,
+                    const f64 *SDSGE_RESTRICT BQBT, f64 *SDSGE_RESTRICT temp_nn,
+                    f64 *SDSGE_RESTRICT out, i64 n) {
+    kf_matmul(A, P_prev, temp_nn, n, n, n);
+    kf_matmul_abt_plus_c(temp_nn, A, BQBT, out, n, n, n);
+}
+
+void kf_measurement_cov(const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT P_pred,
+                        const f64 *SDSGE_RESTRICT R, f64 *SDSGE_RESTRICT temp_mn,
+                        f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    kf_matmul(C, P_pred, temp_mn, m, n, n);
+    kf_matmul_abt_plus_c(temp_mn, C, R, out, m, n, m);
+}
+
+void kf_pc_t(const f64 *SDSGE_RESTRICT P_pred, const f64 *SDSGE_RESTRICT C,
+             f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < n; ++k)
+                s += P_pred[i * n + k] * C[j * n + k];
+            out[i * m + j] = s;
+        }
+    }
+}
+
+void kf_gain_from_pc_t(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT PCt,
+                       f64 *SDSGE_RESTRICT fbuf, f64 *SDSGE_RESTRICT bbuf,
+                       f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    for (i64 row = 0; row < n; ++row)
+        kf_chol_solve_row(L, PCt, row, fbuf, bbuf, out, m);
+}
+
+void kf_state_update(const f64 *SDSGE_RESTRICT x_pred, const f64 *SDSGE_RESTRICT K,
+                     const f64 *SDSGE_RESTRICT v, f64 *SDSGE_RESTRICT out,
+                     i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = x_pred[i];
+        for (i64 j = 0; j < m; ++j)
+            s += K[i * m + j] * v[j];
+        out[i] = s;
+    }
+}
+
+void kf_identity_minus(const f64 *SDSGE_RESTRICT A, f64 *SDSGE_RESTRICT out, i64 n) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < n; ++j)
+            out[i * n + j] = -A[i * n + j];
+        out[i * n + i] += 1.0;
+    }
+}
+
+void kf_joseph_cov(const f64 *SDSGE_RESTRICT K, const f64 *SDSGE_RESTRICT C,
+                   const f64 *SDSGE_RESTRICT P_pred, const f64 *SDSGE_RESTRICT R,
+                   f64 *SDSGE_RESTRICT KC, f64 *SDSGE_RESTRICT I_minus_KC,
+                   f64 *SDSGE_RESTRICT temp_nn, f64 *SDSGE_RESTRICT temp_nm,
+                   f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    kf_matmul(K, C, KC, n, m, n);
+    kf_identity_minus(KC, I_minus_KC, n);
+    kf_matmul(I_minus_KC, P_pred, temp_nn, n, n, n);
+    kf_matmul_abt(temp_nn, I_minus_KC, out, n, n, n);
+    kf_matmul(K, R, temp_nm, n, m, m);
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < n; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < m; ++k)
+                s += temp_nm[i * m + k] * K[j * m + k];
+            out[i * n + j] += s;
+        }
+    }
+}
+
+void kf_build_bqbt(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT Q,
+                   f64 *SDSGE_RESTRICT temp_nk, f64 *SDSGE_RESTRICT out,
+                   i64 n, i64 k) {
+    kf_matmul(B, Q, temp_nk, n, k, k);
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < n; ++j) {
+            f64 s = 0.0;
+            for (i64 l = 0; l < k; ++l)
+                s += temp_nk[i * k + l] * B[j * k + l];
+            out[i * n + j] = s;
+        }
+    }
+    kf_sym_inplace(out, n);
+}
+
+void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT C,
+                               const f64 *SDSGE_RESTRICT Q, f64 *SDSGE_RESTRICT temp_km,
+                               f64 *SDSGE_RESTRICT out, i64 n, i64 k, i64 m) {
+    for (i64 i = 0; i < k; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 l = 0; l < n; ++l)
+                s += B[l * k + i] * C[j * n + l];
+            temp_km[i * m + j] = s;
+        }
+    }
+    kf_matmul(Q, temp_km, out, k, k, m);
+}

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -1,5 +1,7 @@
 #include "kalman.h"
 #include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 void kf_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
     const i64 total = r * c;
@@ -258,4 +260,114 @@ void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RES
         }
     }
     kf_matmul(Q, temp_km, out, k, k, m);
+}
+
+int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
+    const i64 n = in->n, m = in->m, k = in->k, T = in->T;
+
+    /* One scratch arena carved into every per-step buffer (allocated once). */
+    const i64 total = 2 * n + 7 * m   /* vectors + triangular-solve scratch */
+                      + 6 * n * n     /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+                      + 2 * m * m     /* S_buf, L */
+                      + 3 * n * m     /* PCt, K, temp_nm */
+                      + m * n         /* temp_mn */
+                      + n * k         /* temp_nk */
+                      + 2 * k * m;    /* M, temp_km */
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return KF_ERR_ALLOC;
+
+    f64 *p = arena;
+    f64 *x_pred_buf = p; p += n;
+    f64 *x_filt_buf = p; p += n;
+    f64 *y_pred_buf = p; p += m;
+    f64 *y_filt_buf = p; p += m;
+    f64 *v_buf = p; p += m;
+    f64 *u_buf = p; p += m;
+    f64 *S_inv_v = p; p += m;
+    f64 *solve_f = p; p += m;
+    f64 *solve_b = p; p += m;
+    f64 *P_pred_buf = p; p += n * n;
+    f64 *P_filt_buf = p; p += n * n;
+    f64 *KC = p; p += n * n;
+    f64 *I_minus_KC = p; p += n * n;
+    f64 *temp_nn = p; p += n * n;
+    f64 *BQBT = p; p += n * n;
+    f64 *S_buf = p; p += m * m;
+    f64 *L = p; p += m * m;
+    f64 *PCt = p; p += n * m;
+    f64 *K = p; p += n * m;
+    f64 *temp_nm = p; p += n * m;
+    f64 *temp_mn = p; p += m * n;
+    f64 *temp_nk = p; p += n * k;
+    f64 *M = p; p += k * m;
+    f64 *temp_km = p; p += k * m;
+
+    kf_build_bqbt(in->B, in->Q, temp_nk, BQBT, n, k);
+    if (in->return_shocks && in->store_history)
+        kf_build_shock_projection(in->B, in->C, in->Q, temp_km, M, n, k, m);
+
+    const f64 const_term = (f64)m * log(TWO_PI); /* m * log(2*pi) */
+    f64 loglik = 0.0;
+
+    /* x_prev/P_prev start at the inputs, then alias the filtered scratch; each
+     * is read (into x_pred_buf / P_pred_buf) before being overwritten. */
+    const f64 *x_prev = in->x0;
+    const f64 *P_prev = in->P0;
+    int status = KF_OK;
+
+    for (i64 t = 0; t < T; ++t) {
+        kf_matvec(in->A, x_prev, x_pred_buf, n, n);
+        kf_predict_cov(in->A, P_prev, BQBT, temp_nn, P_pred_buf, n);
+        if (in->symmetrize)
+            kf_sym_inplace(P_pred_buf, n);
+
+        kf_matvec_plus_vec(in->C, x_pred_buf, in->d, y_pred_buf, m, n);
+        kf_row_minus_vec(in->y, t, y_pred_buf, v_buf, m);
+        kf_measurement_cov(in->C, P_pred_buf, in->R, temp_mn, S_buf, n, m);
+        if (in->symmetrize)
+            kf_sym_inplace(S_buf, m);
+
+        status = kf_chol_shifted(S_buf, in->jitter, L, m);
+        if (status != KF_OK)
+            break;
+
+        kf_forward_subst(L, v_buf, u_buf, m);
+        kf_backward_subst_chol_t(L, u_buf, S_inv_v, m);
+
+        kf_pc_t(P_pred_buf, in->C, PCt, n, m);
+        kf_gain_from_pc_t(L, PCt, solve_f, solve_b, K, n, m);
+
+        kf_state_update(x_pred_buf, K, v_buf, x_filt_buf, n, m);
+        kf_joseph_cov(K, in->C, P_pred_buf, in->R, KC, I_minus_KC, temp_nn,
+                      temp_nm, P_filt_buf, n, m);
+        if (in->symmetrize)
+            kf_sym_inplace(P_filt_buf, n);
+
+        loglik += -0.5 * (const_term + kf_logdet_from_chol(L, m)
+                          + kf_dot(v_buf, S_inv_v, m));
+
+        if (in->return_shocks && in->store_history)
+            kf_matvec(M, S_inv_v, out->eps_hat + t * k, k, m);
+
+        if (in->store_history) {
+            kf_matvec_plus_vec(in->C, x_filt_buf, in->d, y_filt_buf, m, n);
+            memcpy(out->x_pred + t * n, x_pred_buf, (size_t)n * sizeof(f64));
+            memcpy(out->x_filt + t * n, x_filt_buf, (size_t)n * sizeof(f64));
+            memcpy(out->P_pred + t * n * n, P_pred_buf, (size_t)(n * n) * sizeof(f64));
+            memcpy(out->P_filt + t * n * n, P_filt_buf, (size_t)(n * n) * sizeof(f64));
+            memcpy(out->y_pred + t * m, y_pred_buf, (size_t)m * sizeof(f64));
+            memcpy(out->y_filt + t * m, y_filt_buf, (size_t)m * sizeof(f64));
+            memcpy(out->innov + t * m, v_buf, (size_t)m * sizeof(f64));
+            memcpy(out->std_innov + t * m, u_buf, (size_t)m * sizeof(f64));
+            memcpy(out->S + t * m * m, S_buf, (size_t)(m * m) * sizeof(f64));
+        }
+
+        x_prev = x_filt_buf;
+        P_prev = P_filt_buf;
+    }
+
+    *out->loglik = loglik;
+    free(arena);
+    return status;
 }

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -8,6 +8,7 @@
 #define KF_ERR_SHAPE_MISMATCH -2
 #define KF_ERR_MATRIX_CONDITION -3
 #define KF_ERR_SINGULAR_MATRIX -4
+#define KF_ERR_ALLOC -5
 
 /* Kalman hot-loop helpers ported from the numba `*_into` kernels in
  * SymbolicDSGE/kalman/filter.py. All matrices are C-contiguous, row-major, f64.
@@ -105,5 +106,49 @@ void kf_build_bqbt(const f64 *B, const f64 *Q, f64 *temp_nk, f64 *out,
 /* out(k,m) := Q(k,k) @ (B^T C^T)(k,m), via temp_km(k,m) */
 void kf_build_shock_projection(const f64 *B, const f64 *C, const f64 *Q,
                                f64 *temp_km, f64 *out, i64 n, i64 k, i64 m);
+
+/* ---- Linear Kalman filter hot loop ---- */
+
+/* Model + data inputs. All matrices C-contiguous, row-major, f64. */
+typedef struct {
+    i64 n;              /* state dimension */
+    i64 m;              /* observation dimension */
+    i64 k;              /* shock dimension */
+    i64 T;              /* number of time steps */
+    const f64 *A;       /* (n, n) state transition */
+    const f64 *B;       /* (n, k) shock loading */
+    const f64 *C;       /* (m, n) observation */
+    const f64 *d;       /* (m,)   observation intercept */
+    const f64 *Q;       /* (k, k) shock covariance */
+    const f64 *R;       /* (m, m) measurement covariance */
+    const f64 *y;       /* (T, m) observations */
+    const f64 *x0;      /* (n,)   initial state mean */
+    const f64 *P0;      /* (n, n) initial state covariance (pre-symmetrized) */
+    int symmetrize;     /* symmetrize P/S each step (0/1) */
+    f64 jitter;         /* diagonal jitter for the Cholesky */
+    int return_shocks;  /* compute eps_hat (0/1) */
+    int store_history;  /* fill the per-step history arrays (0/1) */
+} kf_inputs;
+
+/* Caller-allocated outputs. When store_history is 0 the history arrays may be
+ * NULL / zero-length; eps_hat is written only when return_shocks &&
+ * store_history. loglik is always written. */
+typedef struct {
+    f64 *x_pred;     /* (T, n) */
+    f64 *x_filt;     /* (T, n) */
+    f64 *P_pred;     /* (T, n, n) */
+    f64 *P_filt;     /* (T, n, n) */
+    f64 *y_pred;     /* (T, m) */
+    f64 *y_filt;     /* (T, m) */
+    f64 *innov;      /* (T, m)  innovations v */
+    f64 *std_innov;  /* (T, m)  L^-1 v */
+    f64 *S;          /* (T, m, m) innovation covariances */
+    f64 *eps_hat;    /* (T, k) or NULL */
+    f64 *loglik;     /* scalar out */
+} kf_outputs;
+
+/* Run the linear Kalman filter. Returns KF_OK, KF_ERR_MATRIX_CONDITION (non-PD
+ * innovation covariance), or KF_ERR_ALLOC (scratch allocation failed). */
+int kf_hot_loop(const kf_inputs *in, kf_outputs *out);
 
 #endif /* SDSGE_KALMAN_H */

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -3,6 +3,107 @@
 
 #include "../_common/sdsge_common.h"
 
-/* Placeholder for kalman native kernels. Declare prototypes here. */
+#define KF_OK 0
+#define KF_ERR_COMPLEX_MATRIX -1
+#define KF_ERR_SHAPE_MISMATCH -2
+#define KF_ERR_MATRIX_CONDITION -3
+#define KF_ERR_SINGULAR_MATRIX -4
+
+/* Kalman hot-loop helpers ported from the numba `*_into` kernels in
+ * SymbolicDSGE/kalman/filter.py. All matrices are C-contiguous, row-major, f64.
+ * Buffers are caller-allocated; nothing here aliases (inputs and outputs are
+ * always distinct). The dense linear-algebra primitives (kf_matmul, kf_chol_*,
+ * kf_*subst, kf_dot, ...) are candidates to promote to _common/sdsge_linalg
+ * once the regression port needs them. */
+
+/* ---- Dense linear-algebra primitives ---- */
+
+/* out(r,c) := 0 */
+void kf_zero_mat(f64 *out, i64 r, i64 c);
+
+/* P(n,n) := (P + P^T) / 2, in place */
+void kf_sym_inplace(f64 *P, i64 n);
+
+/* out(n,m) := A(n,p) @ B(p,m) */
+void kf_matmul(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
+
+/* out(n,m) := A(n,p) @ B(m,p)^T */
+void kf_matmul_abt(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
+
+/* out(n,m) := A(n,p) @ B(m,p)^T + C(n,m) */
+void kf_matmul_abt_plus_c(const f64 *A, const f64 *B, const f64 *C, f64 *out,
+                          i64 n, i64 p, i64 m);
+
+/* out(n) := A(n,m) @ x(m) */
+void kf_matvec(const f64 *A, const f64 *x, f64 *out, i64 n, i64 m);
+
+/* out(n) := A(n,m) @ x(m) + b(n) */
+void kf_matvec_plus_vec(const f64 *A, const f64 *x, const f64 *b, f64 *out,
+                        i64 n, i64 m);
+
+/* out(m) := A[row, :] - x(m), where A has m columns */
+void kf_row_minus_vec(const f64 *A, i64 row, const f64 *x, f64 *out, i64 m);
+
+/* dot product of a(n) and b(n) */
+f64 kf_dot(const f64 *a, const f64 *b, i64 n);
+
+/* 2 * sum(log(diag(L))) for lower-triangular L(n,n) */
+f64 kf_logdet_from_chol(const f64 *L, i64 n);
+
+/* Lower Cholesky L(n,n) of S(n,n) (+ jitter on the diagonal). Returns KF_OK,
+ * or KF_ERR_MATRIX_CONDITION if S is not positive definite. */
+int kf_chol_shifted(const f64 *S, f64 jitter, f64 *L, i64 n);
+
+/* Solve L(n,n) x = b(n) for lower-triangular L; writes x into out(n). */
+void kf_forward_subst(const f64 *L, const f64 *b, f64 *out, i64 n);
+
+/* Solve L^T x = b using lower-triangular L(n,n); writes x into out(n). */
+void kf_backward_subst_chol_t(const f64 *L, const f64 *b, f64 *out, i64 n);
+
+/* Solve (L L^T) x = B[row, :] for the single row; writes x into out[row, :].
+ * `n` is the Cholesky dimension (= column count of B and out); fbuf/bbuf are
+ * scratch of length n. */
+void kf_chol_solve_row(const f64 *L, const f64 *B, i64 row, f64 *fbuf, f64 *bbuf,
+                       f64 *out, i64 n);
+
+/* ---- Kalman-specific composition helpers ---- */
+
+/* out(n,n) := A P_prev A^T + BQBT, via temp_nn(n,n) */
+void kf_predict_cov(const f64 *A, const f64 *P_prev, const f64 *BQBT,
+                    f64 *temp_nn, f64 *out, i64 n);
+
+/* out(m,m) := C P_pred C^T + R, via temp_mn(m,n) */
+void kf_measurement_cov(const f64 *C, const f64 *P_pred, const f64 *R,
+                        f64 *temp_mn, f64 *out, i64 n, i64 m);
+
+/* out(n,m) := P_pred(n,n) @ C(m,n)^T */
+void kf_pc_t(const f64 *P_pred, const f64 *C, f64 *out, i64 n, i64 m);
+
+/* out K(n,m): solve (L L^T) K[r,:] = PCt[r,:] per row; L is the m×m chol of S.
+ * fbuf/bbuf are scratch of length m. */
+void kf_gain_from_pc_t(const f64 *L, const f64 *PCt, f64 *fbuf, f64 *bbuf,
+                       f64 *out, i64 n, i64 m);
+
+/* out(n) := x_pred(n) + K(n,m) @ v(m) */
+void kf_state_update(const f64 *x_pred, const f64 *K, const f64 *v, f64 *out,
+                     i64 n, i64 m);
+
+/* out(n,n) := I - A(n,n) */
+void kf_identity_minus(const f64 *A, f64 *out, i64 n);
+
+/* Joseph-form covariance update:
+ *   out(n,n) := (I - K C) P_pred (I - K C)^T + K R K^T
+ * KC, I_minus_KC, temp_nn are (n,n) scratch; temp_nm is (n,m) scratch. */
+void kf_joseph_cov(const f64 *K, const f64 *C, const f64 *P_pred, const f64 *R,
+                   f64 *KC, f64 *I_minus_KC, f64 *temp_nn, f64 *temp_nm,
+                   f64 *out, i64 n, i64 m);
+
+/* out(n,n) := sym(B(n,k) Q(k,k) B^T), via temp_nk(n,k) */
+void kf_build_bqbt(const f64 *B, const f64 *Q, f64 *temp_nk, f64 *out,
+                   i64 n, i64 k);
+
+/* out(k,m) := Q(k,k) @ (B^T C^T)(k,m), via temp_km(k,m) */
+void kf_build_shock_projection(const f64 *B, const f64 *C, const f64 *Q,
+                               f64 *temp_km, f64 *out, i64 n, i64 k, i64 m);
 
 #endif /* SDSGE_KALMAN_H */

--- a/SymbolicDSGE/kalman/filter.py
+++ b/SymbolicDSGE/kalman/filter.py
@@ -24,6 +24,14 @@ from typing import Tuple, Callable
 NDF = NDArray[float64]
 NDC = NDArray[complex128]
 
+# Prefer the compiled native linear hot loop; fall back to the numba kernel
+# below when the extension is not built. The numba version stays as the fallback
+# and the parity oracle.
+try:
+    from .._ckernels.kalman import kalman_hot_loop as _kalman_hot_loop_native
+except ImportError:  # pragma: no cover - exercised only without the extension
+    _kalman_hot_loop_native = None
+
 
 @dataclass(frozen=True)
 class FilterResult:
@@ -993,8 +1001,13 @@ class KalmanFilter:
         if symmetrize:
             P_prev = _sym(P_prev)
 
+        hot_loop = (
+            _kalman_hot_loop_native
+            if _kalman_hot_loop_native is not None
+            else _kalman_hot_loop
+        )
         try:
-            err, err_info, out = _kalman_hot_loop(
+            err, err_info, out = hot_loop(
                 T,
                 (n, m, k),
                 A,

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -5,15 +5,7 @@
    "execution_count": 1,
    "id": "8b55608d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Detected IPython. Loading juliacall extension. See https://juliapy.github.io/PythonCall.jl/stable/compat/#IPython\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -58,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "7868d0e5",
    "metadata": {},
    "outputs": [],
@@ -130,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "id": "c4a12aa7",
    "metadata": {},
    "outputs": [
@@ -138,7 +130,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MC run concluded successfully with 520.18 it/s.\n"
+      "datagen concluded successfully with 1346.91 it/s.\n",
+      "filter concluded successfully with 1718.43 it/s.\n",
+      "std_innov_mean concluded successfully with 15748.63 it/s.\n",
+      "OGap_autocorr concluded successfully with 37114.57 it/s.\n",
+      "Infl_autocorr concluded successfully with 53371.19 it/s.\n",
+      "Rate_autocorr concluded successfully with 60151.81 it/s.\n",
+      "std_innov_second_moment concluded successfully with 6308.80 it/s.\n",
+      "OutGap_regression concluded successfully with 5762.74 it/s.\n"
      ]
     }
    ],
@@ -149,7 +148,7 @@
     "    n_rep=1000,\n",
     "    retain_payloads=False,\n",
     "    retain_test_results=False,\n",
-    "    verbosity=1,\n",
+    "    verbosity=2,\n",
     ")"
    ]
   },
@@ -310,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "symbolicdsge (3.13.9)",
+   "display_name": "symbolicdsge (3.11.14)",
    "language": "python",
    "name": "python3"
   },
@@ -324,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = ^(tests/|hooks/|sdsge-scripts/)
+exclude = ^(tests/|hooks/|sdsge-scripts/|build/)
 # Pin analysis to the supported floor so >3.11 stdlib/typing usage is flagged.
 python_version = 3.11
 # Optionals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "pip>=26.0.1",
     "jupyterlab-execute-time>=3.3.0",
     "httpx2>=2.3.0",
+    "setuptools>=82.0.1",
 ]
 
 [build-system]

--- a/tests/ckernels/test_kalman.py
+++ b/tests/ckernels/test_kalman.py
@@ -1,0 +1,132 @@
+"""Parity tests for the native linear Kalman hot loop vs the numba reference.
+
+Skips when the ``_ckernels.kalman`` extension is not built.
+"""
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.kalman.filter import _kalman_hot_loop
+
+kf = pytest.importorskip("SymbolicDSGE._ckernels.kalman")
+
+# Cross-compiler FP (log/sqrt/division last-ULP) accumulates over T steps, so
+# compare tightly rather than bit-exact.
+_RTOL = 1e-9
+_ATOL = 1e-9
+
+_HIST = (
+    "x_pred",
+    "x_filt",
+    "P_pred",
+    "P_filt",
+    "y_pred",
+    "y_filt",
+    "innov",
+    "std_innov",
+    "S",
+)
+
+
+def _c(z: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(z, dtype=np.float64)
+
+
+def _make_system(n: int, m: int, k: int, T: int, seed: int):
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((n, n))
+    A *= 0.5 / np.max(np.abs(np.linalg.eigvals(A)))  # spectral radius 0.5 (stable)
+    B = rng.standard_normal((n, k))
+    C = rng.standard_normal((m, n))
+    d = rng.standard_normal(m)
+    Qh = rng.standard_normal((k, k))
+    Rh = rng.standard_normal((m, m))
+    Ph = rng.standard_normal((n, n))
+    Q = Qh @ Qh.T + np.eye(k)
+    R = Rh @ Rh.T + np.eye(m)
+    P0 = Ph @ Ph.T + np.eye(n)
+    P0 = 0.5 * (P0 + P0.T)
+    y = rng.standard_normal((T, m))
+    x0 = rng.standard_normal(n)
+    return tuple(_c(z) for z in (A, B, C, d, Q, R, y, x0, P0))
+
+
+@pytest.mark.parametrize(
+    "n, m, k, T", [(2, 1, 1, 20), (4, 2, 2, 50), (3, 3, 1, 30), (5, 2, 3, 40)]
+)
+@pytest.mark.parametrize("symmetrize", [True, False])
+@pytest.mark.parametrize("return_shocks", [True, False])
+@pytest.mark.parametrize("store_history", [True, False])
+def test_kalman_matches_numba(
+    n: int,
+    m: int,
+    k: int,
+    T: int,
+    symmetrize: bool,
+    return_shocks: bool,
+    store_history: bool,
+) -> None:
+    A, B, C, d, Q, R, y, x0, P0 = _make_system(
+        n, m, k, T, seed=n * 1000 + m * 100 + k * 10 + T
+    )
+    args = (
+        T,
+        (n, m, k),
+        A,
+        B,
+        C,
+        d,
+        Q,
+        R,
+        y,
+        x0,
+        P0,
+        symmetrize,
+        0.0,
+        return_shocks,
+        store_history,
+    )
+
+    _, _, out_ref = _kalman_hot_loop(*args)
+    _, _, out_native = kf.kalman_hot_loop(*args)
+
+    for i, name in enumerate(_HIST):
+        np.testing.assert_allclose(
+            out_native[i], out_ref[i], rtol=_RTOL, atol=_ATOL, err_msg=name
+        )
+    # eps_hat (index 9)
+    np.testing.assert_allclose(
+        out_native[9], out_ref[9], rtol=_RTOL, atol=_ATOL, err_msg="eps_hat"
+    )
+    # loglik (index 10)
+    np.testing.assert_allclose(
+        out_native[10], out_ref[10], rtol=_RTOL, atol=_ATOL, err_msg="loglik"
+    )
+
+
+def test_kalman_non_pd_raises() -> None:
+    # m=1 with a negative R forces S = C P_pred C^T + R < 0, so the Cholesky
+    # fails -> both paths raise LinAlgError (-> MatrixConditionError upstream).
+    n, m, k, T = 1, 1, 1, 5
+    rng = np.random.default_rng(0)
+    args = (
+        T,
+        (n, m, k),
+        _c([[0.5]]),
+        _c([[1.0]]),
+        _c([[1.0]]),
+        _c([0.0]),
+        _c([[1.0]]),
+        _c([[-10.0]]),  # negative "covariance" -> non-PD innovation covariance
+        _c(rng.standard_normal((T, m))),
+        _c([0.0]),
+        _c([[1.0]]),
+        True,
+        0.0,
+        False,
+        True,
+    )
+    with pytest.raises(np.linalg.LinAlgError):
+        kf.kalman_hot_loop(*args)
+    with pytest.raises(np.linalg.LinAlgError):
+        _kalman_hot_loop(*args)

--- a/tests/kalman/test_filter_internal.py
+++ b/tests/kalman/test_filter_internal.py
@@ -470,6 +470,10 @@ def test_run_converts_internal_linalg_and_error_codes(monkeypatch):
     A, B, C, d, Q, R = _linear_system_1d()
     y = np.zeros((2, 1), dtype=float64)
 
+    # Force the numba path so the monkeypatched hot loop is the one run() calls
+    # (run() prefers the native extension when it is built).
+    monkeypatch.setattr(filter_module, "_kalman_hot_loop_native", None)
+
     def raising_hot_loop(*args, **kwargs):
         raise np.linalg.LinAlgError("boom")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3626,6 +3626,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3764,6 +3773,7 @@ dev = [
     { name = "python-dotenv" },
     { name = "scipy-stubs", version = "1.17.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy-stubs", version = "1.18.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "setuptools" },
     { name = "tabulate" },
     { name = "types-pyyaml" },
 ]
@@ -3810,6 +3820,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "scipy-stubs", specifier = ">=1.16.3.2" },
+    { name = "setuptools", specifier = ">=82.0.1" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]


### PR DESCRIPTION
Port Kalman filter kernel and helpers to native for the linear filter case `_kalman_hot_loop`. EKF relies on codegen and dynamic JIT which is difficult to port to AOT compiled native and remains a `numba` implementation.