### PR TITLE
Enhance HAC estimator with kernel IDs Implement native Wald kernel

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -29,13 +29,21 @@ typedef double f64;
 /* 2*pi as the nearest IEEE-754 double (== 2.0 * numpy's pi, exactly); shared by
  * the kalman / distribution / transform kernels. */
 #define TWO_PI 6.283185307179586
+#define PI 3.141592653589793
 
 /* Shared status codes for the dense linear-algebra primitives in sdsge_linalg.
  * Subsystems map these onto their own error conventions (e.g. the kalman hot
- * loop translates SDSGE_NOT_PD -> KF_ERR_MATRIX_CONDITION; the diag kernels turn
- * it into a DIAG_FALLBACK request). SDSGE_OK is 0 so it coincides with KF_OK. */
+ * loop translates SDSGE_NOT_PD -> KF_ERR_MATRIX_CONDITION; the diag kernels
+ * turn it into a DIAG_FALLBACK request). SDSGE_OK is 0 so it coincides with
+ * KF_OK. */
 #define SDSGE_OK 0
 #define SDSGE_NOT_PD -1
+
+/* Inline min/max for i64 and f64. */
+static inline i64 min_i64(i64 a, i64 b) { return (a < b) ? a : b; }
+static inline i64 max_i64(i64 a, i64 b) { return (a > b) ? a : b; }
+static inline f64 min_f64(f64 a, f64 b) { return (a < b) ? a : b; }
+static inline f64 max_f64(f64 a, f64 b) { return (a > b) ? a : b; }
 
 /* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
  * differently by MSVC). */

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.c
@@ -1,6 +1,7 @@
 #include "sdsge_linalg.h"
 #include <math.h>
 #include <float.h>
+#include <stdlib.h>
 
 void sdsge_zero_mat(f64 *SDSGE_RESTRICT out, i64 r, i64 c) {
     const i64 total = r * c;
@@ -26,6 +27,22 @@ void sdsge_matmul(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
             for (i64 k = 0; k < p; ++k)
                 s += A[i * p + k] * B[k * m + j];
             out[i * m + j] = s;
+        }
+    }
+}
+
+void sdsge_matmul_atb(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+                      f64 *SDSGE_RESTRICT out, i64 n, i64 p, i64 m) {
+    /* Row-contraction accumulated row-by-row (matches sdsge_gram's order, and is
+     * cache-optimal: A row and B row stream contiguously, out stays hot). */
+    sdsge_zero_mat(out, p, m);
+    for (i64 i = 0; i < n; ++i) {
+        const f64 *Ai = A + i * p;
+        const f64 *Bi = B + i * m;
+        for (i64 k = 0; k < p; ++k) {
+            f64 aik = Ai[k];
+            for (i64 l = 0; l < m; ++l)
+                out[k * m + l] += aik * Bi[l];
         }
     }
 }
@@ -217,4 +234,24 @@ int sdsge_chol_inv(const f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT Pinv,
         }
     }
     return SDSGE_OK;
+}
+
+static int sdsge_cmp_f64(const void *a, const void *b) {
+    f64 fa = *(const f64 *)a;
+    f64 fb = *(const f64 *)b;
+    return (fa > fb) - (fa < fb);
+}
+
+void sdsge_sort_f64(f64 *SDSGE_RESTRICT arr, i64 n) {
+    if (n > 1)
+        qsort(arr, (size_t)n, sizeof(f64), sdsge_cmp_f64);
+}
+
+f64 sdsge_median_f64(f64 *SDSGE_RESTRICT arr, i64 n) {
+    if (n <= 0)
+        return NAN;
+    sdsge_sort_f64(arr, n);
+    if (n % 2 == 0)
+        return 0.5 * (arr[n / 2 - 1] + arr[n / 2]);
+    return arr[n / 2];
 }

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
@@ -19,6 +19,14 @@ void sdsge_sym_inplace(f64 *P, i64 n);
 /* out(n,m) := A(n,p) @ B(p,m) */
 void sdsge_matmul(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
 
+/* out(p,m) := A(n,p)^T @ B(n,m). The transpose is folded into the indexing (no
+ * materialized A^T); contraction is over the row axis, accumulated row-by-row
+ * like sdsge_gram (of which this is the asymmetric generalization: matmul_atb of
+ * X with itself equals the full gram of X). `out` must not alias A or B, but A
+ * and B may overlap each other -- both are read-only, so e.g. lagged views of
+ * one buffer (A = M, B = M + j*cols) are fine. */
+void sdsge_matmul_atb(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
+
 /* out(n,m) := A(n,p) @ B(m,p)^T */
 void sdsge_matmul_abt(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
 
@@ -70,5 +78,14 @@ int sdsge_chol_solve(const f64 *G, const f64 *g, f64 *coef, f64 *scratch_L,
 /* SPD inverse: Pinv(p,p) := G(p,p)^-1 via Cholesky. scratch_L(p,p) holds the
  * factor. Returns SDSGE_OK or SDSGE_NOT_PD. */
 int sdsge_chol_inv(const f64 *G, f64 *Pinv, f64 *scratch_L, i64 p);
+
+/* ---- small statistical reductions (diagnostics) ---- */
+
+/* Sort n doubles ascending, in place (libc qsort). */
+void sdsge_sort_f64(f64 *arr, i64 n);
+
+/* Median of n doubles; sorts arr IN PLACE (destroys order). Even n averages the
+ * two central order statistics (matches numpy.median). Returns NaN for n <= 0. */
+f64 sdsge_median_f64(f64 *arr, i64 n);
 
 #endif /* SDSGE_LINALG_H */

--- a/SymbolicDSGE/_ckernels/diag/__init__.py
+++ b/SymbolicDSGE/_ckernels/diag/__init__.py
@@ -13,6 +13,11 @@ from ._diag import (
     cusum_series as cusum_series,
     cusum_stat as cusum_stat,
     cusumsq_stat as cusumsq_stat,
+    fill_centered_ax0 as fill_centered_ax0,
+    fill_mean_ax0 as fill_mean_ax0,
+    fill_symmetric_target_vec as fill_symmetric_target_vec,
     hac_estimator_matmul as hac_estimator_matmul,
     recursive_residuals as recursive_residuals,
+    symmetric_outer_prod_2dim as symmetric_outer_prod_2dim,
+    wald_stat_from_mean_and_cov as wald_stat_from_mean_and_cov,
 )

--- a/SymbolicDSGE/_ckernels/diag/__init__.py
+++ b/SymbolicDSGE/_ckernels/diag/__init__.py
@@ -13,5 +13,6 @@ from ._diag import (
     cusum_series as cusum_series,
     cusum_stat as cusum_stat,
     cusumsq_stat as cusumsq_stat,
+    hac_estimator_matmul as hac_estimator_matmul,
     recursive_residuals as recursive_residuals,
 )

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -36,3 +36,6 @@ def cusum_stat(y: _F64, X: _F64) -> tuple[int, float]:
 
 def cusumsq_stat(y: _F64, X: _F64) -> tuple[int, int, float]:
     """CUSUM-of-squares statistic. Returns (status, n, stat)."""
+
+def hac_estimator_matmul(r: _F64, kernel_id: int, L: int) -> _F64:
+    """HAC long-run covariance (full estimator). Returns the (p, p) matrix."""

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -37,5 +37,24 @@ def cusum_stat(y: _F64, X: _F64) -> tuple[int, float]:
 def cusumsq_stat(y: _F64, X: _F64) -> tuple[int, int, float]:
     """CUSUM-of-squares statistic. Returns (status, n, stat)."""
 
+def fill_mean_ax0(x: _F64) -> _F64:
+    """Column means of x over axis 0. Returns mean(p)."""
+
+def fill_centered_ax0(x: _F64, mean: _F64) -> _F64:
+    """x with its column means subtracted. Returns centered(n, p)."""
+
 def hac_estimator_matmul(r: _F64, kernel_id: int, L: int) -> _F64:
     """HAC long-run covariance (full estimator). Returns the (p, p) matrix."""
+
+def wald_stat_from_mean_and_cov(
+    mean: _F64, target: _F64, omega: _F64, n: int
+) -> tuple[int, float]:
+    """Wald statistic n * dev^T omega^-1 dev. Returns (status, stat)."""
+
+def symmetric_outer_prod_2dim(x: _F64) -> tuple[int, _F64]:
+    """Per-row vech of x_t x_t'. Returns (status, out(n, q))."""
+
+def fill_symmetric_target_vec(
+    target: _F64, atol: float, rtol: float
+) -> tuple[int, _F64]:
+    """Pack the upper triangle of a symmetric target. Returns (status, vec(q))."""

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -43,6 +43,19 @@ cdef extern from "diag_wald.h":
                                     int64_t n, int64_t p, double *gamma_scratch,
                                     double *out) nogil
 
+    int sdsge_wald_stat_from_mean_and_cov(const double *mean,
+                                          const double *target,
+                                          const double *omega, int64_t n,
+                                          int64_t p, double *dev_scratch,
+                                          double *L_scratch,
+                                          double *stat_out) nogil
+
+    int sdsge_symmetric_outer_prod_2dim(const double *x, int64_t n, int64_t p,
+                                        int64_t q, double *out) nogil
+
+    int sdsge_fill_symmetric_target_vec(const double *target, double atol,
+                                        double rtol, int64_t p,
+                                        double *out) nogil
 
 # Re-exported so the Python dispatch layer can recognise the "retry in numba"
 # signal without hard-coding the magic number.

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -32,6 +32,18 @@ cdef extern from "diag.h":
                            int64_t p, int64_t *n_out, double *stat_out) nogil
 
 
+cdef extern from "diag_wald.h":
+    ctypedef enum KernelID:
+        BARTLETT
+        PARZEN
+        QS
+        KERNEL_COUNT
+
+    void sdsge_hac_estimator_matmul(double *r, KernelID kernel_id, int64_t L,
+                                    int64_t n, int64_t p, double *gamma_scratch,
+                                    double *out) nogil
+
+
 # Re-exported so the Python dispatch layer can recognise the "retry in numba"
 # signal without hard-coding the magic number.
 FALLBACK = DIAG_FALLBACK
@@ -120,3 +132,22 @@ def cusumsq_stat(double[::1] y, double[:, ::1] X):
     with nogil:
         status = sdsge_cusumsq_stat(&y[0], &X[0, 0], T, p, &n, &stat)
     return status, n, stat
+
+
+def hac_estimator_matmul(double[:, ::1] r, int kernel_id, int64_t L):
+    """HAC long-run covariance (Gamma_0 + sum_j w_j(Gamma_j + Gamma_j')) / n.
+
+    Full-estimator parity with the numba ``jit_hac_estimator_matmul``: same
+    inputs (centered moment array, integer kernel id, bandwidth) and the same
+    (p, p) output -- no separate Gamma_0/scaling codepath on the caller side.
+    """
+    cdef int64_t n = r.shape[0]
+    cdef int64_t p = r.shape[1]
+    omega = np.empty((p, p), dtype=np.float64)
+    gamma = np.empty((p, p), dtype=np.float64)
+    cdef double[:, ::1] out_mv = omega
+    cdef double[:, ::1] gamma_mv = gamma
+    with nogil:
+        sdsge_hac_estimator_matmul(&r[0, 0], <KernelID>kernel_id, L, n, p,
+                                   &gamma_mv[0, 0], &out_mv[0, 0])
+    return omega

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -39,6 +39,11 @@ cdef extern from "diag_wald.h":
         QS
         KERNEL_COUNT
 
+    void sdsge_fill_mean_ax0(const double *x, int64_t n, int64_t p,
+                             double *mean) nogil
+    void sdsge_fill_centered_ax0(const double *x, const double *mean, int64_t n,
+                                 int64_t p, double *centered) nogil
+
     void sdsge_hac_estimator_matmul(double *r, KernelID kernel_id, int64_t L,
                                     int64_t n, int64_t p, double *gamma_scratch,
                                     double *out) nogil
@@ -164,3 +169,76 @@ def hac_estimator_matmul(double[:, ::1] r, int kernel_id, int64_t L):
         sdsge_hac_estimator_matmul(&r[0, 0], <KernelID>kernel_id, L, n, p,
                                    &gamma_mv[0, 0], &out_mv[0, 0])
     return omega
+
+
+def fill_mean_ax0(double[:, ::1] x):
+    """Column means of x over axis 0. Returns mean(p)."""
+    cdef int64_t n = x.shape[0]
+    cdef int64_t p = x.shape[1]
+    mean = np.empty(p, dtype=np.float64)
+    cdef double[::1] mean_mv = mean
+    with nogil:
+        sdsge_fill_mean_ax0(&x[0, 0], n, p, &mean_mv[0])
+    return mean
+
+
+def fill_centered_ax0(double[:, ::1] x, double[::1] mean):
+    """x with its column means subtracted. Returns centered(n, p)."""
+    cdef int64_t n = x.shape[0]
+    cdef int64_t p = x.shape[1]
+    centered = np.empty((n, p), dtype=np.float64)
+    cdef double[:, ::1] centered_mv = centered
+    with nogil:
+        sdsge_fill_centered_ax0(&x[0, 0], &mean[0], n, p, &centered_mv[0, 0])
+    return centered
+
+
+def wald_stat_from_mean_and_cov(double[::1] mean, double[::1] target,
+                                double[:, ::1] omega, int64_t n):
+    """Wald statistic n * dev^T omega^-1 dev with dev = mean - target.
+
+    Returns (status, stat). status is DIAG_OK, or FALLBACK when omega is not
+    positive definite (the caller recomputes via the numba LU path).
+    """
+    cdef int64_t p = mean.shape[0]
+    cdef double stat = 0.0
+    cdef int status
+    dev = np.empty(p, dtype=np.float64)
+    chol = np.empty((p, p), dtype=np.float64)
+    cdef double[::1] dev_mv = dev
+    cdef double[:, ::1] chol_mv = chol
+    with nogil:
+        status = sdsge_wald_stat_from_mean_and_cov(
+            &mean[0], &target[0], &omega[0, 0], n, p,
+            &dev_mv[0], &chol_mv[0, 0], &stat)
+    return status, stat
+
+
+def symmetric_outer_prod_2dim(double[:, ::1] x):
+    """Per-row vech of the outer product x_t x_t'. Returns (status, out(n, q))."""
+    cdef int64_t n = x.shape[0]
+    cdef int64_t p = x.shape[1]
+    cdef int64_t q = p * (p + 1) // 2
+    out = np.empty((n, q), dtype=np.float64)
+    cdef double[:, ::1] out_mv = out
+    cdef int status
+    with nogil:
+        status = sdsge_symmetric_outer_prod_2dim(&x[0, 0], n, p, q, &out_mv[0, 0])
+    return status, out
+
+
+def fill_symmetric_target_vec(double[:, ::1] target, double atol, double rtol):
+    """Pack the upper triangle of a symmetric target into a vech vector.
+
+    Returns (status, vec(q)); status is DIAG_BAD_SHAPE if the matrix is not
+    symmetric within (atol, rtol).
+    """
+    cdef int64_t p = target.shape[0]
+    cdef int64_t q = p * (p + 1) // 2
+    vec = np.empty(q, dtype=np.float64)
+    cdef double[::1] vec_mv = vec
+    cdef int status
+    with nogil:
+        status = sdsge_fill_symmetric_target_vec(&target[0, 0], atol, rtol, p,
+                                                 &vec_mv[0])
+    return status, vec

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.c
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.c
@@ -165,11 +165,14 @@ f64 kernel_weight(i64 j, i64 L, KernelID kernel_id) {
   }
 }
 
-void hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id, i64 L,
-                          i64 n, i64 p, f64 *SDSGE_RESTRICT gamma_scratch,
-                          f64 *SDSGE_RESTRICT out) {
-  L = min_i64(L, n - 1);
+void sdsge_hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id,
+                                i64 L, i64 n, i64 p,
+                                f64 *SDSGE_RESTRICT gamma_scratch,
+                                f64 *SDSGE_RESTRICT out) {
+  /* Gamma_0 = r^T r (full symmetric); the lag terms accumulate on top. */
+  sdsge_gram(r, out, n, p);
 
+  L = min_i64(L, n - 1);
   for (i64 j = 1; j <= L; ++j) {
     f64 w_j = kernel_weight(j, L, kernel_id);
 
@@ -188,4 +191,13 @@ void hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id, i64 L,
       }
     }
   }
+
+  /* The numba reference divides every autocovariance by n; do it once over the
+   * assembled sum -- identical up to rounding, well within parity tolerance. */
+  for (i64 i = 0; i < p * p; ++i) {
+    out[i] /= (f64)n;
+  }
 }
+
+// ------
+// --- wald_test ---

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.c
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.c
@@ -1,4 +1,5 @@
 #include "diag_wald.h"
+#include "diag.h"
 #include <math.h>
 
 /* Column mean/var of a row-major (n, p) buffer (not on the Python side). */
@@ -201,3 +202,81 @@ void sdsge_hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id,
 
 // ------
 // --- wald_test ---
+
+int sdsge_wald_stat_from_mean_and_cov(const f64 *SDSGE_RESTRICT mean,
+                                      const f64 *SDSGE_RESTRICT target,
+                                      const f64 *SDSGE_RESTRICT omega,
+                                      const i64 n, const i64 p,
+                                      f64 *SDSGE_RESTRICT dev_scratch,
+                                      f64 *SDSGE_RESTRICT L_scratch,
+                                      f64 *SDSGE_RESTRICT stat_out) {
+  /* Compute the Wald statistic: *
+   * dev = mean - target;
+   * stat = n * (dev^T @ omega^-1 @ dev); */
+  for (i64 i = 0; i < p; ++i) {
+    dev_scratch[i] = mean[i] - target[i];
+  }
+  int code = sdsge_chol(omega, 0.0, L_scratch, p);
+  if (code != SDSGE_OK) {
+    return DIAG_FALLBACK;
+  }
+
+  sdsge_forward_subst(L_scratch, dev_scratch, dev_scratch, p);
+
+  /* Stat = n * sum(z_i^2) */
+  f64 stat = 0.0;
+  for (i64 i = 0; i < p; ++i) {
+    stat += dev_scratch[i] * dev_scratch[i];
+  }
+
+  *stat_out = (f64)n * stat;
+  return DIAG_OK;
+}
+
+int sdsge_symmetric_outer_prod_2dim(const f64 *SDSGE_RESTRICT x, const i64 n,
+                                    const i64 p, const i64 q,
+                                    f64 *SDSGE_RESTRICT out) {
+  /* out is (n, q) with q = floor(p * (p + 1) / 2); the python side computes q
+   * for shape checks, so don't recompute it here. x is (n, p): its row stride is
+   * p, only out's row stride is q. */
+  i64 k = 0;
+  f64 x_i = 0.0;
+  for (i64 t = 0; t < n; ++t) {
+    k = 0;
+    for (i64 i = 0; i < p; ++i) {
+      x_i = x[t * p + i];
+      for (i64 j = i; j < p; ++j) {
+        out[t * q + k] = x_i * x[t * p + j];
+        k += 1;
+      }
+    }
+  }
+  return DIAG_OK;
+}
+
+int sdsge_fill_symmetric_target_vec(const f64 *SDSGE_RESTRICT target,
+                                    const f64 atol, const f64 rtol, const i64 p,
+                                    f64 *SDSGE_RESTRICT out) {
+
+  i64 k = 0;
+  f64 a = 0.0;
+  f64 b = 0.0;
+  f64 diff = 0.0;
+
+  for (i64 i = 0; i < p; ++i) {
+    for (i64 j = i; j < p; ++j) {
+      a = target[i * p + j];
+      b = target[j * p + i];
+      if (a != b) {
+        diff = fabs(a - b);
+
+        if (!isfinite(diff) || diff > atol + rtol * fabs(b)) {
+          return DIAG_BAD_SHAPE;
+        }
+      }
+      out[k] = a;
+      k += 1;
+    }
+  }
+  return DIAG_OK;
+}

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.c
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.c
@@ -25,8 +25,8 @@ static f64 col_var(const f64 *SDSGE_RESTRICT x, f64 mean, const i64 n,
 
 // --- moment_calculation_utils ---
 
-static void fill_mean_ax0(const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT mean,
-                          const i64 n, const i64 p) {
+void sdsge_fill_mean_ax0(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
+                         f64 *SDSGE_RESTRICT mean) {
 
   for (i64 i = 0; i < p; ++i) {
     mean[i] = 0.0;
@@ -42,9 +42,9 @@ static void fill_mean_ax0(const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT mean,
   }
 }
 
-static void fill_centered_ax0(const f64 *SDSGE_RESTRICT x,
-                              const f64 *SDSGE_RESTRICT mean, const i64 n,
-                              const i64 p, f64 *SDSGE_RESTRICT centered) {
+void sdsge_fill_centered_ax0(const f64 *SDSGE_RESTRICT x,
+                             const f64 *SDSGE_RESTRICT mean, const i64 n,
+                             const i64 p, f64 *SDSGE_RESTRICT centered) {
   for (i64 i = 0; i < n; ++i) {
     for (i64 j = 0; j < p; ++j) {
       centered[i * p + j] = x[i * p + j] - mean[j];

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.c
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.c
@@ -1,0 +1,191 @@
+#include "diag_wald.h"
+#include <math.h>
+
+/* Column mean/var of a row-major (n, p) buffer (not on the Python side). */
+static f64 col_mean(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
+                    const i64 col) {
+  f64 mean = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    mean += x[i * p + col];
+  }
+
+  return mean / (f64)n;
+}
+
+static f64 col_var(const f64 *SDSGE_RESTRICT x, f64 mean, const i64 n,
+                   const i64 p, const i64 col) {
+  f64 var = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    f64 diff = x[i * p + col] - mean;
+    var += diff * diff;
+  }
+  return var / (f64)n;
+}
+
+// --- moment_calculation_utils ---
+
+static void fill_mean_ax0(const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT mean,
+                          const i64 n, const i64 p) {
+
+  for (i64 i = 0; i < p; ++i) {
+    mean[i] = 0.0;
+  }
+
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < p; ++j) {
+      mean[j] += x[i * p + j];
+    }
+  }
+  for (i64 i = 0; i < p; ++i) {
+    mean[i] /= (f64)n;
+  }
+}
+
+static void fill_centered_ax0(const f64 *SDSGE_RESTRICT x,
+                              const f64 *SDSGE_RESTRICT mean, const i64 n,
+                              const i64 p, f64 *SDSGE_RESTRICT centered) {
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < p; ++j) {
+      centered[i * p + j] = x[i * p + j] - mean[j];
+    }
+  }
+}
+
+// -------
+
+// --- hac_covariance ---
+
+i64 wooldridge_bandwidth(const f64 *SDSGE_RESTRICT
+                             x, /* kept for signature parity with Python */
+                         const i64 n) {
+  (void)x;
+  return (i64)floor(4.0 * pow((f64)n / 100.0, 2.0 / 9.0));
+}
+
+/* Andrews (1991) AR(1)-plug-in bandwidth for the strided series y[0],
+ * y[stride],
+ * ..., y[(n-1)*stride]. The stride lets the matrix variant walk a column of a
+ * row-major (n, p) buffer in place -- no per-column copy. Returns 1 for any
+ * degenerate case (n < 2, ~zero variance, non-finite moments, non-positive
+ * Rhat), matching the numba reference's guards. */
+static i64 andrews_bw_strided(const f64 *SDSGE_RESTRICT y, const i64 n,
+                              const i64 stride, const f64 c, const f64 q) {
+  if (n < 2)
+    return 1;
+
+  f64 mean = 0.0;
+  for (i64 i = 0; i < n; ++i)
+    mean += y[i * stride];
+  mean /= (f64)n;
+
+  f64 var = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    f64 d = y[i * stride] - mean;
+    var += d * d;
+  }
+  var /= (f64)n;
+  if (var <= 1e-14)
+    return 1;
+
+  /* Uncentered AR(1) coefficient: beta = dot(y_lag, y_cur) / dot(y_lag, y_lag),
+   * with y_lag = y[:-1] and y_cur = y[1:] -- a pure index offset, no buffers.
+   */
+  f64 denom = 0.0, numer = 0.0;
+  for (i64 i = 1; i < n; ++i) {
+    f64 prev = y[(i - 1) * stride];
+    denom += prev * prev;
+    numer += prev * y[i * stride];
+  }
+  if (!isfinite(denom) || !isfinite(numer) || denom == 0.0)
+    return 1;
+
+  f64 beta = numer / denom;
+  beta = max_f64(-0.999, min_f64(0.999, beta)); /* clip to avoid Rhat blowup */
+
+  f64 rhat = 2.0 * beta * (1.0 + beta) / ((1.0 - beta) * (1.0 - beta));
+  if (rhat <= 0.0 || !isfinite(rhat))
+    return 1;
+
+  const f64 expo = 1.0 / (2.0 * q + 1.0);
+  return max_i64(1, (i64)floor(c * pow(rhat, expo) * pow((f64)n, expo)));
+}
+
+i64 andrews_bandwidth(const f64 *SDSGE_RESTRICT y, KernelID kernel_id,
+                      const i64 n) {
+  return andrews_bw_strided(y, n, 1, KERNEL_SPECS[kernel_id].c,
+                            KERNEL_SPECS[kernel_id].q);
+}
+
+/* Median of the per-column Andrews bandwidths, excluding near-constant columns
+ * (var <= 1e-14) from the set -- the numba reference drops them before taking
+ * the median. `ls` is caller-owned scratch of length >= p; it is overwritten
+ * and reordered (no allocation here -- slice it from the entry-point arena). */
+i64 andrews_bandwidth_matrix(const f64 *SDSGE_RESTRICT r, KernelID kernel_id,
+                             const i64 n, const i64 p, f64 *SDSGE_RESTRICT ls) {
+  if (p == 1)
+    return andrews_bandwidth(r, kernel_id, n);
+
+  const f64 c = KERNEL_SPECS[kernel_id].c;
+  const f64 q = KERNEL_SPECS[kernel_id].q;
+
+  i64 m = 0;
+  for (i64 j = 0; j < p; ++j) {
+    f64 mean = col_mean(r, n, p, j);
+    if (col_var(r, mean, n, p, j) > 1e-14)
+      ls[m++] = (f64)andrews_bw_strided(r + j, n, p, c, q);
+  }
+  if (m == 0)
+    return 1;
+  return (i64)floor(sdsge_median_f64(ls, m));
+}
+
+// kernel weight function
+
+f64 kernel_weight(i64 j, i64 L, KernelID kernel_id) {
+  f64 x = (f64)j / (f64)(L + 1);
+
+  switch (kernel_id) {
+  case BARTLETT:
+    return (j <= L) ? (1.0 - x) : 0.0;
+  case PARZEN:
+    if (x > 1.0)
+      return 0.0;
+    if (x <= 0.5)
+      return 1.0 - 6.0 * (x * x) + 6.0 * (x * x * x);
+    return 2.0 * (1.0 - x) * (1.0 - x) * (1.0 - x);
+  case QS:
+    if (fabs(x) <= 1e-8)
+      return 1.0; // Handle the case when x is very close to 0
+
+    f64 outer = 25.0 / (12.0 * PI * PI * x * x);
+    f64 arg = 6.0 * PI * x / 5.0;
+    return outer * (sin(arg) / arg - cos(arg));
+  default:
+    return 0.0; // Unknown kernel ID
+  }
+}
+
+void hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id, i64 L,
+                          i64 n, i64 p, f64 *SDSGE_RESTRICT gamma_scratch,
+                          f64 *SDSGE_RESTRICT out) {
+  L = min_i64(L, n - 1);
+
+  for (i64 j = 1; j <= L; ++j) {
+    f64 w_j = kernel_weight(j, L, kernel_id);
+
+    if (w_j == 0.0) {
+      continue;
+    }
+
+    /* Gamma_j = r[:-j]^T @ r[j:] -- lagged views of r, no copy. */
+    sdsge_matmul_atb(r, r + j * p, gamma_scratch, n - j, p, p);
+
+    // out += w_j * (Gamma_j + Gamma_j')
+    for (i64 k = 0; k < p; ++k) {
+      for (i64 l = 0; l < p; ++l) {
+        out[k * p + l] +=
+            w_j * (gamma_scratch[k * p + l] + gamma_scratch[l * p + k]);
+      }
+    }
+  }
+}

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.h
@@ -24,8 +24,13 @@ static const kernel_inp_t KERNEL_SPECS[KERNEL_COUNT] = {
     [PARZEN] = {.c = C_PARZEN, .q = 2.0},
     [QS] = {.c = C_QS, .q = 2.0}};
 
-void hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id, i64 L,
-                          i64 n, i64 p, f64 *SDSGE_RESTRICT gamma_scratch,
-                          f64 *SDSGE_RESTRICT out);
+/* Full HAC long-run covariance: out(p,p) := (Gamma_0 + sum_{j=1..L} w_j (Gamma_j
+ * + Gamma_j^T)) / n, mirroring the numba jit_hac_estimator_matmul. `r` is the
+ * (n, p) centered moment array; `gamma_scratch` and `out` are caller-owned (p, p)
+ * buffers (out must not alias gamma_scratch or r). */
+void sdsge_hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id,
+                                i64 L, i64 n, i64 p,
+                                f64 *SDSGE_RESTRICT gamma_scratch,
+                                f64 *SDSGE_RESTRICT out);
 
 #endif // SDSGE_DIAG_WALD_H

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.h
@@ -24,13 +24,30 @@ static const kernel_inp_t KERNEL_SPECS[KERNEL_COUNT] = {
     [PARZEN] = {.c = C_PARZEN, .q = 2.0},
     [QS] = {.c = C_QS, .q = 2.0}};
 
-/* Full HAC long-run covariance: out(p,p) := (Gamma_0 + sum_{j=1..L} w_j (Gamma_j
+/* Full HAC long-run covariance: out(p,p) := (Gamma_0 + sum_{j=1..L} w_j
+ * (Gamma_j
  * + Gamma_j^T)) / n, mirroring the numba jit_hac_estimator_matmul. `r` is the
- * (n, p) centered moment array; `gamma_scratch` and `out` are caller-owned (p, p)
- * buffers (out must not alias gamma_scratch or r). */
+ * (n, p) centered moment array; `gamma_scratch` and `out` are caller-owned (p,
+ * p) buffers (out must not alias gamma_scratch or r). */
 void sdsge_hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id,
                                 i64 L, i64 n, i64 p,
                                 f64 *SDSGE_RESTRICT gamma_scratch,
                                 f64 *SDSGE_RESTRICT out);
+
+int sdsge_wald_stat_from_mean_and_cov(const f64 *SDSGE_RESTRICT mean,
+                                      const f64 *SDSGE_RESTRICT target,
+                                      const f64 *SDSGE_RESTRICT omega,
+                                      const i64 n, const i64 p,
+                                      f64 *SDSGE_RESTRICT dev_scratch,
+                                      f64 *SDSGE_RESTRICT L_scratch,
+                                      f64 *SDSGE_RESTRICT stat_out);
+
+int sdsge_symmetric_outer_prod_2dim(const f64 *SDSGE_RESTRICT x, const i64 n,
+                                    const i64 p, const i64 q,
+                                    f64 *SDSGE_RESTRICT out);
+
+int sdsge_fill_symmetric_target_vec(const f64 *SDSGE_RESTRICT target,
+                                    const f64 atol, const f64 rtol, const i64 p,
+                                    f64 *SDSGE_RESTRICT out);
 
 #endif // SDSGE_DIAG_WALD_H

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.h
@@ -24,6 +24,15 @@ static const kernel_inp_t KERNEL_SPECS[KERNEL_COUNT] = {
     [PARZEN] = {.c = C_PARZEN, .q = 2.0},
     [QS] = {.c = C_QS, .q = 2.0}};
 
+/* Column means of x(n,p) over axis 0; writes mean(p). */
+void sdsge_fill_mean_ax0(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
+                         f64 *SDSGE_RESTRICT mean);
+
+/* x(n,p) with its column means subtracted; writes centered(n,p). */
+void sdsge_fill_centered_ax0(const f64 *SDSGE_RESTRICT x,
+                             const f64 *SDSGE_RESTRICT mean, const i64 n,
+                             const i64 p, f64 *SDSGE_RESTRICT centered);
+
 /* Full HAC long-run covariance: out(p,p) := (Gamma_0 + sum_{j=1..L} w_j
  * (Gamma_j
  * + Gamma_j^T)) / n, mirroring the numba jit_hac_estimator_matmul. `r` is the

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.h
@@ -1,0 +1,31 @@
+#include "../_common/sdsge_common.h"
+#include "../_common/sdsge_linalg.h"
+
+#ifndef SDSGE_DIAG_WALD_H
+#define SDSGE_DIAG_WALD_H
+
+// Kernel IDs
+typedef enum { BARTLETT = 0, PARZEN = 1, QS = 2, KERNEL_COUNT = 3 } KernelID;
+
+// Kernel Constants
+
+#define C_BARTLETT 1.1447
+#define C_PARZEN 2.6614
+#define C_QS 1.3221
+
+// ID to kernel struct
+typedef struct {
+  f64 c;
+  f64 q;
+} kernel_inp_t;
+
+static const kernel_inp_t KERNEL_SPECS[KERNEL_COUNT] = {
+    [BARTLETT] = {.c = C_BARTLETT, .q = 1.0},
+    [PARZEN] = {.c = C_PARZEN, .q = 2.0},
+    [QS] = {.c = C_QS, .q = 2.0}};
+
+void hac_estimator_matmul(f64 *SDSGE_RESTRICT r, KernelID kernel_id, i64 L,
+                          i64 n, i64 p, f64 *SDSGE_RESTRICT gamma_scratch,
+                          f64 *SDSGE_RESTRICT out);
+
+#endif // SDSGE_DIAG_WALD_H

--- a/SymbolicDSGE/_diag_tests/hac_covariance.py
+++ b/SymbolicDSGE/_diag_tests/hac_covariance.py
@@ -6,6 +6,8 @@ from numba import njit
 
 from typing import Literal, cast
 
+from ._native import native as _native
+
 NDF = NDArray[float64]
 
 
@@ -225,6 +227,13 @@ def hac_covariance(
     L = min(L, n - 1)
 
     if nopython:
+        if _native is not None:
+            return cast(
+                NDF,
+                _native.hac_estimator_matmul(
+                    np.ascontiguousarray(r, dtype=np.float64), kernel_id, L
+                ),
+            )
         return cast(NDF, jit_hac_estimator_matmul(r, kernel_id, L))
 
     return py_hac_estimator(r, kernel_id, L)

--- a/SymbolicDSGE/_diag_tests/hac_covariance.py
+++ b/SymbolicDSGE/_diag_tests/hac_covariance.py
@@ -4,19 +4,33 @@ from numpy.typing import NDArray
 
 from numba import njit
 
-from typing import Literal, Callable, cast
+from typing import Literal, cast
 
 NDF = NDArray[float64]
+
+
+# Kernel IDs (integer). The HAC estimator selects a lag window by id rather than
+# by a passed-in callable, so the jitted path can be ``cache=True`` and the whole
+# branch maps directly onto a plain C ``switch`` for the native port.
+_BARTLETT: int = 0
+_PARZEN: int = 1
+_QS: int = 2
+
+_KERNEL_STR_TO_ID: dict[str, int] = {
+    "bartlett": _BARTLETT,
+    "parzen": _PARZEN,
+    "qs": _QS,
+}
 
 # Andrews (1991) bandwidth constants for different kernels
 _C_BARTLETT = 1.1447
 _C_PARZEN = 2.6614
 _C_QUADRATIC_SPECTRAL = 1.3221
 
-_ANDREWS_C_Q_GETTER: dict[str, tuple[float, float]] = {
-    "bartlett": (_C_BARTLETT, 1.0),
-    "parzen": (_C_PARZEN, 2.0),
-    "qs": (_C_QUADRATIC_SPECTRAL, 2.0),
+_ANDREWS_C_Q_GETTER: dict[int, tuple[float, float]] = {
+    _BARTLETT: (_C_BARTLETT, 1.0),
+    _PARZEN: (_C_PARZEN, 2.0),
+    _QS: (_C_QUADRATIC_SPECTRAL, 2.0),
 }
 
 
@@ -27,9 +41,7 @@ def wooldridge_bandwidth(x: NDF) -> int:
 
 
 # Andrews (1991) bandwidth selection rule for HAC covariance estimation
-def andrews_bandwidth(
-    y: NDF, kernel: Literal["bartlett", "parzen", "qs"] = "bartlett"
-) -> int:
+def andrews_bandwidth(y: NDF, kernel_id: int = _BARTLETT) -> int:
     n = y.shape[0]
     if n < 2 or np.var(y) <= 1e-14:
         return 1
@@ -51,19 +63,19 @@ def andrews_bandwidth(
     if Rhat <= 0.0 or not np.isfinite(Rhat):
         return 1
 
-    c, q = _ANDREWS_C_Q_GETTER[kernel]
+    c, q = _ANDREWS_C_Q_GETTER[kernel_id]
     b = c * (Rhat ** (1.0 / (2 * q + 1))) * (n ** (1.0 / (2 * q + 1)))
     return max(1, int(np.floor(b)))
 
 
 def andrews_bandwidth_matrix(
     r: NDF,
-    kernel: Literal["bartlett", "parzen", "qs"] = "bartlett",
+    kernel_id: int = _BARTLETT,
 ) -> int:
     r = np.asarray(r, dtype=np.float64)
 
     if r.ndim == 1:
-        return andrews_bandwidth(r, kernel=kernel)
+        return andrews_bandwidth(r, kernel_id=kernel_id)
 
     if r.ndim != 2:
         raise ValueError(f"r must be 1D or 2D, got shape {r.shape}.")
@@ -72,7 +84,7 @@ def andrews_bandwidth_matrix(
     for j in range(r.shape[1]):
         col = r[:, j]
         if np.var(col) > 1e-14:
-            Ls.append(andrews_bandwidth(col, kernel=kernel))
+            Ls.append(andrews_bandwidth(col, kernel_id=kernel_id))
 
     if not Ls:
         return 1
@@ -80,93 +92,57 @@ def andrews_bandwidth_matrix(
     return int(np.median(np.asarray(Ls)))
 
 
-_BW_SELECTION_DISPATCHER: dict[str, Callable] = {
-    "wooldridge": wooldridge_bandwidth,
-    "andrews": andrews_bandwidth_matrix,
-}
+@njit(cache=True)
+def _kernel_weight(j: int, L: int, kernel_id: int) -> float64:
+    """Lag-window weight w(j; L) for the selected kernel.
 
-
-def bartlett_kernel(j: int, L: int) -> float64:
-    out: float64 = float64(0.0)
-    if j > L:
-        return out
-    else:
-        out += 1.0 - float64(j) / (float64(L) + 1.0)
-        return out
-
-
-def parzen_kernel(j: int, L: int) -> float64:
-    out: float64 = float64(0.0)
+    A single branch over the integer kernel id (rather than a passed-in callable)
+    so the jitted HAC estimator can be ``cache=True`` and the whole thing maps
+    onto a plain C ``switch`` for the native port. All three closed forms are
+    math.h-expressible.
+    """
     x: float64 = float64(j) / (float64(L) + 1.0)
 
-    if x > 1.0:
-        return out
-    elif x <= 0.5:
-        out += 1.0 - 6.0 * x**2 + 6.0 * x**3
-        return out
-    else:
-        out += 2.0 * (1.0 - x) ** 3
-        return out
+    if kernel_id == _BARTLETT:
+        if j > L:
+            return float64(0.0)
+        return float64(1.0 - x)
+
+    if kernel_id == _PARZEN:
+        if x > 1.0:
+            return float64(0.0)
+        if x <= 0.5:
+            return float64(1.0 - 6.0 * x**2 + 6.0 * x**3)
+        return float64(2.0 * (1.0 - x) ** 3)
+
+    # _QS
+    if abs(x) <= 1e-8:
+        return float64(1.0)
+    outer = 25.0 / (12.0 * np.pi**2 * x**2)
+    arg = 6.0 * np.pi * x / 5.0
+    inner = np.sin(arg) / arg - np.cos(arg)
+    return float64(outer * inner)
 
 
-def quadratic_spectral_kernel(j: int, L: int) -> float64:
-    out: float64 = float64(0.0)
-    x: float64 = float64(j) / (float64(L) + 1.0)
-
-    if np.isclose(x, 0.0, atol=1e-8):
-        out += 1.0
-        return out
-    else:
-        outer = 25.0 / (12.0 * np.pi**2 * x**2)
-        inner = np.sin(6.0 * np.pi * x / 5.0) / (6.0 * np.pi * x / 5.0) - np.cos(
-            6.0 * np.pi * x / 5.0
-        )
-        out += outer * inner
-        return out
-
-
-_KERNEL_GETTER: dict[str, Callable[[int, int], float64]] = {
-    "bartlett": bartlett_kernel,
-    "parzen": parzen_kernel,
-    "qs": quadratic_spectral_kernel,
-}
-
-_JIT_CACHE: dict[str, Callable[[int, int], float64]] = {}
-
-
-def kernel_dispatcher(
-    kernel: Literal["bartlett", "parzen", "qs"], nopython: bool = True
-) -> Callable[[int, int], float64]:
-    if nopython:
-        if kernel not in _JIT_CACHE:
-            _JIT_CACHE[kernel] = njit(_KERNEL_GETTER[kernel], cache=True)
-        return _JIT_CACHE[kernel]
-    else:
-        return _KERNEL_GETTER[kernel]
-
-
-# HAC covariance estimation using the specified kernel and bandwidth.
-# NOTE: deliberately *not* cache=True. `k` is a jitted dispatcher argument, and
-# numba keys an on-disk cache entry on the dispatcher's identity (a weakref), not
-# a stable signature. Each session's kernel is a new object, so the cache never
-# hits cross-session — it only accumulates stale keys whose weakrefs die with the
-# process that made them; the next save re-pickles the index and raises
-# "ReferenceError: underlying object has vanished". In-process JIT reuse is
-# unaffected (the compiled overload is still memoized in memory).
-@njit
+# HAC covariance estimation using the selected kernel and bandwidth. Now that the
+# kernel is chosen by integer id (no jitted-callable argument), this can be
+# ``cache=True``: the on-disk cache keys on the stable (array, int, int)
+# signature instead of a dispatcher weakref that dies with the process.
+@njit(cache=True)
 def jit_hac_estimator_matmul(
     r: NDF,
-    k: Callable[[int, int], float64],  # Kernel function
+    kernel_id: int,
     L: int,  # Bandwidth
 ) -> NDF:
     n = r.shape[0]
-    S = np.zeros((r.shape[1], r.shape[1]), dtype=float64)
+    p = r.shape[1]
+    S = np.zeros((p, p), dtype=float64)
     L = min(L, n - 1)
 
     S += r.T @ r / n  # Gamma 0
 
     for j in range(1, L + 1):
-        w_j = k(j, L)
+        w_j = _kernel_weight(j, L, kernel_id)
         if w_j == 0.0:
             continue
         gamma_j = r[j:].T @ r[:-j] / n
@@ -178,10 +154,9 @@ def jit_hac_estimator_matmul(
 # For testing and maintaining functionality in cases where numba isn't supported.
 def py_hac_estimator(
     r: NDF,
-    k: Callable[[int, int], float64],  # Kernel function
+    kernel_id: int,
     L: int,  # Bandwidth
 ) -> NDF:
-
     n, p = r.shape
     S = np.zeros((p, p), dtype=float64)
     L = min(L, n - 1)
@@ -189,7 +164,7 @@ def py_hac_estimator(
     S += r.T @ r / n  # Gamma 0
 
     for j in range(1, L + 1):
-        w_j = k(j, L)
+        w_j = _kernel_weight.py_func(j, L, kernel_id)
         if w_j == 0.0:
             continue
         gamma_j = r[j:].T @ r[:-j] / n
@@ -200,7 +175,7 @@ def py_hac_estimator(
 def hac_covariance(
     r: NDF,
     kernel: Literal["bartlett", "parzen", "qs"] = "bartlett",
-    bandwidth: int | Literal["wooldridge", "andrews", "auto"] | None = "auto",
+    bandwidth: int | Literal["wooldridge", "andrews", "auto"] | None = None,
     center: bool = False,
     nopython: bool = True,
 ) -> NDF:
@@ -213,23 +188,33 @@ def hac_covariance(
     if n < 2:
         raise ValueError(f"r must have at least 2 observations, got {n}.")
 
+    kernel_id = _KERNEL_STR_TO_ID.get(kernel)
+    if kernel_id is None:
+        raise ValueError(
+            f"Unsupported kernel: {kernel}. Supported kernels are: "
+            f"{list(_KERNEL_STR_TO_ID)}"
+        )
+
     if center:
         r = r - r.mean(axis=0)
 
-    L = -1
+    # Bandwidth resolution. An explicit non-negative int is used as L directly; a
+    # string names a data-driven selection rule; None/"auto" picks the rule
+    # conventionally paired with the kernel (Wooldridge for Bartlett, Andrews
+    # otherwise). There is no integer id for the selection rules -- a bare int
+    # always means a manual bandwidth.
     if bandwidth is None or bandwidth == "auto":
         if kernel == "bartlett":
             L = wooldridge_bandwidth(r)
-        elif kernel in ("parzen", "qs"):
-            L = andrews_bandwidth_matrix(r, kernel=kernel)
         else:
-            raise ValueError(f"Unsupported kernel: {kernel}")
-
+            L = andrews_bandwidth_matrix(r, kernel_id=kernel_id)
     elif isinstance(bandwidth, str):
-        if bandwidth not in _BW_SELECTION_DISPATCHER:
+        if bandwidth == "wooldridge":
+            L = wooldridge_bandwidth(r)
+        elif bandwidth == "andrews":
+            L = andrews_bandwidth_matrix(r, kernel_id=kernel_id)
+        else:
             raise ValueError(f"Unsupported bandwidth selection method: {bandwidth}")
-        L = _BW_SELECTION_DISPATCHER[bandwidth](r)
-
     elif isinstance(bandwidth, int):
         if bandwidth < 0:
             raise ValueError(f"Bandwidth must be non-negative, got {bandwidth}.")
@@ -238,9 +223,8 @@ def hac_covariance(
         raise ValueError(f"Invalid bandwidth specification: {bandwidth}")
 
     L = min(L, n - 1)
-    k = kernel_dispatcher(kernel, nopython=nopython)
 
     if nopython:
-        return cast(NDF, jit_hac_estimator_matmul(r, k, L))
+        return cast(NDF, jit_hac_estimator_matmul(r, kernel_id, L))
 
-    return py_hac_estimator(r, k, L)
+    return py_hac_estimator(r, kernel_id, L)

--- a/SymbolicDSGE/_diag_tests/wald_test.py
+++ b/SymbolicDSGE/_diag_tests/wald_test.py
@@ -3,6 +3,7 @@ from .moment_calculation_utils import jit_fill_centered, jit_fill_mean_ax0
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
 from .status import TestStatus
+from ._native import native as _native, DIAG_FALLBACK
 from ..regression.solvers import _gram_is_pd
 import numpy as np
 from numpy import float64, int64
@@ -11,7 +12,7 @@ from numpy.linalg import cholesky, solve
 
 from numba import njit
 
-from typing import Literal
+from typing import Literal, cast
 
 NDF = NDArray[float64]
 
@@ -66,6 +67,87 @@ def jit_wald_stat_from_mean_and_cov(
         stat = 0.0
 
     return OK, float64(stat), int64(q)
+
+
+def _wald_stat(
+    mean: NDF, target: NDF, omega: NDF, n: int
+) -> tuple[int64, float64, int64]:
+    """Wald statistic; native Cholesky fast path, numba fallback.
+
+    The native kernel returns ``DIAG_FALLBACK`` when omega is not positive
+    definite, in which case the numba kernel recomputes via its LU fallback
+    (which handles an indefinite-but-nonsingular omega). Shapes are guaranteed by
+    the callers, so the native path is only gated on the extension being present.
+    """
+    q = mean.shape[0]
+    if _native is not None:
+        status, stat = _native.wald_stat_from_mean_and_cov(
+            np.ascontiguousarray(mean, dtype=float64),
+            np.ascontiguousarray(target, dtype=float64),
+            np.ascontiguousarray(omega, dtype=float64),
+            n,
+        )
+        if status != DIAG_FALLBACK:
+            return int64(status), float64(stat), int64(q)
+    nb_err, nb_stat, nb_df = jit_wald_stat_from_mean_and_cov(mean, target, omega, n)
+    return int64(nb_err), float64(nb_stat), int64(nb_df)
+
+
+def _fill_symmetric_target_vec(target: NDF) -> tuple[int64, NDF]:
+    """Pack a symmetric target into its vech vector; native or numba.
+
+    No fallback path: the kernel is a pure copy that returns BAD_SHAPE only on a
+    genuinely asymmetric target (a hard error the caller raises on), so the native
+    branch is used whenever the extension is present.
+    """
+    if _native is not None:
+        status, vec = _native.fill_symmetric_target_vec(
+            np.ascontiguousarray(target, dtype=float64),
+            SYMMETRY_ATOL,
+            SYMMETRY_RTOL,
+        )
+        return int64(status), vec
+    p = target.shape[0]
+    out = np.empty(p * (p + 1) // 2, dtype=float64)
+    err = jit_fill_symmetric_target_vec(target, out)
+    return int64(err), out
+
+
+def _symmetric_outer_prod(x: NDF) -> tuple[int64, NDF]:
+    """Per-row vech of the outer product x_t x_t'; native or numba."""
+    n, p = x.shape
+    if _native is not None:
+        status, out = _native.symmetric_outer_prod_2dim(
+            np.ascontiguousarray(x, dtype=float64)
+        )
+        return int64(status), out
+    out = np.empty((n, p * (p + 1) // 2), dtype=float64)
+    err = jit_symmetric_outer_prod_2dim(x, out)
+    return int64(err), out
+
+
+def _fill_mean_ax0(x: NDF) -> NDF:
+    """Column means of x over axis 0; native or numba (no JIT cost when native)."""
+    if _native is not None:
+        return cast(NDF, _native.fill_mean_ax0(np.ascontiguousarray(x, dtype=float64)))
+    mean = np.empty(x.shape[1], dtype=float64)
+    jit_fill_mean_ax0(x, mean)
+    return mean
+
+
+def _fill_centered_ax0(x: NDF, mean: NDF) -> NDF:
+    """x with its column means subtracted; native or numba."""
+    if _native is not None:
+        return cast(
+            NDF,
+            _native.fill_centered_ax0(
+                np.ascontiguousarray(x, dtype=float64),
+                np.ascontiguousarray(mean, dtype=float64),
+            ),
+        )
+    centered = np.empty_like(x)
+    jit_fill_centered(x, mean, centered)
+    return centered
 
 
 @njit(cache=True)
@@ -150,12 +232,10 @@ def wald_mean_hac(
 
     g_arr = np.ascontiguousarray(g, dtype=float64)
     target_arr = np.ascontiguousarray(target, dtype=float64)
-    n, q = g_arr.shape
+    n = g_arr.shape[0]
 
-    mean_buffer = np.empty(q, dtype=float64)
-    centered_buffer = np.empty_like(g_arr)
-    jit_fill_mean_ax0(g_arr, mean_buffer)
-    jit_fill_centered(g_arr, mean_buffer, centered_buffer)
+    mean_buffer = _fill_mean_ax0(g_arr)
+    centered_buffer = _fill_centered_ax0(g_arr, mean_buffer)
 
     omega = hac_covariance(
         centered_buffer,
@@ -164,7 +244,7 @@ def wald_mean_hac(
         center=False,
         nopython=True,
     )
-    out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
+    out: tuple[int64, float64, int64] = _wald_stat(
         mean_buffer,
         target_arr,
         omega,
@@ -220,29 +300,21 @@ def wald_covariance_hac(
     if target_arr.shape[0] != g_arr.shape[1]:
         raise ValueError("Target covariance matrix dimension must match g columns")
 
-    n, p = g_arr.shape
-    q = p * (p + 1) // 2
-    target_vec = np.empty(q, dtype=float64)
-    err = jit_fill_symmetric_target_vec(target_arr, target_vec)
+    err, target_vec = _fill_symmetric_target_vec(target_arr)
     if err != OK:
         raise ValueError("Target covariance matrix must be symmetric")
 
-    centered = np.empty_like(g_arr)
-    mean = np.empty(p, dtype=float64)
-    jit_fill_mean_ax0(g_arr, mean)
-    jit_fill_centered(g_arr, mean, centered)
+    mean = _fill_mean_ax0(g_arr)
+    centered = _fill_centered_ax0(g_arr, mean)
 
-    g_cov = np.empty((n, q), dtype=float64)
-    err = jit_symmetric_outer_prod_2dim(centered, g_cov)
+    err, g_cov = _symmetric_outer_prod(centered)
     if err != OK:
         raise ValueError(
             f"Failed to compute symmetric outer product with error code {err}"
         )
 
-    g_cov_mean = np.empty(q, dtype=float64)
-    g_cov_centered = np.empty_like(g_cov)
-    jit_fill_mean_ax0(g_cov, g_cov_mean)
-    jit_fill_centered(g_cov, g_cov_mean, g_cov_centered)
+    g_cov_mean = _fill_mean_ax0(g_cov)
+    g_cov_centered = _fill_centered_ax0(g_cov, g_cov_mean)
 
     omega = hac_covariance(
         g_cov_centered,
@@ -252,7 +324,7 @@ def wald_covariance_hac(
         nopython=True,
     )
 
-    out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
+    out: tuple[int64, float64, int64] = _wald_stat(
         g_cov_mean,
         target_vec,
         omega,
@@ -308,28 +380,18 @@ def wald_second_moment_hac(
     if target_arr.shape[0] != g_arr.shape[1]:
         raise ValueError("Target second moment matrix dimension must match g columns")
 
-    n, p = g_arr.shape
-    q = p * (p + 1) // 2
-    target_vec = np.empty(q, dtype=float64)
-    err = jit_fill_symmetric_target_vec(target_arr, target_vec)
+    err, target_vec = _fill_symmetric_target_vec(target_arr)
     if err != OK:
         raise ValueError("Target second moment matrix must be symmetric")
 
-    g_second_moment = np.empty((n, q), dtype=float64)
-    err = jit_symmetric_outer_prod_2dim(g_arr, g_second_moment)
+    err, g_second_moment = _symmetric_outer_prod(g_arr)
     if err != OK:
         raise ValueError(
             f"Failed to compute symmetric outer product with error code {err}"
         )
 
-    g_second_moment_mean = np.empty(q, dtype=float64)
-    g_second_moment_centered = np.empty_like(g_second_moment)
-    jit_fill_mean_ax0(g_second_moment, g_second_moment_mean)
-    jit_fill_centered(
-        g_second_moment,
-        g_second_moment_mean,
-        g_second_moment_centered,
-    )
+    g_second_moment_mean = _fill_mean_ax0(g_second_moment)
+    g_second_moment_centered = _fill_centered_ax0(g_second_moment, g_second_moment_mean)
 
     omega = hac_covariance(
         g_second_moment_centered,
@@ -339,7 +401,7 @@ def wald_second_moment_hac(
         nopython=True,
     )
 
-    out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
+    out: tuple[int64, float64, int64] = _wald_stat(
         g_second_moment_mean,
         target_vec,
         omega,

--- a/SymbolicDSGE/_diag_tests/wald_test.py
+++ b/SymbolicDSGE/_diag_tests/wald_test.py
@@ -1,4 +1,4 @@
-from .hac_covariance import jit_hac_estimator_matmul, hac_covariance
+from .hac_covariance import hac_covariance
 from .moment_calculation_utils import jit_fill_centered, jit_fill_mean_ax0
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 
 from numba import njit
 
-from typing import Callable, Literal
+from typing import Literal
 
 NDF = NDArray[float64]
 
@@ -53,67 +53,6 @@ def jit_wald_stat_from_mean_and_cov(
         stat = 0.0
 
     return OK, float64(stat), int64(q)
-
-
-@njit(cache=True)
-def jit_wald_hac_stat(
-    g: NDF,
-    target: NDF,
-    k: Callable[[int, int], float64],
-    L: int,
-    mean_buffer: NDF,
-    centered_buffer: NDF,
-    omega_buffer: NDF,
-) -> tuple[int64, float64, int64]:
-    """
-    Generic HAC-robust Wald statistic for H0: E[g_t] = target.
-
-    Parameters
-    ----------
-    g:
-        Moment array with shape (n, q).
-    target:
-        Target vector with shape (q,).
-    k:
-        Numba-compatible HAC kernel.
-    L:
-        HAC bandwidth.
-    mean_buf:
-        Work buffer with shape (q,).
-    centered_buf:
-        Work buffer with shape (n, q).
-    omega_buf:
-        Work buffer with shape (q, q).
-
-    Returns
-    -------
-    err:
-        0 if successful, negative error code otherwise.
-    statistic:
-        Wald statistic.
-    df:
-        Chi-square degrees of freedom.
-    """
-    n, q = g.shape
-
-    if target.shape[0] != q:
-        return ERR_BAD_SHAPE, F64_NAN, q
-
-    jit_fill_mean_ax0(g, mean_buffer)
-    jit_fill_centered(g, mean_buffer, centered_buffer)
-
-    omega = jit_hac_estimator_matmul(centered_buffer, k, L)
-    for i in range(q):
-        for j in range(q):
-            omega_buffer[i, j] = omega[i, j]
-
-    out: tuple[int64, float64, int64] = jit_wald_stat_from_mean_and_cov(
-        mean_buffer,
-        target,
-        omega_buffer,
-        n,
-    )
-    return out
 
 
 @njit(cache=True)

--- a/SymbolicDSGE/_diag_tests/wald_test.py
+++ b/SymbolicDSGE/_diag_tests/wald_test.py
@@ -3,9 +3,11 @@ from .moment_calculation_utils import jit_fill_centered, jit_fill_mean_ax0
 from .result import TestResult
 from .distributions import PvalMethod, ReferenceDistribution
 from .status import TestStatus
+from ..regression.solvers import _gram_is_pd
 import numpy as np
 from numpy import float64, int64
 from numpy.typing import NDArray
+from numpy.linalg import cholesky, solve
 
 from numba import njit
 
@@ -39,10 +41,21 @@ def jit_wald_stat_from_mean_and_cov(
     for i in range(q):
         dev[i] = mean[i] - target[i]
 
-    try:
-        solved = np.linalg.solve(omega, dev)
-    except Exception:
-        return ERR_LINALG, F64_NAN, int64(q)
+    # Cholesky on the PD fast path -- same algorithm as the native
+    # sdsge_chol_solve, so native parity is same-algorithm rather than
+    # Cholesky-vs-LU. LU (np.linalg.solve) is kept only as the fallback for an
+    # indefinite-but-nonsingular omega. The PD gate is the deterministic
+    # relative-threshold check shared with the native sdsge_chol; relying on
+    # np.linalg.cholesky to raise is not reliably catchable in nopython mode.
+    if _gram_is_pd(omega):
+        L = cholesky(omega)
+        z = solve(L, dev)
+        solved = solve(L.T, z)
+    else:
+        try:
+            solved = solve(omega, dev)
+        except Exception:
+            return ERR_LINALG, F64_NAN, int64(q)
 
     stat = 0.0
     for i in range(q):

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -216,3 +216,89 @@ def test_hac_estimator_parity(kernel_id, shape, lags):
     native = diag.hac_estimator_matmul(r, kernel_id, lags)
     ref = jit_hac_estimator_matmul(r, kernel_id, lags)
     np.testing.assert_allclose(native, ref, rtol=RTOL, atol=ATOL)
+
+
+# ---------------------------------------------------------------- Wald helpers
+
+from SymbolicDSGE._diag_tests.wald_test import (  # noqa: E402
+    jit_fill_symmetric_target_vec,
+    jit_symmetric_outer_prod_2dim,
+    jit_wald_stat_from_mean_and_cov,
+)
+
+
+@pytest.mark.parametrize("q", [1, 2, 5])
+def test_wald_stat_parity(q):
+    """Native Wald statistic matches numba on a positive-definite omega."""
+    rng = np.random.default_rng([q, 11])
+    mean = np.ascontiguousarray(rng.standard_normal(q))
+    target = np.ascontiguousarray(rng.standard_normal(q))
+    m = rng.standard_normal((q, q))
+    omega = np.ascontiguousarray(m @ m.T + q * np.eye(q))  # SPD, well-conditioned
+    ns, nstat = diag.wald_stat_from_mean_and_cov(mean, target, omega, 100)
+    rs, rstat, rdf = jit_wald_stat_from_mean_and_cov(mean, target, omega, 100)
+    assert ns == rs == 0
+    assert rdf == q
+    assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_wald_stat_fallback_on_non_pd():
+    """A non-PD omega makes the native Cholesky path signal DIAG_FALLBACK."""
+    q = 3
+    mean = np.ascontiguousarray(np.ones(q))
+    target = np.ascontiguousarray(np.zeros(q))
+    omega = np.zeros((q, q), dtype=np.float64)
+    assert diag.wald_stat_from_mean_and_cov(mean, target, omega, 50)[0] == diag.FALLBACK
+
+
+@pytest.mark.parametrize("shape", [(10, 1), (20, 3), (15, 4)])
+def test_symmetric_outer_prod_parity(shape):
+    """Native per-row vech outer product matches numba."""
+    n, p = shape
+    rng = np.random.default_rng([n, p])
+    x = np.ascontiguousarray(rng.standard_normal((n, p)))
+    ns, nout = diag.symmetric_outer_prod_2dim(x)
+    rout = np.empty((n, p * (p + 1) // 2), dtype=np.float64)
+    rs = jit_symmetric_outer_prod_2dim(x, rout)
+    assert ns == rs == 0
+    np.testing.assert_allclose(nout, rout, rtol=RTOL, atol=ATOL)
+
+
+def test_fill_symmetric_target_vec_parity():
+    """Native vech packing matches numba; asymmetric input is rejected."""
+    rng = np.random.default_rng(99)
+    p = 4
+    a = rng.standard_normal((p, p))
+    sym = np.ascontiguousarray(a + a.T)
+    ns, nvec = diag.fill_symmetric_target_vec(sym, 1e-8, 1e-5)
+    rvec = np.empty(p * (p + 1) // 2, dtype=np.float64)
+    rs = jit_fill_symmetric_target_vec(sym, rvec)
+    assert ns == rs == 0
+    np.testing.assert_allclose(nvec, rvec, rtol=RTOL, atol=ATOL)
+
+    asym = np.ascontiguousarray(np.array([[1.0, 0.1], [0.2, 1.0]]))
+    assert diag.fill_symmetric_target_vec(asym, 1e-8, 1e-5)[0] != 0
+
+
+from SymbolicDSGE._diag_tests.moment_calculation_utils import (  # noqa: E402
+    jit_fill_centered,
+    jit_fill_mean_ax0,
+)
+
+
+@pytest.mark.parametrize("shape", [(10, 1), (20, 3), (50, 4)])
+def test_fill_mean_and_centered_parity(shape):
+    """Native column-mean and centering match numba (bit-exact loops)."""
+    n, p = shape
+    rng = np.random.default_rng([n, p, 7])
+    x = np.ascontiguousarray(rng.standard_normal((n, p)))
+
+    nmean = diag.fill_mean_ax0(x)
+    rmean = np.empty(p, dtype=np.float64)
+    jit_fill_mean_ax0(x, rmean)
+    np.testing.assert_allclose(nmean, rmean, rtol=RTOL, atol=ATOL)
+
+    ncentered = diag.fill_centered_ax0(x, nmean)
+    rcentered = np.empty((n, p), dtype=np.float64)
+    jit_fill_centered(x, rmean, rcentered)
+    np.testing.assert_allclose(ncentered, rcentered, rtol=RTOL, atol=ATOL)

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -151,3 +151,68 @@ def test_rank_deficient_dispatch_matches_numba():
     _same_result(bg_mod.bg_stat(eps, X, 2), bg_mod._bg_stat_numba(eps, X, 2))
     _same_result(bp_mod.bp_stat(eps, X), bp_mod._bp_stat_numba(eps, X))
     _same_result(chow_mod._chow_stat(y, X, 80), chow_mod._chow_stat_numba(y, X, 80))
+
+
+# ---------------------------------------------------------------- HAC estimator
+
+from SymbolicDSGE._diag_tests.hac_covariance import (  # noqa: E402
+    _BARTLETT,
+    _PARZEN,
+    _QS,
+    jit_hac_estimator_matmul,
+)
+
+# Golden HAC long-run covariances for the centered design below at bandwidth 2,
+# mirroring tests/diag_tests/test_hac_covariance.py::GOLDEN_HAC_CENTERED. These
+# anchor the native kernel to the same absolute values the numba side is pinned
+# to, rather than relying only on transitivity through the parity sweep below.
+_HAC_GOLDEN_R = np.array(
+    [[1.0, 2.0], [2.0, -1.0], [0.0, 1.0], [3.0, 0.0], [-1.0, 2.0]],
+    dtype=np.float64,
+)
+_HAC_GOLDEN = {
+    _BARTLETT: np.array(
+        [
+            [0.6666666666666667, -0.5599999999999998],
+            [-0.5599999999999998, 0.6453333333333331],
+        ],
+        dtype=np.float64,
+    ),
+    _PARZEN: np.array(
+        [
+            [0.5629629629629630, -0.3733333333333333],
+            [-0.3733333333333333, 0.6079999999999999],
+        ],
+        dtype=np.float64,
+    ),
+    _QS: np.array(
+        [
+            [0.4104387018488457, -0.4840134757411693],
+            [-0.4840134757411693, 0.5017280910104844],
+        ],
+        dtype=np.float64,
+    ),
+}
+
+
+@pytest.mark.parametrize("kernel_id", [_BARTLETT, _PARZEN, _QS])
+def test_hac_estimator_matches_golden(kernel_id):
+    """Native HAC long-run covariance matches the pinned golden fixtures (an
+    absolute anchor independent of the numba reference)."""
+    centered = np.ascontiguousarray(_HAC_GOLDEN_R - _HAC_GOLDEN_R.mean(axis=0))
+    out = diag.hac_estimator_matmul(centered, kernel_id, 2)
+    np.testing.assert_allclose(out, _HAC_GOLDEN[kernel_id], rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("kernel_id", [_BARTLETT, _PARZEN, _QS])
+@pytest.mark.parametrize("shape", [(160, 3), (200, 2), (80, 4), (50, 1)])
+@pytest.mark.parametrize("lags", [0, 1, 4, 9])
+def test_hac_estimator_parity(kernel_id, shape, lags):
+    """Native HAC matches the numba jit_hac_estimator_matmul across kernels,
+    bandwidths, and shapes -- broad coverage beyond the golden fixtures."""
+    n, p = shape
+    rng = np.random.default_rng([kernel_id, n, p, lags])
+    r = np.ascontiguousarray(rng.standard_normal((n, p)))
+    native = diag.hac_estimator_matmul(r, kernel_id, lags)
+    ref = jit_hac_estimator_matmul(r, kernel_id, lags)
+    np.testing.assert_allclose(native, ref, rtol=RTOL, atol=ATOL)

--- a/tests/diag_tests/test_hac_covariance.py
+++ b/tests/diag_tests/test_hac_covariance.py
@@ -4,15 +4,15 @@ import numpy as np
 import pytest
 
 from SymbolicDSGE._diag_tests.hac_covariance import (
+    _BARTLETT,
+    _PARZEN,
+    _QS,
+    _kernel_weight,
     andrews_bandwidth,
     andrews_bandwidth_matrix,
-    bartlett_kernel,
     hac_covariance,
     jit_hac_estimator_matmul,
-    kernel_dispatcher,
-    parzen_kernel,
     py_hac_estimator,
-    quadratic_spectral_kernel,
     wooldridge_bandwidth,
 )
 
@@ -88,7 +88,7 @@ def test_andrews_bandwidth_matrix_handles_negative_rhat_columns() -> None:
     series = np.array([(-1.0) ** i for i in range(20)], dtype=np.float64)
     r = np.column_stack([series])
 
-    assert andrews_bandwidth_matrix(r, kernel="qs") == 1
+    assert andrews_bandwidth_matrix(r, kernel_id=_QS) == 1
     out = hac_covariance(r, kernel="qs", bandwidth="auto", nopython=False)
 
     assert out.shape == (1, 1)
@@ -119,19 +119,18 @@ def test_hac_covariance_raises_on_bad_bandwidth() -> None:
         hac_covariance(GOLDEN_R, bandwidth="bad")
 
 
-def test_kernel_functions_and_dispatcher_cover_boundary_branches() -> None:
-    assert bartlett_kernel(3, 2) == np.float64(0.0)
-    assert bartlett_kernel(1, 2) == pytest.approx(2.0 / 3.0)
+def test_kernel_weight_covers_boundary_branches() -> None:
+    w = _kernel_weight.py_func
 
-    assert parzen_kernel(4, 2) == np.float64(0.0)
-    assert parzen_kernel(1, 3) == pytest.approx(1.0 - 6.0 * 0.25**2 + 6.0 * 0.25**3)
-    assert parzen_kernel(2, 2) == pytest.approx(2.0 * (1.0 / 3.0) ** 3)
+    assert w(3, 2, _BARTLETT) == np.float64(0.0)
+    assert w(1, 2, _BARTLETT) == pytest.approx(2.0 / 3.0)
 
-    assert quadratic_spectral_kernel(0, 2) == pytest.approx(1.0)
-    assert np.isfinite(quadratic_spectral_kernel(1, 2))
+    assert w(4, 2, _PARZEN) == np.float64(0.0)
+    assert w(1, 3, _PARZEN) == pytest.approx(1.0 - 6.0 * 0.25**2 + 6.0 * 0.25**3)
+    assert w(2, 2, _PARZEN) == pytest.approx(2.0 * (1.0 / 3.0) ** 3)
 
-    assert kernel_dispatcher("bartlett", nopython=False) is bartlett_kernel
-    assert callable(kernel_dispatcher("bartlett", nopython=True))
+    assert w(0, 2, _QS) == pytest.approx(1.0)
+    assert np.isfinite(w(1, 2, _QS))
 
 
 def test_hac_covariance_covers_auto_and_explicit_selection_branches() -> None:
@@ -161,20 +160,20 @@ def test_hac_covariance_covers_auto_and_explicit_selection_branches() -> None:
     assert out_none.shape == (2, 2)
     assert out_wide.shape == (9, 9)
     np.testing.assert_allclose(
-        py_hac_estimator(GOLDEN_R, bartlett_kernel, 0),
+        py_hac_estimator(GOLDEN_R, _BARTLETT, 0),
         GOLDEN_R.T @ GOLDEN_R / GOLDEN_R.shape[0],
     )
 
 
 def test_hac_jit_matmul_python_path_matches_py_estimator() -> None:
-    expected = py_hac_estimator(GOLDEN_R, bartlett_kernel, 2)
-    matmul_out = jit_hac_estimator_matmul.py_func(GOLDEN_R, bartlett_kernel, 2)
+    expected = py_hac_estimator(GOLDEN_R, _BARTLETT, 2)
+    matmul_out = jit_hac_estimator_matmul.py_func(GOLDEN_R, _BARTLETT, 2)
 
     np.testing.assert_allclose(matmul_out, expected)
 
 
 def test_andrews_bandwidth_matrix_validates_shape_and_accepts_vectors() -> None:
-    assert andrews_bandwidth_matrix(GOLDEN_R[:, 0], kernel="bartlett") >= 1
+    assert andrews_bandwidth_matrix(GOLDEN_R[:, 0], kernel_id=_BARTLETT) >= 1
 
     with pytest.raises(ValueError, match="1D or 2D"):
         andrews_bandwidth_matrix(np.zeros((1, 2, 3), dtype=np.float64))

--- a/tests/diag_tests/test_wald_test.py
+++ b/tests/diag_tests/test_wald_test.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 import numpy as np
 
 from SymbolicDSGE._diag_tests.distributions import PvalMethod
-from SymbolicDSGE._diag_tests.hac_covariance import (
-    kernel_dispatcher,
-    wooldridge_bandwidth,
-)
 from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE._diag_tests.moment_calculation_utils import (
     jit_fill_centered,
@@ -17,7 +13,6 @@ from SymbolicDSGE._diag_tests.wald_test import (
     ERR_LINALG,
     OK,
     jit_fill_symmetric_target_vec,
-    jit_wald_hac_stat,
     jit_symmetric_outer_prod_2dim,
     jit_wald_stat_from_mean_and_cov,
     wald_covariance_hac,
@@ -76,45 +71,6 @@ def _quadratic_sample() -> np.ndarray:
             dtype=np.float64,
         )
     )
-
-
-def test_jit_wald_hac_stat_matches_manual_statistic() -> None:
-    g = np.ascontiguousarray(
-        np.array(
-            [
-                [1.0, 2.0],
-                [2.0, -1.0],
-                [0.0, 1.0],
-                [3.0, 0.0],
-                [-1.0, 2.0],
-            ],
-            dtype=np.float64,
-        )
-    )
-    target = np.zeros(2, dtype=np.float64)
-    mean_buffer = np.empty(2, dtype=np.float64)
-    centered_buffer = np.empty_like(g)
-    omega_buffer = np.empty((2, 2), dtype=np.float64)
-    bandwidth = wooldridge_bandwidth(g)
-
-    err, stat, df = jit_wald_hac_stat.py_func(
-        g,
-        target,
-        kernel_dispatcher("bartlett"),
-        bandwidth,
-        mean_buffer,
-        centered_buffer,
-        omega_buffer,
-    )
-    manual_mean = g.mean(axis=0)
-    manual_centered = g - manual_mean
-    manual_omega = _manual_bartlett_hac(manual_centered, bandwidth)
-    manual_stat = g.shape[0] * manual_mean @ np.linalg.solve(manual_omega, manual_mean)
-
-    assert err == OK
-    assert OK == TestStatus.OK
-    assert df == 2
-    assert np.isclose(stat, manual_stat)
 
 
 def test_wald_mean_hac_uses_right_tail_p_value_method() -> None:
@@ -215,29 +171,6 @@ def test_wald_quadratic_hac_rejects_target_dimension_mismatch() -> None:
 
     with np.testing.assert_raises_regex(ValueError, "second moment matrix dimension"):
         wald_second_moment_hac(g, target, bandwidth=0)
-
-
-def test_jit_wald_hac_stat_returns_shape_error_for_bad_target() -> None:
-    g = np.ascontiguousarray(np.ones((5, 2), dtype=np.float64))
-    target = np.zeros(3, dtype=np.float64)
-    mean_buffer = np.empty(2, dtype=np.float64)
-    centered_buffer = np.empty_like(g)
-    omega_buffer = np.empty((2, 2), dtype=np.float64)
-
-    err, stat, df = jit_wald_hac_stat.py_func(
-        g,
-        target,
-        kernel_dispatcher("bartlett"),
-        0,
-        mean_buffer,
-        centered_buffer,
-        omega_buffer,
-    )
-
-    assert err == ERR_BAD_SHAPE
-    assert ERR_BAD_SHAPE == TestStatus.BAD_SHAPE
-    assert np.isnan(stat)
-    assert df == 2
 
 
 def test_jit_wald_stat_from_mean_and_cov_returns_shape_error_for_bad_target() -> None:

--- a/tests/diag_tests/test_wald_test.py
+++ b/tests/diag_tests/test_wald_test.py
@@ -52,7 +52,10 @@ def _quadratic_wald_stat(
     centered_moments = quadratic_moments - mean
     omega = _manual_bartlett_hac(centered_moments, bandwidth)
     dev = mean - target[vech_idx]
-    return float(g.shape[0] * dev @ np.linalg.solve(omega, dev))
+    # Match the production Cholesky solve so the oracle stays same-algorithm.
+    L = np.linalg.cholesky(omega)
+    solved = np.linalg.solve(L.T, np.linalg.solve(L, dev))
+    return float(g.shape[0] * dev @ solved)
 
 
 def _quadratic_sample() -> np.ndarray:


### PR DESCRIPTION
This pull request adds several new statistical linear algebra and diagnostic utilities to the C and Python/Cython backend, mainly for efficient matrix operations and statistical testing. The changes include new C implementations for column means, centering, HAC covariance estimation, Wald statistics, and symmetric matrix packing, along with Python/Cython bindings and exports for these functions.

The most important changes are:

**Statistical and Linear Algebra Utilities:**

* Added new C functions in `diag_wald.c` and `diag_wald.h` for:
  - Computing column means (`sdsge_fill_mean_ax0`), centering matrices (`sdsge_fill_centered_ax0`), HAC covariance estimation (`sdsge_hac_estimator_matmul`), Wald statistic calculation (`sdsge_wald_stat_from_mean_and_cov`), symmetric outer product (`sdsge_symmetric_outer_prod_2dim`), and packing symmetric matrices (`sdsge_fill_symmetric_target_vec`). [[1]](diffhunk://#diff-259606756951868973d570f72e35b8dff49b37c3e5258aac5c934634bdece18cR1-R282) [[2]](diffhunk://#diff-f034b12b946dc44475a48ba886cdbfa45fea5ece7e21f753ae6f753bf0cf2a64R1-R62)
* Exposed these functions to Cython in `diag/_diag.pyx` and provided Python wrappers for easy use from Python. [[1]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0R35-R64) [[2]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0R153-R244)
* Added corresponding type annotations in `diag/_diag.pyi` for the new functions.
* Updated the Python `__init__.py` to export the new functions.

**Matrix and Sorting Primitives:**

* Added new matrix multiplication variant (`sdsge_matmul_atb`) and in-place min/max utilities for `i64` and `f64` in the common C backend, with header and implementation updates. [[1]](diffhunk://#diff-949e9e5f1b867f996dd79454aeb9a58d9836406ccef965734a5f71717e9caabeR34-R49) [[2]](diffhunk://#diff-f3f797a9a16b8ebf3c36a8fd8e97ef2db34fd1fe724dd8c3da1e3b7e80f3dc26R32-R47) [[3]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adR22-R29)
* Added in-place sorting and median computation for `f64` arrays in the C backend, with header and implementation updates. [[1]](diffhunk://#diff-949e9e5f1b867f996dd79454aeb9a58d9836406ccef965734a5f71717e9caabeR238-R257) [[2]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adR82-R90)

**Other Infrastructure:**

* Added a definition for `PI` in the common C header for use in kernel functions.
* Included necessary headers and improved code comments/documentation for clarity and maintainability. [[1]](diffhunk://#diff-949e9e5f1b867f996dd79454aeb9a58d9836406ccef965734a5f71717e9caabeR4) [[2]](diffhunk://#diff-f034b12b946dc44475a48ba886cdbfa45fea5ece7e21f753ae6f753bf0cf2a64R1-R62)

These changes provide efficient, reusable building blocks for statistical tests and matrix operations, and make them available in both C and Python environments.

closes #220  