### PR TITLE
Add shared linalg and native diag kernels

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -30,6 +30,13 @@ typedef double f64;
  * the kalman / distribution / transform kernels. */
 #define TWO_PI 6.283185307179586
 
+/* Shared status codes for the dense linear-algebra primitives in sdsge_linalg.
+ * Subsystems map these onto their own error conventions (e.g. the kalman hot
+ * loop translates SDSGE_NOT_PD -> KF_ERR_MATRIX_CONDITION; the diag kernels turn
+ * it into a DIAG_FALLBACK request). SDSGE_OK is 0 so it coincides with KF_OK. */
+#define SDSGE_OK 0
+#define SDSGE_NOT_PD -1
+
 /* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
  * differently by MSVC). */
 #if defined(__GNUC__) || defined(__clang__)

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
@@ -1,5 +1,6 @@
 #include "sdsge_linalg.h"
 #include <math.h>
+#include <float.h>
 
 void sdsge_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
     const i64 total = r * c;
@@ -92,6 +93,23 @@ f64 sdsge_logdet_from_chol(const f64 *SDSGE_RESTRICT L, i64 n) {
 int sdsge_chol(const f64 *SDSGE_RESTRICT S, f64 jitter,
                f64 *SDSGE_RESTRICT L, i64 n) {
     sdsge_zero_mat(L, n, n);
+    /* Scale reference for a relative positive-definiteness threshold: the
+     * largest (jittered) diagonal entry. A genuinely rank-deficient matrix has
+     * an exact-arithmetic pivot of zero, but in floating point that pivot rounds
+     * to a tiny value of either sign that depends on the compiler/BLAS build.
+     * Testing the pivot against 0.0 therefore detects rank deficiency
+     * nondeterministically across builds. Comparing against scale * n * eps
+     * makes the decision deterministic while never rejecting a pivot of a truly
+     * positive-definite matrix (those sit far above this floor). */
+    f64 scale = 0.0;
+    for (i64 i = 0; i < n; ++i) {
+        f64 d = S[i * n + i];
+        if (jitter > 0.0)
+            d += jitter;
+        if (d > scale)
+            scale = d;
+    }
+    const f64 pivot_tol = scale * (f64)n * DBL_EPSILON;
     for (i64 i = 0; i < n; ++i) {
         for (i64 j = 0; j <= i; ++j) {
             f64 s = S[i * n + j];
@@ -100,7 +118,7 @@ int sdsge_chol(const f64 *SDSGE_RESTRICT S, f64 jitter,
             for (i64 k = 0; k < j; ++k)
                 s -= L[i * n + k] * L[j * n + k];
             if (i == j) {
-                if (s <= 0.0)
+                if (s <= pivot_tol)
                     return SDSGE_NOT_PD;
                 L[i * n + j] = sqrt(s);
             } else {

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
@@ -1,0 +1,202 @@
+#include "sdsge_linalg.h"
+#include <math.h>
+
+void sdsge_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
+    const i64 total = r * c;
+    for (i64 i = 0; i < total; ++i)
+        out[i] = 0.0;
+}
+
+void sdsge_sym_inplace(f64 *SDSGE_RESTRICT P, i64 n) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = i + 1; j < n; ++j) {
+            f64 avg = 0.5 * (P[i * n + j] + P[j * n + i]);
+            P[i * n + j] = avg;
+            P[j * n + i] = avg;
+        }
+    }
+}
+
+void sdsge_matmul(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                  f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[k * m + j];
+            out[i * m + j] = s;
+        }
+    }
+}
+
+void sdsge_matmul_abt(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                      f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[j * p + k];
+            out[i * m + j] = s;
+        }
+    }
+}
+
+void sdsge_matmul_abt_plus_c(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                             const f64 *SDSGE_RESTRICT C, f64 *SDSGE_RESTRICT out,
+                             i64 n, i64 p, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j < m; ++j) {
+            f64 s = 0.0;
+            for (i64 k = 0; k < p; ++k)
+                s += A[i * p + k] * B[j * p + k];
+            out[i * m + j] = s + C[i * m + j];
+        }
+    }
+}
+
+void sdsge_matvec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
+                  f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = 0.0;
+        for (i64 j = 0; j < m; ++j)
+            s += A[i * m + j] * x[j];
+        out[i] = s;
+    }
+}
+
+void sdsge_matvec_plus_vec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
+                           const f64 *SDSGE_RESTRICT b, f64 *SDSGE_RESTRICT out,
+                           i64 n, i64 m) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = b[i];
+        for (i64 j = 0; j < m; ++j)
+            s += A[i * m + j] * x[j];
+        out[i] = s;
+    }
+}
+
+f64 sdsge_dot(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b, i64 n) {
+    f64 s = 0.0;
+    for (i64 i = 0; i < n; ++i)
+        s += a[i] * b[i];
+    return s;
+}
+
+f64 sdsge_logdet_from_chol(const f64 *SDSGE_RESTRICT L, i64 n) {
+    f64 s = 0.0;
+    for (i64 i = 0; i < n; ++i)
+        s += log(L[i * n + i]);
+    return 2.0 * s;
+}
+
+int sdsge_chol(const f64 *SDSGE_RESTRICT S, f64 jitter,
+               f64 *SDSGE_RESTRICT L, i64 n) {
+    sdsge_zero_mat(L, n, n);
+    for (i64 i = 0; i < n; ++i) {
+        for (i64 j = 0; j <= i; ++j) {
+            f64 s = S[i * n + j];
+            if (i == j && jitter > 0.0)
+                s += jitter;
+            for (i64 k = 0; k < j; ++k)
+                s -= L[i * n + k] * L[j * n + k];
+            if (i == j) {
+                if (s <= 0.0)
+                    return SDSGE_NOT_PD;
+                L[i * n + j] = sqrt(s);
+            } else {
+                L[i * n + j] = s / L[j * n + j];
+            }
+        }
+    }
+    return SDSGE_OK;
+}
+
+/* out may alias b: out[i] is written only after reading b[i], and the loop reads
+ * out[j] for j < i, which were already written this call. */
+void sdsge_forward_subst(const f64 *SDSGE_RESTRICT L, const f64 *b,
+                         f64 *out, i64 n) {
+    for (i64 i = 0; i < n; ++i) {
+        f64 s = 0.0;
+        for (i64 j = 0; j < i; ++j)
+            s += L[i * n + j] * out[j];
+        out[i] = (b[i] - s) / L[i * n + i];
+    }
+}
+
+/* out may alias b: descending i reads out[j] for j > i (already written) and
+ * b[i] at the index about to be written. */
+void sdsge_backward_subst_chol_t(const f64 *SDSGE_RESTRICT L, const f64 *b,
+                                 f64 *out, i64 n) {
+    for (i64 i = n - 1; i >= 0; --i) {
+        f64 s = 0.0;
+        for (i64 j = i + 1; j < n; ++j)
+            s += L[j * n + i] * out[j];
+        out[i] = (b[i] - s) / L[i * n + i];
+    }
+}
+
+void sdsge_gram(const f64 *SDSGE_RESTRICT X, f64 *SDSGE_RESTRICT G, i64 n, i64 p) {
+    sdsge_zero_mat(G, p, p);
+    /* Lower triangle, accumulated row-by-row to match the numba xtx_xty order. */
+    for (i64 r = 0; r < n; ++r) {
+        const f64 *Xr = X + r * p;
+        for (i64 a = 0; a < p; ++a) {
+            f64 xra = Xr[a];
+            for (i64 b = 0; b <= a; ++b)
+                G[a * p + b] += xra * Xr[b];
+        }
+    }
+    /* Mirror to full symmetric. */
+    for (i64 a = 0; a < p; ++a)
+        for (i64 b = 0; b < a; ++b)
+            G[b * p + a] = G[a * p + b];
+}
+
+void sdsge_gram_rhs(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+                    f64 *SDSGE_RESTRICT g, i64 n, i64 p) {
+    for (i64 a = 0; a < p; ++a)
+        g[a] = 0.0;
+    for (i64 r = 0; r < n; ++r) {
+        const f64 *Xr = X + r * p;
+        f64 yr = y[r];
+        for (i64 a = 0; a < p; ++a)
+            g[a] += Xr[a] * yr;
+    }
+}
+
+int sdsge_chol_solve(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT g,
+                     f64 *SDSGE_RESTRICT coef, f64 *SDSGE_RESTRICT scratch_L,
+                     i64 p) {
+    int status = sdsge_chol(G, 0.0, scratch_L, p);
+    if (status != SDSGE_OK)
+        return status;
+    /* coef holds z := L^-1 g, then is overwritten with L^-T z in place. */
+    sdsge_forward_subst(scratch_L, g, coef, p);
+    sdsge_backward_subst_chol_t(scratch_L, coef, coef, p);
+    return SDSGE_OK;
+}
+
+int sdsge_chol_inv(const f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT Pinv,
+                   f64 *SDSGE_RESTRICT scratch_L, i64 p) {
+    int status = sdsge_chol(G, 0.0, scratch_L, p);
+    if (status != SDSGE_OK)
+        return status;
+    /* Solve (L L^T) x = e_j for each unit column j; column j of Pinv stores the
+     * forward-substitution result z, then is overwritten in place with x. */
+    for (i64 j = 0; j < p; ++j) {
+        for (i64 i = 0; i < p; ++i) {
+            f64 s = 0.0;
+            for (i64 t = 0; t < i; ++t)
+                s += scratch_L[i * p + t] * Pinv[t * p + j];
+            f64 rhs = (i == j) ? 1.0 : 0.0;
+            Pinv[i * p + j] = (rhs - s) / scratch_L[i * p + i];
+        }
+        for (i64 i = p - 1; i >= 0; --i) {
+            f64 s = 0.0;
+            for (i64 t = i + 1; t < p; ++t)
+                s += scratch_L[t * p + i] * Pinv[t * p + j];
+            Pinv[i * p + j] = (Pinv[i * p + j] - s) / scratch_L[i * p + i];
+        }
+    }
+    return SDSGE_OK;
+}

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
@@ -1,0 +1,74 @@
+#ifndef SDSGE_LINALG_H
+#define SDSGE_LINALG_H
+
+#include "sdsge_common.h"
+
+/* Dense linear-algebra primitives shared across the native subsystems. These
+ * were first written for the kalman hot loop (as the `kf_*` kernels) and are now
+ * promoted here so the regression / diagnostic kernels reuse them. Everything is
+ * plain C on C-contiguous, row-major f64 buffers; no CPython, no NumPy, no BLAS
+ * (matrices are small and we keep bit-parity with the numba reference). Buffers
+ * are caller-allocated and never alias unless a function documents otherwise. */
+
+/* out(r,c) := 0 */
+void sdsge_zero_mat(f64 *out, i64 r, i64 c);
+
+/* P(n,n) := (P + P^T) / 2, in place */
+void sdsge_sym_inplace(f64 *P, i64 n);
+
+/* out(n,m) := A(n,p) @ B(p,m) */
+void sdsge_matmul(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
+
+/* out(n,m) := A(n,p) @ B(m,p)^T */
+void sdsge_matmul_abt(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
+
+/* out(n,m) := A(n,p) @ B(m,p)^T + C(n,m) */
+void sdsge_matmul_abt_plus_c(const f64 *A, const f64 *B, const f64 *C, f64 *out,
+                             i64 n, i64 p, i64 m);
+
+/* out(n) := A(n,m) @ x(m) */
+void sdsge_matvec(const f64 *A, const f64 *x, f64 *out, i64 n, i64 m);
+
+/* out(n) := A(n,m) @ x(m) + b(n) */
+void sdsge_matvec_plus_vec(const f64 *A, const f64 *x, const f64 *b, f64 *out,
+                           i64 n, i64 m);
+
+/* dot product of a(n) and b(n) */
+f64 sdsge_dot(const f64 *a, const f64 *b, i64 n);
+
+/* 2 * sum(log(diag(L))) for lower-triangular L(n,n) */
+f64 sdsge_logdet_from_chol(const f64 *L, i64 n);
+
+/* Lower Cholesky L(n,n) of S(n,n) (+ jitter on the diagonal). Returns SDSGE_OK,
+ * or SDSGE_NOT_PD if S is not positive definite. Pass jitter == 0 for a plain
+ * factorization. */
+int sdsge_chol(const f64 *S, f64 jitter, f64 *L, i64 n);
+
+/* Solve L(n,n) x = b(n) for lower-triangular L; writes x into out(n). out may
+ * alias b. */
+void sdsge_forward_subst(const f64 *L, const f64 *b, f64 *out, i64 n);
+
+/* Solve L^T x = b using lower-triangular L(n,n); writes x into out(n). out may
+ * alias b. */
+void sdsge_backward_subst_chol_t(const f64 *L, const f64 *b, f64 *out, i64 n);
+
+/* ---- Gram-matrix / normal-equation helpers (regression, diagnostics) ---- */
+
+/* G(p,p) := X(n,p)^T X(n,p). Lower triangle accumulated row-by-row (matching the
+ * numba xtx_xty summation order), then mirrored to full symmetric. */
+void sdsge_gram(const f64 *X, f64 *G, i64 n, i64 p);
+
+/* g(p) := X(n,p)^T y(n) */
+void sdsge_gram_rhs(const f64 *X, const f64 *y, f64 *g, i64 n, i64 p);
+
+/* Solve the SPD system G(p,p) coef = g(p) via Cholesky. coef(p) is the output
+ * (may alias g); scratch_L(p,p) holds the factor. Returns SDSGE_OK or
+ * SDSGE_NOT_PD (G not positive definite -- caller falls back to lstsq). */
+int sdsge_chol_solve(const f64 *G, const f64 *g, f64 *coef, f64 *scratch_L,
+                     i64 p);
+
+/* SPD inverse: Pinv(p,p) := G(p,p)^-1 via Cholesky. scratch_L(p,p) holds the
+ * factor. Returns SDSGE_OK or SDSGE_NOT_PD. */
+int sdsge_chol_inv(const f64 *G, f64 *Pinv, f64 *scratch_L, i64 p);
+
+#endif /* SDSGE_LINALG_H */

--- a/SymbolicDSGE/_ckernels/diag/__init__.py
+++ b/SymbolicDSGE/_ckernels/diag/__init__.py
@@ -1,1 +1,17 @@
-"""Native diagnostic-test kernels (placeholder)."""
+"""Native diagnostic-test kernels (Breusch-Godfrey, Breusch-Pagan, Chow, CUSUM).
+
+Re-exports the compiled ``_diag`` extension. If it is not built, importing this
+module raises ``ImportError`` and the consumers (``SymbolicDSGE._diag_tests``)
+fall back to their numba kernels.
+"""
+
+from ._diag import (
+    FALLBACK as FALLBACK,
+    bg_stat as bg_stat,
+    bp_aux as bp_aux,
+    chow_stat as chow_stat,
+    cusum_series as cusum_series,
+    cusum_stat as cusum_stat,
+    cusumsq_stat as cusumsq_stat,
+    recursive_residuals as recursive_residuals,
+)

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -1,10 +1,38 @@
-"""Type stubs for the compiled ``_diag`` extension (placeholder).
+"""Type stubs for the compiled ``_diag`` extension.
 
-The diagnostic-test kernels are not implemented yet; this stub exists so the
-landsite is ready and the package's ``py.typed`` coverage stays consistent (a
-compiled module carries no inspectable types, so without a stub its symbols
-degrade to ``Any`` for consumers). As each kernel lands in ``_diag.pyx`` /
-``diag.c``, add the matching ``def`` signature here -- typed NumPy arrays in,
-status code or output array out -- kept in sync with the numba reference. The
-parity tests guard the runtime behavior, not this stub.
+The native kernels carry no inspectable type information (the type checker never
+parses ``_diag.pyx`` nor introspects the compiled object), so these signatures
+exist solely to give the LSP and mypy the shapes of the exported functions. They
+must stay in sync with ``_diag.pyx`` / ``diag.c`` and the numba references in
+``SymbolicDSGE._diag_tests``; the parity tests guard the runtime behavior, not
+this stub.
 """
+
+from numpy import float64
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+
+#: Status value meaning "design rank-deficient -- retry the statistic in numba".
+FALLBACK: int
+
+def bg_stat(eps: _F64, X: _F64, lags: int) -> tuple[int, float]:
+    """Breusch-Godfrey LM statistic. Returns (status, stat)."""
+
+def bp_aux(eps: _F64, X_aug: _F64) -> tuple[int, float, float]:
+    """Breusch-Pagan auxiliary regression. Returns (status, rss, tss)."""
+
+def chow_stat(y: _F64, X: _F64, t_break: int) -> tuple[int, float]:
+    """Chow break-point F statistic. Returns (status, stat)."""
+
+def recursive_residuals(y: _F64, X: _F64) -> tuple[int, _F64]:
+    """Brown-Durbin-Evans recursive residuals. Returns (status, w)."""
+
+def cusum_series(y: _F64, X: _F64) -> tuple[int, _F64]:
+    """Standardized CUSUM series. Returns (status, series)."""
+
+def cusum_stat(y: _F64, X: _F64) -> tuple[int, float]:
+    """CUSUM statistic. Returns (status, stat)."""
+
+def cusumsq_stat(y: _F64, X: _F64) -> tuple[int, int, float]:
+    """CUSUM-of-squares statistic. Returns (status, n, stat)."""

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -1,6 +1,122 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
-"""Cython shim for the diagnostic-test native kernels (placeholder).
+"""Thin Cython shim mapping NumPy buffers to the pure-C diagnostic-test kernels.
 
-Declare the C prototypes with ``cdef extern from "diag.h"`` and add one ``def``
-wrapper per entrypoint that maps NumPy memoryviews to ``double*``.
+No numeric logic here -- only buffer->pointer marshalling and the GIL release.
+The algorithms live in diag.c. Each ``def`` mirrors the matching numba kernel in
+SymbolicDSGE/_diag_tests/ and returns the same (status, ...) tuple shape. A
+status of ``DIAG_FALLBACK`` means the design was rank-deficient and the caller
+must re-run the whole statistic via numba (which has the lstsq/SVD fallback).
 """
+
+import numpy as np
+
+from libc.stdint cimport int64_t
+
+
+cdef extern from "diag.h":
+    int DIAG_FALLBACK
+
+    int sdsge_bg_stat(const double *eps, const double *X, int64_t n, int64_t K,
+                      int64_t lags, double *stat_out) nogil
+    int sdsge_bp_aux(const double *eps, const double *X_aug, int64_t n,
+                     int64_t p, double *rss_out, double *tss_out) nogil
+    int sdsge_chow_stat(const double *y, const double *X, int64_t T, int64_t p,
+                        int64_t t_break, double *stat_out) nogil
+    int sdsge_recursive_residuals(const double *y, const double *X, int64_t T,
+                                  int64_t p, double *w_out) nogil
+    int sdsge_cusum_series(const double *y, const double *X, int64_t T,
+                           int64_t p, double *series_out) nogil
+    int sdsge_cusum_stat(const double *y, const double *X, int64_t T,
+                         int64_t p, double *stat_out) nogil
+    int sdsge_cusumsq_stat(const double *y, const double *X, int64_t T,
+                           int64_t p, int64_t *n_out, double *stat_out) nogil
+
+
+# Re-exported so the Python dispatch layer can recognise the "retry in numba"
+# signal without hard-coding the magic number.
+FALLBACK = DIAG_FALLBACK
+
+
+def bg_stat(double[::1] eps, double[:, ::1] X, int64_t lags):
+    """Breusch-Godfrey LM statistic. Returns (status, stat)."""
+    cdef int64_t n = eps.shape[0]
+    cdef int64_t K = X.shape[1]
+    cdef double stat = 0.0
+    cdef int status
+    with nogil:
+        status = sdsge_bg_stat(&eps[0], &X[0, 0], n, K, lags, &stat)
+    return status, stat
+
+
+def bp_aux(double[::1] eps, double[:, ::1] X_aug):
+    """Breusch-Pagan auxiliary regression. Returns (status, rss, tss)."""
+    cdef int64_t n = X_aug.shape[0]
+    cdef int64_t p = X_aug.shape[1]
+    cdef double rss = 0.0
+    cdef double tss = 0.0
+    cdef int status
+    with nogil:
+        status = sdsge_bp_aux(&eps[0], &X_aug[0, 0], n, p, &rss, &tss)
+    return status, rss, tss
+
+
+def chow_stat(double[::1] y, double[:, ::1] X, int64_t t_break):
+    """Chow break-point F statistic. Returns (status, stat)."""
+    cdef int64_t T = X.shape[0]
+    cdef int64_t p = X.shape[1]
+    cdef double stat = 0.0
+    cdef int status
+    with nogil:
+        status = sdsge_chow_stat(&y[0], &X[0, 0], T, p, t_break, &stat)
+    return status, stat
+
+
+def recursive_residuals(double[::1] y, double[:, ::1] X):
+    """Brown-Durbin-Evans recursive residuals. Returns (status, w)."""
+    cdef int64_t T = X.shape[0]
+    cdef int64_t p = X.shape[1]
+    cdef int64_t w_len = T - p if T > p else 0
+    w = np.empty(w_len, dtype=np.float64)
+    cdef double[::1] w_mv = w
+    cdef double *w_ptr = &w_mv[0] if w_len > 0 else NULL
+    cdef int status
+    with nogil:
+        status = sdsge_recursive_residuals(&y[0], &X[0, 0], T, p, w_ptr)
+    return status, w
+
+
+def cusum_series(double[::1] y, double[:, ::1] X):
+    """Standardized CUSUM series. Returns (status, series)."""
+    cdef int64_t T = X.shape[0]
+    cdef int64_t p = X.shape[1]
+    cdef int64_t s_len = T - p if T > p else 0
+    series = np.empty(s_len, dtype=np.float64)
+    cdef double[::1] s_mv = series
+    cdef double *s_ptr = &s_mv[0] if s_len > 0 else NULL
+    cdef int status
+    with nogil:
+        status = sdsge_cusum_series(&y[0], &X[0, 0], T, p, s_ptr)
+    return status, series
+
+
+def cusum_stat(double[::1] y, double[:, ::1] X):
+    """CUSUM statistic. Returns (status, stat)."""
+    cdef int64_t T = X.shape[0]
+    cdef int64_t p = X.shape[1]
+    cdef double stat = 0.0
+    cdef int status
+    with nogil:
+        status = sdsge_cusum_stat(&y[0], &X[0, 0], T, p, &stat)
+    return status, stat
+
+
+def cusumsq_stat(double[::1] y, double[:, ::1] X):
+    """CUSUM-of-squares statistic. Returns (status, n, stat)."""
+    cdef int64_t T = X.shape[0]
+    cdef int64_t p = X.shape[1]
+    cdef int64_t n = 0
+    cdef double stat = 0.0
+    cdef int status
+    with nogil:
+        status = sdsge_cusumsq_stat(&y[0], &X[0, 0], T, p, &n, &stat)
+    return status, n, stat

--- a/SymbolicDSGE/_ckernels/diag/diag.c
+++ b/SymbolicDSGE/_ckernels/diag/diag.c
@@ -1,3 +1,382 @@
 #include "diag.h"
+#include <math.h>
+#include <stdlib.h>
 
-/* Placeholder for diagnostic-test native kernels. */
+/* Breusch-Godfrey: regress eps on [1 | X | lagged eps], statistic n * R^2 (no
+ * intercept removal -- TSS is sum(eps^2), matching the numba kernel). */
+int sdsge_bg_stat(const f64 *eps, const f64 *X, i64 n, i64 K, i64 lags,
+                  f64 *stat_out) {
+    if (n <= lags) {
+        *stat_out = NAN;
+        return DIAG_INSUFFICIENT_SAMPLES;
+    }
+
+    const i64 p = K + lags + 1; /* intercept + regressors + lagged residuals */
+
+    /* arena: design(n*p) + G(p*p) + L(p*p) + g(p) + coef(p) */
+    const i64 total = n * p + 2 * p * p + 2 * p;
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return DIAG_LINALG;
+    f64 *ptr = arena;
+    f64 *design = ptr; ptr += n * p;
+    f64 *G = ptr; ptr += p * p;
+    f64 *L = ptr; ptr += p * p;
+    f64 *g = ptr; ptr += p;
+    f64 *coef = ptr; ptr += p;
+
+    /* Build the design row by row: [1, X[r, :], eps[r-1], ..., eps[r-lags]]. */
+    for (i64 r = 0; r < n; ++r) {
+        f64 *row = design + r * p;
+        row[0] = 1.0;
+        for (i64 j = 0; j < K; ++j)
+            row[1 + j] = X[r * K + j];
+        for (i64 lag = 1; lag <= lags; ++lag)
+            row[K + lag] = (r >= lag) ? eps[r - lag] : 0.0;
+    }
+
+    sdsge_gram(design, G, n, p);
+    sdsge_gram_rhs(design, eps, g, n, p);
+    if (sdsge_chol_solve(G, g, coef, L, p) != SDSGE_OK) {
+        free(arena);
+        return DIAG_FALLBACK;
+    }
+
+    f64 rss = 0.0, tss = 0.0;
+    for (i64 r = 0; r < n; ++r) {
+        const f64 *row = design + r * p;
+        f64 fit = 0.0;
+        for (i64 j = 0; j < p; ++j)
+            fit += row[j] * coef[j];
+        f64 resid = eps[r] - fit;
+        rss += resid * resid;
+        tss += eps[r] * eps[r];
+    }
+
+    *stat_out = (tss > 0.0) ? (f64)n * (1.0 - rss / tss) : 0.0;
+    free(arena);
+    return DIAG_OK;
+}
+
+/* Breusch-Pagan auxiliary regression of the scaled squared residuals on X_aug.
+ * Returns the fit's RSS and centered TSS; the caller shapes them into bp_stat /
+ * robust_bp_stat. */
+int sdsge_bp_aux(const f64 *eps, const f64 *X_aug, i64 n, i64 p, f64 *rss_out,
+                 f64 *tss_out) {
+    if (n == 0)
+        return DIAG_INSUFFICIENT_SAMPLES;
+
+    /* sigma2 = mean(eps^2); g = eps^2 / sigma2. */
+    f64 sum_sq = 0.0;
+    for (i64 r = 0; r < n; ++r)
+        sum_sq += eps[r] * eps[r];
+    f64 sigma2 = sum_sq / (f64)n;
+    if (!isfinite(sigma2) || sigma2 <= 0.0)
+        return DIAG_UDEF_VARIANCE;
+
+    /* arena: g(n) + G(p*p) + L(p*p) + rhs(p) + coef(p) */
+    const i64 total = n + 2 * p * p + 2 * p;
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return DIAG_LINALG;
+    f64 *ptr = arena;
+    f64 *gvec = ptr; ptr += n;
+    f64 *G = ptr; ptr += p * p;
+    f64 *L = ptr; ptr += p * p;
+    f64 *rhs = ptr; ptr += p;
+    f64 *coef = ptr; ptr += p;
+
+    for (i64 r = 0; r < n; ++r)
+        gvec[r] = (eps[r] * eps[r]) / sigma2;
+
+    sdsge_gram(X_aug, G, n, p);
+    sdsge_gram_rhs(X_aug, gvec, rhs, n, p);
+    if (sdsge_chol_solve(G, rhs, coef, L, p) != SDSGE_OK) {
+        free(arena);
+        return DIAG_FALLBACK;
+    }
+
+    f64 g_sum = 0.0;
+    for (i64 r = 0; r < n; ++r)
+        g_sum += gvec[r];
+    f64 g_mean = g_sum / (f64)n;
+
+    f64 rss = 0.0, tss = 0.0;
+    for (i64 r = 0; r < n; ++r) {
+        const f64 *row = X_aug + r * p;
+        f64 fit = 0.0;
+        for (i64 j = 0; j < p; ++j)
+            fit += row[j] * coef[j];
+        f64 resid = gvec[r] - fit;
+        rss += resid * resid;
+        f64 centered = gvec[r] - g_mean;
+        tss += centered * centered;
+    }
+
+    *rss_out = rss;
+    *tss_out = tss;
+    free(arena);
+    return DIAG_OK;
+}
+
+/* Residual sum of squares of the OLS fit of y_seg(rows) on X_seg(rows, p), via
+ * the normal equations. Returns SDSGE_OK / SDSGE_NOT_PD. Scratch G/L/g/coef are
+ * caller-provided (all length p / p*p). */
+static int chow_segment_rss(const f64 *y_seg, const f64 *X_seg, i64 rows, i64 p,
+                            f64 *G, f64 *L, f64 *g, f64 *coef, f64 *rss_out) {
+    sdsge_gram(X_seg, G, rows, p);
+    sdsge_gram_rhs(X_seg, y_seg, g, rows, p);
+    int status = sdsge_chol_solve(G, g, coef, L, p);
+    if (status != SDSGE_OK)
+        return status;
+
+    f64 rss = 0.0;
+    for (i64 r = 0; r < rows; ++r) {
+        const f64 *row = X_seg + r * p;
+        f64 fit = 0.0;
+        for (i64 j = 0; j < p; ++j)
+            fit += row[j] * coef[j];
+        f64 resid = y_seg[r] - fit;
+        rss += resid * resid;
+    }
+    *rss_out = rss;
+    return SDSGE_OK;
+}
+
+int sdsge_chow_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 t_break,
+                    f64 *stat_out) {
+    if (T <= 2 * p) {
+        *stat_out = NAN;
+        return DIAG_INSUFFICIENT_SAMPLES;
+    }
+    if (t_break <= 0 || t_break >= T) {
+        *stat_out = NAN;
+        return DIAG_BAD_PARAMETER;
+    }
+
+    /* arena: G(p*p) + L(p*p) + g(p) + coef(p), reused across the three fits. */
+    const i64 total = 2 * p * p + 2 * p;
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return DIAG_LINALG;
+    f64 *ptr = arena;
+    f64 *G = ptr; ptr += p * p;
+    f64 *L = ptr; ptr += p * p;
+    f64 *g = ptr; ptr += p;
+    f64 *coef = ptr; ptr += p;
+
+    const i64 n1 = t_break;
+    const i64 n2 = T - t_break;
+    f64 rss_c = 0.0, rss_1 = 0.0, rss_2 = 0.0;
+
+    if (chow_segment_rss(y, X, T, p, G, L, g, coef, &rss_c) != SDSGE_OK ||
+        chow_segment_rss(y, X, n1, p, G, L, g, coef, &rss_1) != SDSGE_OK ||
+        chow_segment_rss(y + n1, X + n1 * p, n2, p, G, L, g, coef, &rss_2)
+            != SDSGE_OK) {
+        free(arena);
+        return DIAG_FALLBACK;
+    }
+
+    f64 num = (rss_c - (rss_1 + rss_2)) / (f64)p;
+    f64 denom = (rss_1 + rss_2) / (f64)(T - 2 * p);
+    *stat_out = num / denom;
+    free(arena);
+    return DIAG_OK;
+}
+
+/* Full-sample OLS residual std (sqrt(SSR / (T-p))) via the normal equations.
+ * G/L/g/coef are caller scratch (length p / p*p). Returns SDSGE_OK / NOT_PD. */
+static int ols_residual_sigma(const f64 *y, const f64 *X, i64 T, i64 p,
+                              f64 *G, f64 *L, f64 *g, f64 *coef, f64 *sigma_out) {
+    sdsge_gram(X, G, T, p);
+    sdsge_gram_rhs(X, y, g, T, p);
+    int status = sdsge_chol_solve(G, g, coef, L, p);
+    if (status != SDSGE_OK)
+        return status;
+
+    f64 ssr = 0.0;
+    for (i64 r = 0; r < T; ++r) {
+        const f64 *row = X + r * p;
+        f64 fit = 0.0;
+        for (i64 j = 0; j < p; ++j)
+            fit += row[j] * coef[j];
+        f64 resid = y[r] - fit;
+        ssr += resid * resid;
+    }
+    *sigma_out = sqrt(ssr / (f64)(T - p));
+    return SDSGE_OK;
+}
+
+int sdsge_cusum_series(const f64 *y, const f64 *X, i64 T, i64 p,
+                       f64 *series_out) {
+    if (T == 0 || T <= p)
+        return DIAG_INSUFFICIENT_SAMPLES;
+
+    /* arena: w(T-p) + G(p*p) + L(p*p) + g(p) + coef(p) */
+    const i64 nrec = T - p;
+    const i64 total = nrec + 2 * p * p + 2 * p;
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return DIAG_LINALG;
+    f64 *ptr = arena;
+    f64 *w = ptr; ptr += nrec;
+    f64 *G = ptr; ptr += p * p;
+    f64 *L = ptr; ptr += p * p;
+    f64 *g = ptr; ptr += p;
+    f64 *coef = ptr; ptr += p;
+
+    int status = sdsge_recursive_residuals(y, X, T, p, w);
+    if (status != DIAG_OK) {
+        free(arena);
+        return status; /* INSUFFICIENT_SAMPLES or FALLBACK */
+    }
+
+    f64 sigma = 0.0;
+    if (ols_residual_sigma(y, X, T, p, G, L, g, coef, &sigma) != SDSGE_OK) {
+        free(arena);
+        return DIAG_FALLBACK;
+    }
+
+    f64 acc = 0.0;
+    for (i64 i = 0; i < nrec; ++i) {
+        acc += w[i];
+        series_out[i] = acc / sigma;
+    }
+    free(arena);
+    return DIAG_OK;
+}
+
+int sdsge_cusum_stat(const f64 *y, const f64 *X, i64 T, i64 p, f64 *stat_out) {
+    if (T == 0 || T <= p) {
+        *stat_out = NAN;
+        return DIAG_INSUFFICIENT_SAMPLES;
+    }
+
+    const i64 nrec = T - p;
+    f64 *series = (f64 *)malloc((size_t)nrec * sizeof(f64));
+    if (series == NULL)
+        return DIAG_LINALG;
+
+    int status = sdsge_cusum_series(y, X, T, p, series);
+    if (status != DIAG_OK) {
+        *stat_out = NAN;
+        free(series);
+        return status;
+    }
+
+    const f64 sqrt_Tp = sqrt((f64)nrec);
+    f64 best = 0.0;
+    for (i64 i = 0; i < nrec; ++i) {
+        f64 denom = sqrt_Tp + (2.0 * (f64)i / sqrt_Tp);
+        f64 val = fabs(series[i]) / denom;
+        if (i == 0 || val > best)
+            best = val;
+    }
+    *stat_out = best;
+    free(series);
+    return DIAG_OK;
+}
+
+int sdsge_cusumsq_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 *n_out,
+                       f64 *stat_out) {
+    const i64 nrec = (T > p) ? (T - p) : 0;
+    *n_out = nrec;
+    if (T == 0 || T <= p) {
+        *stat_out = NAN;
+        return DIAG_INSUFFICIENT_SAMPLES;
+    }
+
+    f64 *w = (f64 *)malloc((size_t)nrec * sizeof(f64));
+    if (w == NULL)
+        return DIAG_LINALG;
+
+    int status = sdsge_recursive_residuals(y, X, T, p, w);
+    if (status != DIAG_OK) {
+        *stat_out = NAN;
+        free(w);
+        return status;
+    }
+
+    f64 total_sq = 0.0;
+    for (i64 i = 0; i < nrec; ++i)
+        total_sq += w[i] * w[i];
+
+    f64 acc = 0.0, best = 0.0;
+    for (i64 i = 0; i < nrec; ++i) {
+        acc += w[i] * w[i];
+        f64 s = acc / total_sq;
+        f64 expected = (f64)(i + 1) / (f64)nrec;
+        f64 dev = fabs(s - expected);
+        if (i == 0 || dev > best)
+            best = dev;
+    }
+    *stat_out = best / sqrt(2.0);
+    free(w);
+    return DIAG_OK;
+}
+
+int sdsge_recursive_residuals(const f64 *y, const f64 *X, i64 T, i64 p,
+                              f64 *w_out) {
+    if (T == 0 || T <= p)
+        return DIAG_INSUFFICIENT_SAMPLES;
+
+    /* arena: G(p*p) + L(p*p) + P(p*p) + Xty(p) + beta(p) + Px(p) */
+    const i64 total = 3 * p * p + 3 * p;
+    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+    if (arena == NULL)
+        return DIAG_LINALG;
+    f64 *ptr = arena;
+    f64 *G = ptr; ptr += p * p;
+    f64 *L = ptr; ptr += p * p;
+    f64 *P = ptr; ptr += p * p;
+    f64 *Xty = ptr; ptr += p;
+    f64 *beta = ptr; ptr += p;
+    f64 *Px = ptr; ptr += p;
+
+    /* Seed from the first p rows: P = (X_p' X_p)^-1, beta = P X_p' y_p. */
+    sdsge_gram(X, G, p, p);
+    sdsge_gram_rhs(X, y, Xty, p, p);
+    if (sdsge_chol_inv(G, P, L, p) != SDSGE_OK) {
+        free(arena);
+        return DIAG_FALLBACK;
+    }
+    for (i64 a = 0; a < p; ++a) {
+        f64 s = 0.0;
+        for (i64 b = 0; b < p; ++b)
+            s += P[a * p + b] * Xty[b];
+        beta[a] = s;
+    }
+
+    /* Recursive residuals via the symmetric rank-1 downdate of P. */
+    for (i64 i = 0; i < T - p; ++i) {
+        const f64 *xt = X + (p + i) * p;
+
+        f64 e = y[p + i];
+        for (i64 a = 0; a < p; ++a)
+            e -= xt[a] * beta[a];
+
+        f64 quad = 0.0;
+        for (i64 a = 0; a < p; ++a) {
+            f64 s = 0.0;
+            for (i64 b = 0; b < p; ++b)
+                s += P[a * p + b] * xt[b];
+            Px[a] = s;
+            quad += xt[a] * s;
+        }
+
+        f64 ft = 1.0 + quad;
+        w_out[i] = e / sqrt(ft);
+
+        f64 inv_ft = 1.0 / ft;
+        f64 coef = e * inv_ft;
+        for (i64 a = 0; a < p; ++a) {
+            f64 pa = Px[a];
+            beta[a] += pa * coef;
+            for (i64 b = 0; b < p; ++b)
+                P[a * p + b] -= pa * Px[b] * inv_ft;
+        }
+    }
+
+    free(arena);
+    return DIAG_OK;
+}

--- a/SymbolicDSGE/_ckernels/diag/diag.h
+++ b/SymbolicDSGE/_ckernels/diag/diag.h
@@ -2,7 +2,65 @@
 #define SDSGE_DIAG_H
 
 #include "../_common/sdsge_common.h"
+#include "../_common/sdsge_linalg.h"
 
-/* Placeholder for diagnostic-test native kernels. Declare prototypes here. */
+/* Native diagnostic-test statistic kernels (Breusch-Godfrey, Breusch-Pagan,
+ * Chow, Brown-Durbin-Evans recursive residuals). Each mirrors the numba kernel
+ * in SymbolicDSGE/_diag_tests/. All matrices are C-contiguous, row-major, f64.
+ *
+ * Error/status convention: the full-rank fast path (Cholesky on the normal
+ * equations) runs entirely here. The negative codes below mirror the Python
+ * TestStatus IntEnum exactly, so the Cython shim returns them verbatim.
+ * DIAG_FALLBACK is the one extra value: it means "the design is rank-deficient,
+ * the Cholesky path can't proceed -- re-run the whole statistic via the numba
+ * kernel (which has the SVD-based lstsq fallback)". There is deliberately no
+ * lstsq/SVD in C; this keeps the native side LAPACK-free. */
+
+#define DIAG_OK 0
+#define DIAG_BAD_SHAPE -1
+#define DIAG_LINALG -2
+#define DIAG_UDEF_VARIANCE -3
+#define DIAG_BAD_LAG -4
+#define DIAG_INSUFFICIENT_SAMPLES -5
+#define DIAG_ITERATIVE_NONCONVERGENCE -6
+#define DIAG_BAD_PARAMETER -7
+#define DIAG_FALLBACK 1
+
+/* Breusch-Godfrey LM statistic. eps(n), X(n,K). Builds the auxiliary design
+ * [1 | X | lagged eps] internally. Writes the statistic to *stat_out. */
+int sdsge_bg_stat(const f64 *eps, const f64 *X, i64 n, i64 K, i64 lags,
+                  f64 *stat_out);
+
+/* Breusch-Pagan auxiliary regression. eps(n), X_aug(n,p) already augmented with
+ * the intercept column (the augment + constant-column validation stay in the
+ * Python wrapper). Writes RSS and centered TSS of the auxiliary fit. */
+int sdsge_bp_aux(const f64 *eps, const f64 *X_aug, i64 n, i64 p, f64 *rss_out,
+                 f64 *tss_out);
+
+/* Chow break-point F statistic. y(T), X(T,p), split at t_break. Fits the pooled
+ * and the two sub-sample regressions; DIAG_FALLBACK if any is rank-deficient. */
+int sdsge_chow_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 t_break,
+                    f64 *stat_out);
+
+/* Brown-Durbin-Evans recursive residuals (the w series, length T-p). y(T),
+ * X(T,p). Fully native: seeds beta/P from the first p rows via an SPD inverse,
+ * then the rank-1 downdate recursion. DIAG_FALLBACK if the seed Gram is
+ * singular. */
+int sdsge_recursive_residuals(const f64 *y, const f64 *X, i64 T, i64 p,
+                              f64 *w_out);
+
+/* Standardized CUSUM series (length T-p): cumsum(recursive residuals) / sigma,
+ * where sigma is the full-sample OLS residual std. DIAG_FALLBACK if the seed
+ * Gram or the full-sample normal equations are rank-deficient. */
+int sdsge_cusum_series(const f64 *y, const f64 *X, i64 T, i64 p, f64 *series_out);
+
+/* CUSUM statistic: max over t of |series_t| / (sqrt(T-p) + 2 (t-p) / sqrt(T-p)). */
+int sdsge_cusum_stat(const f64 *y, const f64 *X, i64 T, i64 p, f64 *stat_out);
+
+/* CUSUM-of-squares statistic. Writes the residual count n = T-p and the
+ * Kolmogorov-type max deviation of the normalized squared-residual partial sums
+ * from the t/n line, divided by sqrt(2). */
+int sdsge_cusumsq_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 *n_out,
+                       f64 *stat_out);
 
 #endif /* SDSGE_DIAG_H */

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -3,141 +3,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-void kf_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
-    const i64 total = r * c;
-    for (i64 i = 0; i < total; ++i)
-        out[i] = 0.0;
-}
-
-void kf_sym_inplace(f64 *SDSGE_RESTRICT P, i64 n) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = i + 1; j < n; ++j) {
-            f64 avg = 0.5 * (P[i * n + j] + P[j * n + i]);
-            P[i * n + j] = avg;
-            P[j * n + i] = avg;
-        }
-    }
-}
-
-void kf_matmul(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
-               f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < m; ++j) {
-            f64 s = 0.0;
-            for (i64 k = 0; k < p; ++k)
-                s += A[i * p + k] * B[k * m + j];
-            out[i * m + j] = s;
-        }
-    }
-}
-
-void kf_matmul_abt(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
-                   f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < m; ++j) {
-            f64 s = 0.0;
-            for (i64 k = 0; k < p; ++k)
-                s += A[i * p + k] * B[j * p + k];
-            out[i * m + j] = s;
-        }
-    }
-}
-
-void kf_matmul_abt_plus_c(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
-                          const f64 *SDSGE_RESTRICT C, f64 *SDSGE_RESTRICT out,
-                          i64 n, i64 p, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < m; ++j) {
-            f64 s = 0.0;
-            for (i64 k = 0; k < p; ++k)
-                s += A[i * p + k] * B[j * p + k];
-            out[i * m + j] = s + C[i * m + j];
-        }
-    }
-}
-
-void kf_matvec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
-               f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        f64 s = 0.0;
-        for (i64 j = 0; j < m; ++j)
-            s += A[i * m + j] * x[j];
-        out[i] = s;
-    }
-}
-
-void kf_matvec_plus_vec(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT x,
-                        const f64 *SDSGE_RESTRICT b, f64 *SDSGE_RESTRICT out,
-                        i64 n, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        f64 s = b[i];
-        for (i64 j = 0; j < m; ++j)
-            s += A[i * m + j] * x[j];
-        out[i] = s;
-    }
-}
-
 void kf_row_minus_vec(const f64 *SDSGE_RESTRICT A, i64 row,
                       const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT out, i64 m) {
     const f64 *Arow = A + row * m;
     for (i64 j = 0; j < m; ++j)
         out[j] = Arow[j] - x[j];
-}
-
-f64 kf_dot(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b, i64 n) {
-    f64 s = 0.0;
-    for (i64 i = 0; i < n; ++i)
-        s += a[i] * b[i];
-    return s;
-}
-
-f64 kf_logdet_from_chol(const f64 *SDSGE_RESTRICT L, i64 n) {
-    f64 s = 0.0;
-    for (i64 i = 0; i < n; ++i)
-        s += log(L[i * n + i]);
-    return 2.0 * s;
-}
-
-int kf_chol_shifted(const f64 *SDSGE_RESTRICT S, f64 jitter,
-                    f64 *SDSGE_RESTRICT L, i64 n) {
-    kf_zero_mat(L, n, n);
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j <= i; ++j) {
-            f64 s = S[i * n + j];
-            if (i == j && jitter > 0.0)
-                s += jitter;
-            for (i64 k = 0; k < j; ++k)
-                s -= L[i * n + k] * L[j * n + k];
-            if (i == j) {
-                if (s <= 0.0)
-                    return KF_ERR_MATRIX_CONDITION;
-                L[i * n + j] = sqrt(s);
-            } else {
-                L[i * n + j] = s / L[j * n + j];
-            }
-        }
-    }
-    return KF_OK;
-}
-
-void kf_forward_subst(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT b,
-                      f64 *SDSGE_RESTRICT out, i64 n) {
-    for (i64 i = 0; i < n; ++i) {
-        f64 s = 0.0;
-        for (i64 j = 0; j < i; ++j)
-            s += L[i * n + j] * out[j];
-        out[i] = (b[i] - s) / L[i * n + i];
-    }
-}
-
-void kf_backward_subst_chol_t(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT b,
-                              f64 *SDSGE_RESTRICT out, i64 n) {
-    for (i64 i = n - 1; i >= 0; --i) {
-        f64 s = 0.0;
-        for (i64 j = i + 1; j < n; ++j)
-            s += L[j * n + i] * out[j];
-        out[i] = (b[i] - s) / L[i * n + i];
-    }
 }
 
 void kf_chol_solve_row(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT B,
@@ -164,15 +34,15 @@ void kf_chol_solve_row(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT B,
 void kf_predict_cov(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT P_prev,
                     const f64 *SDSGE_RESTRICT BQBT, f64 *SDSGE_RESTRICT temp_nn,
                     f64 *SDSGE_RESTRICT out, i64 n) {
-    kf_matmul(A, P_prev, temp_nn, n, n, n);
-    kf_matmul_abt_plus_c(temp_nn, A, BQBT, out, n, n, n);
+    sdsge_matmul(A, P_prev, temp_nn, n, n, n);
+    sdsge_matmul_abt_plus_c(temp_nn, A, BQBT, out, n, n, n);
 }
 
 void kf_measurement_cov(const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT P_pred,
                         const f64 *SDSGE_RESTRICT R, f64 *SDSGE_RESTRICT temp_mn,
                         f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    kf_matmul(C, P_pred, temp_mn, m, n, n);
-    kf_matmul_abt_plus_c(temp_mn, C, R, out, m, n, m);
+    sdsge_matmul(C, P_pred, temp_mn, m, n, n);
+    sdsge_matmul_abt_plus_c(temp_mn, C, R, out, m, n, m);
 }
 
 void kf_pc_t(const f64 *SDSGE_RESTRICT P_pred, const f64 *SDSGE_RESTRICT C,
@@ -218,11 +88,11 @@ void kf_joseph_cov(const f64 *SDSGE_RESTRICT K, const f64 *SDSGE_RESTRICT C,
                    f64 *SDSGE_RESTRICT KC, f64 *SDSGE_RESTRICT I_minus_KC,
                    f64 *SDSGE_RESTRICT temp_nn, f64 *SDSGE_RESTRICT temp_nm,
                    f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    kf_matmul(K, C, KC, n, m, n);
+    sdsge_matmul(K, C, KC, n, m, n);
     kf_identity_minus(KC, I_minus_KC, n);
-    kf_matmul(I_minus_KC, P_pred, temp_nn, n, n, n);
-    kf_matmul_abt(temp_nn, I_minus_KC, out, n, n, n);
-    kf_matmul(K, R, temp_nm, n, m, m);
+    sdsge_matmul(I_minus_KC, P_pred, temp_nn, n, n, n);
+    sdsge_matmul_abt(temp_nn, I_minus_KC, out, n, n, n);
+    sdsge_matmul(K, R, temp_nm, n, m, m);
     for (i64 i = 0; i < n; ++i) {
         for (i64 j = 0; j < n; ++j) {
             f64 s = 0.0;
@@ -236,7 +106,7 @@ void kf_joseph_cov(const f64 *SDSGE_RESTRICT K, const f64 *SDSGE_RESTRICT C,
 void kf_build_bqbt(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT Q,
                    f64 *SDSGE_RESTRICT temp_nk, f64 *SDSGE_RESTRICT out,
                    i64 n, i64 k) {
-    kf_matmul(B, Q, temp_nk, n, k, k);
+    sdsge_matmul(B, Q, temp_nk, n, k, k);
     for (i64 i = 0; i < n; ++i) {
         for (i64 j = 0; j < n; ++j) {
             f64 s = 0.0;
@@ -245,7 +115,7 @@ void kf_build_bqbt(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT Q,
             out[i * n + j] = s;
         }
     }
-    kf_sym_inplace(out, n);
+    sdsge_sym_inplace(out, n);
 }
 
 void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT C,
@@ -259,7 +129,7 @@ void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RES
             temp_km[i * m + j] = s;
         }
     }
-    kf_matmul(Q, temp_km, out, k, k, m);
+    sdsge_matmul(Q, temp_km, out, k, k, m);
 }
 
 int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
@@ -317,23 +187,24 @@ int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
     int status = KF_OK;
 
     for (i64 t = 0; t < T; ++t) {
-        kf_matvec(in->A, x_prev, x_pred_buf, n, n);
+        sdsge_matvec(in->A, x_prev, x_pred_buf, n, n);
         kf_predict_cov(in->A, P_prev, BQBT, temp_nn, P_pred_buf, n);
         if (in->symmetrize)
-            kf_sym_inplace(P_pred_buf, n);
+            sdsge_sym_inplace(P_pred_buf, n);
 
-        kf_matvec_plus_vec(in->C, x_pred_buf, in->d, y_pred_buf, m, n);
+        sdsge_matvec_plus_vec(in->C, x_pred_buf, in->d, y_pred_buf, m, n);
         kf_row_minus_vec(in->y, t, y_pred_buf, v_buf, m);
         kf_measurement_cov(in->C, P_pred_buf, in->R, temp_mn, S_buf, n, m);
         if (in->symmetrize)
-            kf_sym_inplace(S_buf, m);
+            sdsge_sym_inplace(S_buf, m);
 
-        status = kf_chol_shifted(S_buf, in->jitter, L, m);
-        if (status != KF_OK)
+        if (sdsge_chol(S_buf, in->jitter, L, m) != SDSGE_OK) {
+            status = KF_ERR_MATRIX_CONDITION;
             break;
+        }
 
-        kf_forward_subst(L, v_buf, u_buf, m);
-        kf_backward_subst_chol_t(L, u_buf, S_inv_v, m);
+        sdsge_forward_subst(L, v_buf, u_buf, m);
+        sdsge_backward_subst_chol_t(L, u_buf, S_inv_v, m);
 
         kf_pc_t(P_pred_buf, in->C, PCt, n, m);
         kf_gain_from_pc_t(L, PCt, solve_f, solve_b, K, n, m);
@@ -342,16 +213,16 @@ int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
         kf_joseph_cov(K, in->C, P_pred_buf, in->R, KC, I_minus_KC, temp_nn,
                       temp_nm, P_filt_buf, n, m);
         if (in->symmetrize)
-            kf_sym_inplace(P_filt_buf, n);
+            sdsge_sym_inplace(P_filt_buf, n);
 
-        loglik += -0.5 * (const_term + kf_logdet_from_chol(L, m)
-                          + kf_dot(v_buf, S_inv_v, m));
+        loglik += -0.5 * (const_term + sdsge_logdet_from_chol(L, m)
+                          + sdsge_dot(v_buf, S_inv_v, m));
 
         if (in->return_shocks && in->store_history)
-            kf_matvec(M, S_inv_v, out->eps_hat + t * k, k, m);
+            sdsge_matvec(M, S_inv_v, out->eps_hat + t * k, k, m);
 
         if (in->store_history) {
-            kf_matvec_plus_vec(in->C, x_filt_buf, in->d, y_filt_buf, m, n);
+            sdsge_matvec_plus_vec(in->C, x_filt_buf, in->d, y_filt_buf, m, n);
             memcpy(out->x_pred + t * n, x_pred_buf, (size_t)n * sizeof(f64));
             memcpy(out->x_filt + t * n, x_filt_buf, (size_t)n * sizeof(f64));
             memcpy(out->P_pred + t * n * n, P_pred_buf, (size_t)(n * n) * sizeof(f64));

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -2,6 +2,7 @@
 #define SDSGE_KALMAN_H
 
 #include "../_common/sdsge_common.h"
+#include "../_common/sdsge_linalg.h"
 
 #define KF_OK 0
 #define KF_ERR_COMPLEX_MATRIX -1
@@ -13,53 +14,14 @@
 /* Kalman hot-loop helpers ported from the numba `*_into` kernels in
  * SymbolicDSGE/kalman/filter.py. All matrices are C-contiguous, row-major, f64.
  * Buffers are caller-allocated; nothing here aliases (inputs and outputs are
- * always distinct). The dense linear-algebra primitives (kf_matmul, kf_chol_*,
- * kf_*subst, kf_dot, ...) are candidates to promote to _common/sdsge_linalg
- * once the regression port needs them. */
+ * always distinct). The dense linear-algebra primitives these build on
+ * (sdsge_matmul, sdsge_chol, sdsge_*subst, sdsge_dot, ...) now live in
+ * _common/sdsge_linalg so the regression / diagnostic kernels share them. */
 
-/* ---- Dense linear-algebra primitives ---- */
-
-/* out(r,c) := 0 */
-void kf_zero_mat(f64 *out, i64 r, i64 c);
-
-/* P(n,n) := (P + P^T) / 2, in place */
-void kf_sym_inplace(f64 *P, i64 n);
-
-/* out(n,m) := A(n,p) @ B(p,m) */
-void kf_matmul(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
-
-/* out(n,m) := A(n,p) @ B(m,p)^T */
-void kf_matmul_abt(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
-
-/* out(n,m) := A(n,p) @ B(m,p)^T + C(n,m) */
-void kf_matmul_abt_plus_c(const f64 *A, const f64 *B, const f64 *C, f64 *out,
-                          i64 n, i64 p, i64 m);
-
-/* out(n) := A(n,m) @ x(m) */
-void kf_matvec(const f64 *A, const f64 *x, f64 *out, i64 n, i64 m);
-
-/* out(n) := A(n,m) @ x(m) + b(n) */
-void kf_matvec_plus_vec(const f64 *A, const f64 *x, const f64 *b, f64 *out,
-                        i64 n, i64 m);
+/* ---- Kalman-specific dense helpers (not general enough for sdsge_linalg) ---- */
 
 /* out(m) := A[row, :] - x(m), where A has m columns */
 void kf_row_minus_vec(const f64 *A, i64 row, const f64 *x, f64 *out, i64 m);
-
-/* dot product of a(n) and b(n) */
-f64 kf_dot(const f64 *a, const f64 *b, i64 n);
-
-/* 2 * sum(log(diag(L))) for lower-triangular L(n,n) */
-f64 kf_logdet_from_chol(const f64 *L, i64 n);
-
-/* Lower Cholesky L(n,n) of S(n,n) (+ jitter on the diagonal). Returns KF_OK,
- * or KF_ERR_MATRIX_CONDITION if S is not positive definite. */
-int kf_chol_shifted(const f64 *S, f64 jitter, f64 *L, i64 n);
-
-/* Solve L(n,n) x = b(n) for lower-triangular L; writes x into out(n). */
-void kf_forward_subst(const f64 *L, const f64 *b, f64 *out, i64 n);
-
-/* Solve L^T x = b using lower-triangular L(n,n); writes x into out(n). */
-void kf_backward_subst_chol_t(const f64 *L, const f64 *b, f64 *out, i64 n);
 
 /* Solve (L L^T) x = B[row, :] for the single row; writes x into out[row, :].
  * `n` is the Cholesky dimension (= column count of B and out); fbuf/bbuf are

--- a/SymbolicDSGE/_diag_tests/_native.py
+++ b/SymbolicDSGE/_diag_tests/_native.py
@@ -1,0 +1,32 @@
+"""Shared handle to the native diagnostic kernels, with the numba overrides.
+
+Each diagnostic module prefers the compiled ``_ckernels.diag`` kernels and falls
+back to its numba kernel when (a) the extension is not built, (b)
+``ALWAYS_USE_NUMBA`` is set, or (c) a kernel returns ``DIAG_FALLBACK`` -- the
+signal that the design is rank-deficient and the statistic must be recomputed
+through the numba path (which has the SVD-based lstsq fallback the C side
+deliberately lacks). ``NEVER_USE_NUMBA`` makes a missing extension raise instead
+of falling back. See ``SymbolicDSGE._native_dispatch`` for the env flags.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from .._native_dispatch import FORCE_NUMBA, REQUIRE_NATIVE
+
+#: Mirrors the C ``#define DIAG_FALLBACK 1`` (the native kernels' "retry in
+#: numba" sentinel). Overwritten below with the authoritative value exported by
+#: the extension when it is available.
+DIAG_FALLBACK = 1
+
+native: ModuleType | None = None
+if not FORCE_NUMBA:
+    try:
+        from .._ckernels import diag as _diag_ext
+    except ImportError:  # pragma: no cover - exercised only without the extension
+        if REQUIRE_NATIVE:
+            raise
+    else:
+        native = _diag_ext
+        DIAG_FALLBACK = _diag_ext.FALLBACK

--- a/SymbolicDSGE/_diag_tests/breusch_godfrey.py
+++ b/SymbolicDSGE/_diag_tests/breusch_godfrey.py
@@ -10,6 +10,7 @@ from ..regression.solvers import chol_solve, lstsq_solve
 from .status import TestStatus
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
+from ._native import native as _native, DIAG_FALLBACK
 
 NDF = NDArray[float64]
 
@@ -36,7 +37,7 @@ def build_design_matrix(X: NDF, eps: NDF, lags: int) -> NDF:
 
 
 @njit(cache=True)
-def bg_stat(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
+def _bg_stat_numba(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
     n = eps.size
     if n <= lags:
         return INSUFFICIENT_SAMPLES, float64(np.nan)
@@ -55,6 +56,25 @@ def bg_stat(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
     stat = n * (1.0 - np.sum(resid**2) / tss) if tss > 0.0 else 0.0
 
     return OK, float64(stat)
+
+
+def bg_stat(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
+    """Breusch-Godfrey LM statistic; native fast path, numba fallback.
+
+    The native kernel handles the full-rank case; on a rank-deficient design it
+    returns ``DIAG_FALLBACK`` and we recompute through the numba kernel (which
+    has the lstsq fallback).
+    """
+    if _native is not None and eps.size > lags and X.shape[0] == eps.size:
+        status, stat = _native.bg_stat(
+            np.ascontiguousarray(eps, dtype=np.float64),
+            np.ascontiguousarray(X, dtype=np.float64),
+            lags,
+        )
+        if status != DIAG_FALLBACK:
+            return status, float64(stat)
+    nb_status, nb_stat = _bg_stat_numba(eps, X, lags)
+    return int(nb_status), float64(nb_stat)
 
 
 def breusch_godfrey(

--- a/SymbolicDSGE/_diag_tests/breusch_godfrey.py
+++ b/SymbolicDSGE/_diag_tests/breusch_godfrey.py
@@ -5,6 +5,7 @@ from numpy import float64
 from numpy.typing import NDArray
 from numba import njit
 
+from ..regression.enums import RegressionStatus
 from ..regression.solvers import chol_solve, lstsq_solve
 
 from .status import TestStatus
@@ -18,6 +19,7 @@ OK = int(TestStatus.OK)
 UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
 BAD_SHAPE = int(TestStatus.BAD_SHAPE)
 INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
+REGRESSION_OK = int(RegressionStatus.OK)
 
 
 @njit(cache=True)
@@ -46,9 +48,8 @@ def _bg_stat_numba(eps: NDF, X: NDF, lags: int) -> tuple[int, float64]:
 
     design = build_design_matrix(X, eps, lags)
 
-    try:
-        bhat, _, _ = chol_solve(design, eps)
-    except Exception:
+    bhat, _, regression_status = chol_solve(design, eps)
+    if regression_status != REGRESSION_OK:
         bhat, _, _ = lstsq_solve(design, eps)
 
     resid = eps - design @ bhat

--- a/SymbolicDSGE/_diag_tests/breusch_pagan.py
+++ b/SymbolicDSGE/_diag_tests/breusch_pagan.py
@@ -10,6 +10,7 @@ from ..regression.solvers import chol_solve, lstsq_solve
 from .distributions import PvalMethod, ReferenceDistribution
 from .result import TestResult
 from .status import TestStatus
+from ._native import native as _native, DIAG_FALLBACK
 
 OK = int(TestStatus.OK)
 LINALG = int(TestStatus.LINALG)
@@ -48,7 +49,7 @@ def bp_aux(eps: NDF, X: NDF) -> tuple[int, float64, float64]:
 
 
 @njit(cache=True)
-def bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+def _bp_stat_numba(eps: NDF, X: NDF) -> tuple[int, float64]:
     status, rss, tss = bp_aux(eps, X)
     if status != OK:
         return status, float64(np.nan)
@@ -57,7 +58,7 @@ def bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
 
 
 @njit(cache=True)
-def robust_bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+def _robust_bp_stat_numba(eps: NDF, X: NDF) -> tuple[int, float64]:
     status, rss, tss = bp_aux(eps, X)
     if status != OK:
         return status, float64(np.nan)
@@ -66,6 +67,50 @@ def robust_bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
 
     r2 = min(float64(1.0), max(float64(0.0), float64(1.0 - rss / tss)))
     return OK, r2 * len(eps)
+
+
+def _native_bp_aux(eps: NDF, X: NDF) -> tuple[int, float64, float64] | None:
+    """Run the native auxiliary regression, or None to defer to numba.
+
+    Returns None when the extension is absent or the design is rank-deficient
+    (``DIAG_FALLBACK``); otherwise the (status, rss, tss) triple.
+    """
+    if _native is None or eps.shape[0] != X.shape[0]:
+        return None
+    status, rss, tss = _native.bp_aux(
+        np.ascontiguousarray(eps, dtype=np.float64),
+        np.ascontiguousarray(X, dtype=np.float64),
+    )
+    if status == DIAG_FALLBACK:
+        return None
+    return status, float64(rss), float64(tss)
+
+
+def bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+    """Breusch-Pagan statistic; native fast path, numba fallback."""
+    native = _native_bp_aux(eps, X)
+    if native is not None:
+        status, rss, tss = native
+        if status != OK:
+            return status, float64(np.nan)
+        return OK, max(float64(0.0), (tss - rss) * 0.5)
+    nb_status, nb_stat = _bp_stat_numba(eps, X)
+    return int(nb_status), float64(nb_stat)
+
+
+def robust_bp_stat(eps: NDF, X: NDF) -> tuple[int, float64]:
+    """Robust Breusch-Pagan statistic; native fast path, numba fallback."""
+    native = _native_bp_aux(eps, X)
+    if native is not None:
+        status, rss, tss = native
+        if status != OK:
+            return status, float64(np.nan)
+        if tss <= 0.0:
+            return OK, float64(0.0)
+        r2 = min(float64(1.0), max(float64(0.0), float64(1.0 - rss / tss)))
+        return OK, r2 * len(eps)
+    nb_status, nb_stat = _robust_bp_stat_numba(eps, X)
+    return int(nb_status), float64(nb_stat)
 
 
 def _prepare_bp_inputs(eps: NDF, X: NDF) -> tuple[NDF, NDF]:

--- a/SymbolicDSGE/_diag_tests/breusch_pagan.py
+++ b/SymbolicDSGE/_diag_tests/breusch_pagan.py
@@ -34,9 +34,8 @@ def bp_aux(eps: NDF, X: NDF) -> tuple[int, float64, float64]:
         return UDEF_VARIANCE, float64(np.nan), float64(np.nan)
     g = eps_sq / sigma2
 
-    try:
-        bhat, _, regression_status = chol_solve(X, g)
-    except Exception:
+    bhat, _, regression_status = chol_solve(X, g)
+    if regression_status != REGRESSION_OK:
         bhat, _, regression_status = lstsq_solve(X, g)
     if regression_status != REGRESSION_OK:
         return LINALG, float64(np.nan), float64(np.nan)

--- a/SymbolicDSGE/_diag_tests/chow.py
+++ b/SymbolicDSGE/_diag_tests/chow.py
@@ -9,6 +9,7 @@ from .status import TestStatus
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
 from ..regression.solvers import chol_solve, lstsq_solve
+from ._native import native as _native, DIAG_FALLBACK
 
 NDF = NDArray[float64]
 
@@ -19,8 +20,27 @@ INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
 BAD_PARAMETER = int(TestStatus.BAD_PARAMETER)
 
 
-@njit(cache=True)
 def _chow_stat(y: NDF, X: NDF, t_break: int) -> tuple[int, float64]:
+    """Chow break-point F statistic; native fast path, numba fallback.
+
+    The native kernel returns ``DIAG_FALLBACK`` if any of the three regressions
+    is rank-deficient, in which case the numba kernel (with its lstsq fallback)
+    recomputes the statistic.
+    """
+    if _native is not None and y.size == X.shape[0]:
+        status, stat = _native.chow_stat(
+            np.ascontiguousarray(y, dtype=np.float64),
+            np.ascontiguousarray(X, dtype=np.float64),
+            t_break,
+        )
+        if status != DIAG_FALLBACK:
+            return status, float64(stat)
+    nb_status, nb_stat = _chow_stat_numba(y, X, t_break)
+    return int(nb_status), float64(nb_stat)
+
+
+@njit(cache=True)
+def _chow_stat_numba(y: NDF, X: NDF, t_break: int) -> tuple[int, float64]:
     if y.size != X.shape[0]:
         return BAD_SHAPE, float64(np.nan)
 

--- a/SymbolicDSGE/_diag_tests/chow.py
+++ b/SymbolicDSGE/_diag_tests/chow.py
@@ -8,6 +8,7 @@ from numba import njit
 from .status import TestStatus
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
+from ..regression.enums import RegressionStatus
 from ..regression.solvers import chol_solve, lstsq_solve
 from ._native import native as _native, DIAG_FALLBACK
 
@@ -18,6 +19,7 @@ LINALG = int(TestStatus.LINALG)
 BAD_SHAPE = int(TestStatus.BAD_SHAPE)
 INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
 BAD_PARAMETER = int(TestStatus.BAD_PARAMETER)
+REGRESSION_OK = int(RegressionStatus.OK)
 
 
 def _chow_stat(y: NDF, X: NDF, t_break: int) -> tuple[int, float64]:
@@ -62,9 +64,8 @@ def _chow_stat_numba(y: NDF, X: NDF, t_break: int) -> tuple[int, float64]:
     tss = np.empty(3, dtype=float64)
 
     for i, (Xi, yi) in enumerate([(X, y), (X1, y1), (X2, y2)]):
-        try:
-            beta, _, status = chol_solve(Xi, yi)
-        except Exception:
+        beta, _, status = chol_solve(Xi, yi)
+        if status != REGRESSION_OK:
             beta, _, status = lstsq_solve(Xi, yi)
 
         statuses[i] = status

--- a/SymbolicDSGE/_diag_tests/cusum.py
+++ b/SymbolicDSGE/_diag_tests/cusum.py
@@ -18,6 +18,7 @@ from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
 from .cusum_utils import OK, NDF, recursive_residuals
 
+from ..regression.enums import RegressionStatus
 from ..regression.solvers import chol_solve, lstsq_solve
 from ._native import native as _native, DIAG_FALLBACK
 
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     import optype.numpy as onp
 
 DistributionOutput: TypeAlias = float | float64 | NDF
+
+REGRESSION_OK = int(RegressionStatus.OK)
 
 # Newton Status
 CONVERGED = 0
@@ -212,9 +215,8 @@ def _cusum_series_numba(y: NDF, X: NDF) -> tuple[int, NDF]:
     if status != OK:
         return status, rec_resid
 
-    try:
-        bhat, _, _ = chol_solve(X, y)
-    except Exception:
+    bhat, _, regression_status = chol_solve(X, y)
+    if regression_status != REGRESSION_OK:
         bhat, _, _ = lstsq_solve(X, y)
 
     resid = y - X @ bhat

--- a/SymbolicDSGE/_diag_tests/cusum.py
+++ b/SymbolicDSGE/_diag_tests/cusum.py
@@ -19,6 +19,7 @@ from .distributions import PvalMethod, ReferenceDistribution
 from .cusum_utils import OK, NDF, recursive_residuals
 
 from ..regression.solvers import chol_solve, lstsq_solve
+from ._native import native as _native, DIAG_FALLBACK
 
 if TYPE_CHECKING:
     import optype.numpy as onp
@@ -191,8 +192,21 @@ class CusumDist(rv_frozen):
 
 
 # Test Code
-@njit(cache=True)
 def cusum_series(y: NDF, X: NDF) -> tuple[int, NDF]:
+    """Standardized CUSUM series; native fast path, numba fallback."""
+    if _native is not None and y.shape[0] == X.shape[0]:
+        status, series = _native.cusum_series(
+            np.ascontiguousarray(y, dtype=np.float64),
+            np.ascontiguousarray(X, dtype=np.float64),
+        )
+        if status != DIAG_FALLBACK:
+            return status, series
+    nb_status, nb_series = _cusum_series_numba(y, X)
+    return int(nb_status), nb_series
+
+
+@njit(cache=True)
+def _cusum_series_numba(y: NDF, X: NDF) -> tuple[int, NDF]:
     T, p = X.shape
     status, rec_resid = recursive_residuals(y, X)
     if status != OK:
@@ -210,10 +224,23 @@ def cusum_series(y: NDF, X: NDF) -> tuple[int, NDF]:
     return OK, std_cusum
 
 
-@njit(cache=True)
 def cusum_stat(y: NDF, X: NDF) -> tuple[int, float64]:
+    """CUSUM statistic; native fast path, numba fallback."""
+    if _native is not None and y.shape[0] == X.shape[0]:
+        status, stat = _native.cusum_stat(
+            np.ascontiguousarray(y, dtype=np.float64),
+            np.ascontiguousarray(X, dtype=np.float64),
+        )
+        if status != DIAG_FALLBACK:
+            return status, float64(stat)
+    nb_status, nb_stat = _cusum_stat_numba(y, X)
+    return int(nb_status), float64(nb_stat)
+
+
+@njit(cache=True)
+def _cusum_stat_numba(y: NDF, X: NDF) -> tuple[int, float64]:
     T, p = X.shape
-    status, cusum = cusum_series(y, X)
+    status, cusum = _cusum_series_numba(y, X)
     if status != OK:
         return status, float64(np.nan)
 

--- a/SymbolicDSGE/_diag_tests/cusumsq.py
+++ b/SymbolicDSGE/_diag_tests/cusumsq.py
@@ -15,6 +15,7 @@ from SymbolicDSGE._diag_tests.result import TestResult
 
 from .cusum_utils import recursive_residuals
 from .status import TestStatus
+from ._native import native as _native, DIAG_FALLBACK
 
 if TYPE_CHECKING:
     import optype.numpy as onp
@@ -25,8 +26,21 @@ DistributionOutput: TypeAlias = float | float64 | NDF
 OK = int(TestStatus.OK)
 
 
-@njit(cache=True)
 def _cusumsq_stat(y: NDF, X: NDF) -> tuple[int, int, float64]:
+    """CUSUM-of-squares statistic; native fast path, numba fallback."""
+    if _native is not None and y.shape[0] == X.shape[0]:
+        status, n, stat = _native.cusumsq_stat(
+            np.ascontiguousarray(y, dtype=np.float64),
+            np.ascontiguousarray(X, dtype=np.float64),
+        )
+        if status != DIAG_FALLBACK:
+            return status, int(n), float64(stat)
+    nb_status, nb_n, nb_stat = _cusumsq_stat_numba(y, X)
+    return int(nb_status), int(nb_n), float64(nb_stat)
+
+
+@njit(cache=True)
+def _cusumsq_stat_numba(y: NDF, X: NDF) -> tuple[int, int, float64]:
     status, rec_eps = recursive_residuals(y, X)
     N = rec_eps.size
     if status != OK:

--- a/SymbolicDSGE/regression/ols/core.py
+++ b/SymbolicDSGE/regression/ols/core.py
@@ -25,9 +25,8 @@ def ols(
         X = np.hstack((np.ones((X.shape[0], 1), dtype=np.float64), X))
         var_names = ["Intercept", *var_names]
 
-    try:
-        coef, L, status = chol_solve(X, y)
-    except Exception:
+    coef, L, status = chol_solve(X, y)
+    if status != int(RegressionStatus.OK):
         coef, L, status = lstsq_solve(X, y)
 
     return OLSResult(

--- a/SymbolicDSGE/regression/solvers.py
+++ b/SymbolicDSGE/regression/solvers.py
@@ -43,8 +43,50 @@ def xtx_xty(X: NDF, y: NDF) -> tuple[NDF, NDF]:
 
 
 @njit(cache=True)
+def _gram_is_pd(G: NDF) -> bool:
+    """Deterministic positive-definiteness check for the Gram matrix.
+
+    Runs a hand-rolled Cholesky purely to test the pivots against a relative
+    floor (``scale * p * eps``). A rank-deficient Gram has an exact pivot of
+    zero that rounds to a tiny value of either sign depending on the BLAS build,
+    so relying on ``numpy.linalg.cholesky`` to raise (and on the caller's
+    ``try/except`` to catch it) detects rank deficiency nondeterministically
+    across builds. This gate makes the decision build-independent; when it
+    passes, the fast LAPACK path below is used unchanged, so positive-definite
+    results stay bit-for-bit identical. Mirrors the native ``sdsge_chol``.
+    """
+    p = G.shape[0]
+    scale = float64(0.0)
+    for i in range(p):
+        if G[i, i] > scale:
+            scale = G[i, i]
+    pivot_tol = scale * p * np.finfo(float64).eps
+    L = np.zeros((p, p), dtype=float64)
+    for i in range(p):
+        for j in range(i + 1):
+            s = G[i, j]
+            for k in range(j):
+                s -= L[i, k] * L[j, k]
+            if i == j:
+                if s <= pivot_tol:
+                    return False
+                L[i, j] = np.sqrt(s)
+            else:
+                L[i, j] = s / L[j, j]
+    return True
+
+
+@njit(cache=True)
 def chol_solve(X: NDF, y: NDF) -> tuple[NDF, NDF, int]:
     G, g = xtx_xty(X, y)
+
+    if not _gram_is_pd(G):
+        p = G.shape[0]
+        return (
+            np.full(p, np.nan, dtype=float64),
+            np.empty((0, 0), dtype=float64),
+            RANK_DEFICIENT,
+        )
 
     L = cholesky(G)
     z = solve(L, g)

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -309,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "symbolicdsge (3.11.14)",
+   "display_name": "symbolicdsge (3.11.14.final.0)",
    "language": "python",
    "name": "python3"
   },

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -23,10 +23,20 @@ RTOL = 1e-7
 ATOL = 1e-9
 
 
-def _design(rng, T=160, k=3):
-    """Full-rank design with an intercept plus a stable response."""
-    X = np.column_stack([np.ones(T), rng.standard_normal((T, k - 1))])
-    beta = rng.standard_normal(k)
+def _design(rng, T=160, k=3, intercept=True):
+    """Full-rank design plus a stable response.
+
+    ``intercept`` controls whether a leading column of ones is included. The
+    Breusch-Godfrey kernel builds its own intercept into the auxiliary design,
+    so it must be fed an intercept-free X — otherwise the augmented matrix has
+    two identical columns of ones and is rank-deficient (cond ~1e16), which
+    makes the chol-vs-lstsq path build-dependent rather than a parity check.
+    """
+    if intercept:
+        X = np.column_stack([np.ones(T), rng.standard_normal((T, k - 1))])
+    else:
+        X = rng.standard_normal((T, k))
+    beta = rng.standard_normal(X.shape[1])
     y = X @ beta + rng.standard_normal(T)
     return np.ascontiguousarray(y), np.ascontiguousarray(X)
 
@@ -44,7 +54,8 @@ def _collinear_design(rng, T=160):
 
 def test_bg_stat_parity():
     rng = np.random.default_rng(0)
-    y, X = _design(rng)
+    # bg adds its own intercept; feed an intercept-free design to keep it full rank.
+    y, X = _design(rng, intercept=False)
     eps = np.ascontiguousarray(rng.standard_normal(X.shape[0]))
     for lags in (1, 2, 4):
         ns, nstat = diag.bg_stat(eps, X, lags)

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -1,0 +1,142 @@
+"""Parity tests for the native diagnostic-test kernels (_ckernels.diag).
+
+Each native kernel is checked against its numba oracle on full-rank designs, and
+the rank-deficient path is checked to return DIAG_FALLBACK so the consumer
+recomputes through numba. Gram matrices square the condition number of the
+design, so the tolerance here is looser than the kalman parity suite's 1e-9.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+diag = pytest.importorskip("SymbolicDSGE._ckernels.diag")
+
+from SymbolicDSGE._diag_tests import breusch_godfrey as bg_mod
+from SymbolicDSGE._diag_tests import breusch_pagan as bp_mod
+from SymbolicDSGE._diag_tests import chow as chow_mod
+from SymbolicDSGE._diag_tests import cusum as cusum_mod
+from SymbolicDSGE._diag_tests import cusumsq as cusumsq_mod
+
+RTOL = 1e-7
+ATOL = 1e-9
+
+
+def _design(rng, T=160, k=3):
+    """Full-rank design with an intercept plus a stable response."""
+    X = np.column_stack([np.ones(T), rng.standard_normal((T, k - 1))])
+    beta = rng.standard_normal(k)
+    y = X @ beta + rng.standard_normal(T)
+    return np.ascontiguousarray(y), np.ascontiguousarray(X)
+
+
+def _collinear_design(rng, T=160):
+    """Rank-deficient design: a duplicated regressor column."""
+    a = rng.standard_normal(T)
+    X = np.column_stack([np.ones(T), a, a])
+    y = a + rng.standard_normal(T)
+    return np.ascontiguousarray(y), np.ascontiguousarray(X)
+
+
+# ---------------------------------------------------------------- full-rank parity
+
+
+def test_bg_stat_parity():
+    rng = np.random.default_rng(0)
+    y, X = _design(rng)
+    eps = np.ascontiguousarray(rng.standard_normal(X.shape[0]))
+    for lags in (1, 2, 4):
+        ns, nstat = diag.bg_stat(eps, X, lags)
+        rs, rstat = bg_mod._bg_stat_numba(eps, X, lags)
+        assert ns == rs == 0
+        assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_bp_aux_parity():
+    rng = np.random.default_rng(1)
+    _, X = _design(rng)
+    eps = np.ascontiguousarray(rng.standard_normal(X.shape[0]))
+    ns, nrss, ntss = diag.bp_aux(eps, X)
+    rs, rrss, rtss = bp_mod.bp_aux(eps, X)
+    assert ns == rs == 0
+    assert np.isclose(nrss, rrss, rtol=RTOL, atol=ATOL)
+    assert np.isclose(ntss, rtss, rtol=RTOL, atol=ATOL)
+
+
+def test_chow_stat_parity():
+    rng = np.random.default_rng(2)
+    y, X = _design(rng)
+    for t_break in (40, 80, 120):
+        ns, nstat = diag.chow_stat(y, X, t_break)
+        rs, rstat = chow_mod._chow_stat_numba(y, X, t_break)
+        assert ns == rs == 0
+        assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_cusum_series_parity():
+    rng = np.random.default_rng(3)
+    y, X = _design(rng)
+    ns, nser = diag.cusum_series(y, X)
+    rs, rser = cusum_mod._cusum_series_numba(y, X)
+    assert ns == rs == 0
+    np.testing.assert_allclose(nser, rser, rtol=RTOL, atol=ATOL)
+
+
+def test_cusum_stat_parity():
+    rng = np.random.default_rng(4)
+    y, X = _design(rng)
+    ns, nstat = diag.cusum_stat(y, X)
+    rs, rstat = cusum_mod._cusum_stat_numba(y, X)
+    assert ns == rs == 0
+    assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_cusumsq_stat_parity():
+    rng = np.random.default_rng(5)
+    y, X = _design(rng)
+    ns, nn, nstat = diag.cusumsq_stat(y, X)
+    rs, rn, rstat = cusumsq_mod._cusumsq_stat_numba(y, X)
+    assert ns == rs == 0
+    assert nn == rn
+    assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+# ---------------------------------------------------------------- fallback signal
+
+
+def test_rank_deficient_returns_fallback():
+    """A collinear design makes the Cholesky path fail; the native kernels must
+    signal DIAG_FALLBACK rather than producing a (wrong) result."""
+    rng = np.random.default_rng(6)
+    y, X = _collinear_design(rng)
+    eps = np.ascontiguousarray(rng.standard_normal(X.shape[0]))
+
+    assert diag.bg_stat(eps, X, 2)[0] == diag.FALLBACK
+    assert diag.bp_aux(eps, X)[0] == diag.FALLBACK
+    assert diag.chow_stat(y, X, 80)[0] == diag.FALLBACK
+    assert diag.cusum_series(y, X)[0] == diag.FALLBACK
+    assert diag.cusum_stat(y, X)[0] == diag.FALLBACK
+    assert diag.cusumsq_stat(y, X)[0] == diag.FALLBACK
+
+
+def _same_result(a, b):
+    """Compare (status, stat) results, treating nan == nan."""
+    (sa, va), (sb, vb) = a, b
+    assert sa == sb
+    if np.isnan(va) or np.isnan(vb):
+        assert np.isnan(va) and np.isnan(vb)
+    else:
+        assert np.isclose(va, vb, rtol=RTOL, atol=ATOL)
+
+
+def test_rank_deficient_dispatch_matches_numba():
+    """On a rank-deficient design the public dispatch must transparently fall
+    back to the numba (lstsq) path, producing the same result as pure numba."""
+    rng = np.random.default_rng(7)
+    y, X = _collinear_design(rng)
+    eps = np.ascontiguousarray(rng.standard_normal(X.shape[0]))
+
+    _same_result(bg_mod.bg_stat(eps, X, 2), bg_mod._bg_stat_numba(eps, X, 2))
+    _same_result(bp_mod.bp_stat(eps, X), bp_mod._bp_stat_numba(eps, X))
+    _same_result(chow_mod._chow_stat(y, X, 80), chow_mod._chow_stat_numba(y, X, 80))


### PR DESCRIPTION
This pull request implements and exposes a new set of native diagnostic-test kernels (Breusch-Godfrey, Breusch-Pagan, Chow, CUSUM, etc.) in the `SymbolicDSGE._ckernels.diag` module. It provides C implementations of dense linear algebra routines, Cython wrappers for Python interop, and type stubs for static analysis. The new code replaces placeholders with fully functional kernels, ensuring consistency with the package's numba-based fallbacks and improving performance for small matrices.

The most important changes are:

### Diagnostic test kernel implementation and exposure

* Replaces the placeholder diagnostic-test kernel module with a complete implementation, exposing functions such as `bg_stat`, `bp_aux`, `chow_stat`, `cusum_series`, `cusum_stat`, `cusumsq_stat`, and `recursive_residuals` from the compiled `_diag` extension. The module now raises `ImportError` if not built, allowing consumers to fall back to numba implementations. (`SymbolicDSGE/_ckernels/diag/__init__.py`)
* Implements the Cython bridge (`_diag.pyx`) that marshals NumPy arrays to C pointers, releases the GIL, and returns status codes and results in a Pythonic way. This ensures efficient and safe interop with the native C diagnostic routines. (`SymbolicDSGE/_ckernels/diag/_diag.pyx`)
* Adds precise type stubs for all exported diagnostic-test functions, ensuring that type checkers and IDEs can provide accurate signatures and autocompletion. (`SymbolicDSGE/_ckernels/diag/_diag.pyi`)

### Linear algebra primitives

* Introduces a new shared header (`sdsge_linalg.h`) and implementation (`sdsge_linalg.c`) for dense linear algebra routines (matrix multiplication, Cholesky decomposition, Gram matrix helpers, etc.), used by the diagnostic kernels and other subsystems. These routines are plain C, row-major, and avoid BLAS for bit-parity with the numba reference. (`SymbolicDSGE/_ckernels/_common/sdsge_linalg.h`, `SymbolicDSGE/_ckernels/_common/sdsge_linalg.c`) [[1]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adR1-R74) [[2]](diffhunk://#diff-949e9e5f1b867f996dd79454aeb9a58d9836406ccef965734a5f71717e9caabeR1-R220)
* Adds shared status codes (`SDSGE_OK`, `SDSGE_NOT_PD`) for error handling in linear algebra routines, improving consistency across subsystems. (`SymbolicDSGE/_ckernels/_common/sdsge_common.h`)