### PR TITLE
Add native kernel stubs and selection flags

### DIFF
--- a/SymbolicDSGE/_ckernels/core/_core.pyi
+++ b/SymbolicDSGE/_ckernels/core/_core.pyi
@@ -1,0 +1,32 @@
+"""Type stubs for the compiled ``_core`` extension.
+
+The native kernels carry no inspectable type information (the type checker never
+parses ``_core.pyx`` nor introspects the compiled object), so these signatures
+exist solely to give the LSP and mypy the shapes of the exported functions. They
+must stay in sync with ``_core.pyx`` / ``core.c`` and the numba reference in
+``SymbolicDSGE.core.simulation``; the parity tests guard the runtime behavior,
+not this stub.
+"""
+
+from numpy import float64
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+
+def simulate_linear_states_into(
+    A: _F64,
+    B: _F64,
+    x0: _F64,
+    shock_mat: _F64,
+    out: _F64,
+) -> None:
+    """out[(T+1, n)] <- linear state recursion. Mirrors the numba kernel."""
+
+def affine_observations_into(
+    states: _F64,
+    C: _F64,
+    d: _F64,
+    state_start: int,
+    out: _F64,
+) -> None:
+    """out[(T, m)] <- d + C @ states[state_start + t]. Mirrors the numba kernel."""

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -1,0 +1,10 @@
+"""Type stubs for the compiled ``_diag`` extension (placeholder).
+
+The diagnostic-test kernels are not implemented yet; this stub exists so the
+landsite is ready and the package's ``py.typed`` coverage stays consistent (a
+compiled module carries no inspectable types, so without a stub its symbols
+degrade to ``Any`` for consumers). As each kernel lands in ``_diag.pyx`` /
+``diag.c``, add the matching ``def`` signature here -- typed NumPy arrays in,
+status code or output array out -- kept in sync with the numba reference. The
+parity tests guard the runtime behavior, not this stub.
+"""

--- a/SymbolicDSGE/_ckernels/distributions/_distributions.pyi
+++ b/SymbolicDSGE/_ckernels/distributions/_distributions.pyi
@@ -1,0 +1,10 @@
+"""Type stubs for the compiled ``_distributions`` extension (placeholder).
+
+The distribution kernels are not implemented yet; this stub exists so the
+landsite is ready and the package's ``py.typed`` coverage stays consistent (a
+compiled module carries no inspectable types, so without a stub its symbols
+degrade to ``Any`` for consumers). As each kernel lands in ``_distributions.pyx``
+/ ``distributions.c``, add the matching ``def`` signature here -- typed NumPy
+arrays in, status code or output array out -- kept in sync with the numba
+reference. The parity tests guard the runtime behavior, not this stub.
+"""

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
@@ -1,0 +1,37 @@
+"""Type stubs for the compiled ``_kalman`` extension.
+
+The native kernel carries no inspectable type information (the type checker never
+parses ``_kalman.pyx`` nor introspects the compiled object), so this signature
+exists solely to give the LSP and mypy the shape of the exported function. It
+must stay in sync with ``_kalman.pyx`` / ``kalman.c`` and the numba reference
+``SymbolicDSGE.kalman.filter._kalman_hot_loop`` (the two are interchangeable at
+the call site); the parity tests guard the runtime behavior, not this stub.
+"""
+
+from numpy import float64
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+
+def kalman_hot_loop(
+    T: int,
+    nmk: tuple[int, int, int],
+    A: _F64,
+    B: _F64,
+    C: _F64,
+    d: _F64,
+    Q: _F64,
+    R: _F64,
+    y: _F64,
+    x0: _F64,
+    P0: _F64,
+    symmetrize: bool,
+    jitter: float,
+    return_shocks: bool = ...,
+    store_history: bool = ...,
+) -> tuple[
+    int,
+    tuple[float64, float64, float64],
+    tuple[_F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, float64],
+]:
+    """Run the linear Kalman filter; mirrors numba ``_kalman_hot_loop``."""

--- a/SymbolicDSGE/_ckernels/regression/_regression.pyi
+++ b/SymbolicDSGE/_ckernels/regression/_regression.pyi
@@ -1,0 +1,10 @@
+"""Type stubs for the compiled ``_regression`` extension (placeholder).
+
+The regression kernels are not implemented yet; this stub exists so the
+landsite is ready and the package's ``py.typed`` coverage stays consistent (a
+compiled module carries no inspectable types, so without a stub its symbols
+degrade to ``Any`` for consumers). As each kernel lands in ``_regression.pyx`` /
+``regression.c``, add the matching ``def`` signature here -- typed NumPy arrays
+in, status code or output array out -- kept in sync with the numba reference. The
+parity tests guard the runtime behavior, not this stub.
+"""

--- a/SymbolicDSGE/_native_dispatch.py
+++ b/SymbolicDSGE/_native_dispatch.py
@@ -1,0 +1,48 @@
+"""Runtime selection between the native (``_ckernels``) and numba kernels.
+
+Each consumer that has both a compiled native kernel and a numba reference picks
+between them at import time. The default policy is *prefer native, fall back to
+numba* when the extension is not built. Two debug environment variables override
+that policy:
+
+* ``ALWAYS_USE_NUMBA`` -- ignore the native extension entirely and pin the numba
+  path, even when the extension is built. Useful for benchmarking the fallback or
+  bisecting a native/numba parity discrepancy.
+* ``NEVER_USE_NUMBA`` -- require the native extension. Instead of silently
+  falling back, let the ``ImportError`` propagate so execution halts loudly.
+  Useful for confirming the native path is actually the one running.
+
+A variable counts as *set* when present and not one of ``0/false/no/off`` (case
+insensitive); an empty value is treated as unset. Setting both is contradictory
+and raises at import time.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["FORCE_NUMBA", "REQUIRE_NATIVE"]
+
+_FALSEY = {"", "0", "false", "no", "off"}
+
+
+def _flag(name: str) -> bool:
+    """Return whether the debug env var ``name`` is set to a truthy value."""
+    val = os.environ.get(name)
+    if val is None:
+        return False
+    return val.strip().lower() not in _FALSEY
+
+
+#: Pin the numba path and skip the native import (``ALWAYS_USE_NUMBA``).
+FORCE_NUMBA = _flag("ALWAYS_USE_NUMBA")
+
+#: Require the native extension; let an ``ImportError`` halt instead of falling
+#: back to numba (``NEVER_USE_NUMBA``).
+REQUIRE_NATIVE = _flag("NEVER_USE_NUMBA")
+
+if FORCE_NUMBA and REQUIRE_NATIVE:
+    raise ValueError(
+        "ALWAYS_USE_NUMBA and NEVER_USE_NUMBA are mutually exclusive; set at most "
+        "one (ALWAYS_USE_NUMBA pins numba, NEVER_USE_NUMBA requires native)."
+    )

--- a/SymbolicDSGE/core/simulation.py
+++ b/SymbolicDSGE/core/simulation.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from numba import njit
 import numpy as np
 from numpy import ascontiguousarray, float64
@@ -8,14 +10,30 @@ NDF = NDArray[np.float64]
 # Prefer the compiled native kernels; fall back to the numba kernels below when
 # the _ckernels extension is not built (sdist without a compiler, etc.). The
 # numba versions stay in place permanently as the fallback and the parity oracle.
-try:
-    from .._ckernels.core import (
-        affine_observations_into as _affine_native,
-        simulate_linear_states_into as _simulate_native,
-    )
-except ImportError:  # pragma: no cover - exercised only without the extension
+# ALWAYS_USE_NUMBA / NEVER_USE_NUMBA override this default (see _native_dispatch).
+from .._native_dispatch import FORCE_NUMBA, REQUIRE_NATIVE
+
+# Declared explicitly so the FORCE_NUMBA branch (which binds None first) doesn't
+# pin the inferred type to None; the native handle matches the _core.pyi stub.
+_SimulateKernel = Callable[[NDF, NDF, NDF, NDF, NDF], None]
+_AffineKernel = Callable[[NDF, NDF, NDF, int, NDF], None]
+_simulate_native: _SimulateKernel | None
+_affine_native: _AffineKernel | None
+
+if FORCE_NUMBA:
     _affine_native = None
     _simulate_native = None
+else:
+    try:
+        from .._ckernels.core import (
+            affine_observations_into as _affine_native,
+            simulate_linear_states_into as _simulate_native,
+        )
+    except ImportError:  # pragma: no cover - exercised only without the extension
+        if REQUIRE_NATIVE:
+            raise
+        _affine_native = None
+        _simulate_native = None
 
 
 @njit(cache=True)

--- a/SymbolicDSGE/kalman/filter.py
+++ b/SymbolicDSGE/kalman/filter.py
@@ -26,11 +26,29 @@ NDC = NDArray[complex128]
 
 # Prefer the compiled native linear hot loop; fall back to the numba kernel
 # below when the extension is not built. The numba version stays as the fallback
-# and the parity oracle.
-try:
-    from .._ckernels.kalman import kalman_hot_loop as _kalman_hot_loop_native
-except ImportError:  # pragma: no cover - exercised only without the extension
+# and the parity oracle. ALWAYS_USE_NUMBA / NEVER_USE_NUMBA override this default
+# (see _native_dispatch).
+from .._native_dispatch import FORCE_NUMBA, REQUIRE_NATIVE
+
+# Declared explicitly so the FORCE_NUMBA branch (which binds None first) doesn't
+# pin the inferred type to None; the native handle matches the _kalman.pyi stub
+# and the numba _kalman_hot_loop return shape.
+_KalmanReturn = Tuple[
+    int,
+    Tuple[float64, float64, float64],
+    Tuple[NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, float64],
+]
+_kalman_hot_loop_native: Callable[..., _KalmanReturn] | None
+
+if FORCE_NUMBA:
     _kalman_hot_loop_native = None
+else:
+    try:
+        from .._ckernels.kalman import kalman_hot_loop as _kalman_hot_loop_native
+    except ImportError:  # pragma: no cover - exercised only without the extension
+        if REQUIRE_NATIVE:
+            raise
+        _kalman_hot_loop_native = None
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,9 @@ where = ["."]
 include = ["SymbolicDSGE*"]
 
 [tool.setuptools.package-data]
+"SymbolicDSGE" = ["py.typed"]
 "SymbolicDSGE.ui" = ["_static/**/*"]
-"SymbolicDSGE._ckernels" = ["**/*.pyx", "**/*.pxd", "**/*.c", "**/*.h"]
+"SymbolicDSGE._ckernels" = ["**/*.pyx", "**/*.pxd", "**/*.pyi", "**/*.c", "**/*.h"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/ckernels/test_native_dispatch.py
+++ b/tests/ckernels/test_native_dispatch.py
@@ -1,0 +1,74 @@
+"""Tests for the native/numba selection env-var overrides (_native_dispatch)."""
+
+import importlib
+
+import pytest
+
+import SymbolicDSGE._native_dispatch as dispatch
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("anything", True),
+        ("0", False),
+        ("false", False),
+        ("No", False),
+        ("off", False),
+        ("", False),
+        ("  ", False),
+    ],
+)
+def test_flag_parsing(monkeypatch, value, expected):
+    monkeypatch.setenv("SDSGE_TEST_FLAG", value)
+    assert dispatch._flag("SDSGE_TEST_FLAG") is expected
+
+
+def test_flag_unset_is_false(monkeypatch):
+    monkeypatch.delenv("SDSGE_TEST_FLAG", raising=False)
+    assert dispatch._flag("SDSGE_TEST_FLAG") is False
+
+
+def _reload(monkeypatch, *, always=None, never=None):
+    for name, val in (("ALWAYS_USE_NUMBA", always), ("NEVER_USE_NUMBA", never)):
+        if val is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, val)
+    return importlib.reload(dispatch)
+
+
+def test_default_is_prefer_native(monkeypatch):
+    mod = _reload(monkeypatch)
+    assert mod.FORCE_NUMBA is False
+    assert mod.REQUIRE_NATIVE is False
+
+
+def test_always_use_numba_sets_force(monkeypatch):
+    mod = _reload(monkeypatch, always="1")
+    assert mod.FORCE_NUMBA is True
+    assert mod.REQUIRE_NATIVE is False
+
+
+def test_never_use_numba_sets_require(monkeypatch):
+    mod = _reload(monkeypatch, never="1")
+    assert mod.FORCE_NUMBA is False
+    assert mod.REQUIRE_NATIVE is True
+
+
+def test_both_set_raises(monkeypatch):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _reload(monkeypatch, always="1", never="1")
+
+
+@pytest.fixture(autouse=True)
+def _restore_dispatch():
+    """Reload the module clean after env-mutating tests so other tests see the
+    process default (neither override set)."""
+    yield
+    importlib.reload(dispatch)


### PR DESCRIPTION
Add .pyi stubs for the compiled _ckernels (core, kalman, diag, distributions, regression) to provide static types for LSP/mypy and keep py.typed coverage. Introduce SymbolicDSGE._native_dispatch to control runtime selection between native C extensions and numba via ALWAYS_USE_NUMBA / NEVER_USE_NUMBA, and update core.simulation and kalman.filter to respect these flags and use typed callables for the native handles. Include a py.typed marker and update pyproject package-data to ship .pyi files. Add tests for env-var parsing and dispatch behavior.

closes #215 