### PR TITLE
Add native Ljung-Box diagnostics and expose acorr/lb_stat

### DIFF
--- a/SymbolicDSGE/_ckernels/diag/__init__.py
+++ b/SymbolicDSGE/_ckernels/diag/__init__.py
@@ -7,6 +7,7 @@ fall back to their numba kernels.
 
 from ._diag import (
     FALLBACK as FALLBACK,
+    acorr as acorr,
     bg_stat as bg_stat,
     bp_aux as bp_aux,
     chow_stat as chow_stat,
@@ -17,6 +18,7 @@ from ._diag import (
     fill_mean_ax0 as fill_mean_ax0,
     fill_symmetric_target_vec as fill_symmetric_target_vec,
     hac_estimator_matmul as hac_estimator_matmul,
+    lb_stat as lb_stat,
     recursive_residuals as recursive_residuals,
     symmetric_outer_prod_2dim as symmetric_outer_prod_2dim,
     wald_stat_from_mean_and_cov as wald_stat_from_mean_and_cov,

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -37,6 +37,12 @@ def cusum_stat(y: _F64, X: _F64) -> tuple[int, float]:
 def cusumsq_stat(y: _F64, X: _F64) -> tuple[int, int, float]:
     """CUSUM-of-squares statistic. Returns (status, n, stat)."""
 
+def acorr(x: _F64, L: int) -> tuple[int, _F64]:
+    """Autocorrelation of x up to lag L. Returns (status, out(L+1))."""
+
+def lb_stat(x: _F64, L: int) -> tuple[int, float]:
+    """Ljung-Box statistic for x up to lag L. Returns (status, stat)."""
+
 def fill_mean_ax0(x: _F64) -> _F64:
     """Column means of x over axis 0. Returns mean(p)."""
 

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -30,8 +30,11 @@ cdef extern from "diag.h":
                          int64_t p, double *stat_out) nogil
     int sdsge_cusumsq_stat(const double *y, const double *X, int64_t T,
                            int64_t p, int64_t *n_out, double *stat_out) nogil
-
-
+    int sdsge_acorr(const double *x, const int64_t n, const int64_t L,
+                    double *z_scratch, double *out) nogil
+    int sdsge_lb_stat(const double *x, const int64_t n, int64_t L,
+                      double *z_scratch, double *acorr_scratch,
+                      double *out) nogil
 cdef extern from "diag_wald.h":
     ctypedef enum KernelID:
         BARTLETT
@@ -150,6 +153,46 @@ def cusumsq_stat(double[::1] y, double[:, ::1] X):
     with nogil:
         status = sdsge_cusumsq_stat(&y[0], &X[0, 0], T, p, &n, &stat)
     return status, n, stat
+
+
+def acorr(double[::1] x, int64_t L):
+    """Autocorrelation of x up to lag L. Returns (status, out(L+1)).
+
+    Mirrors the numba ``acorr`` (no L/n clamping here); ``out`` is length L+1 and
+    z_scratch is length n. status is DIAG_UDEF_VARIANCE for a constant series.
+    """
+    cdef int64_t n = x.shape[0]
+    out = np.empty(L + 1, dtype=np.float64)
+    z = np.empty(n, dtype=np.float64)
+    cdef double[::1] out_mv = out
+    cdef double[::1] z_mv = z
+    cdef double *x_ptr = &x[0] if n > 0 else NULL
+    cdef double *z_ptr = &z_mv[0] if n > 0 else NULL
+    cdef int status
+    with nogil:
+        status = sdsge_acorr(x_ptr, n, L, z_ptr, &out_mv[0])
+    return status, out
+
+
+def lb_stat(double[::1] x, int64_t L):
+    """Ljung-Box statistic for x up to lag L. Returns (status, stat).
+
+    The kernel clamps L to n-1 and validates n/L internally; the two length-n
+    scratch buffers cover the clamped lag (L_eff <= n-1, so L_eff+1 <= n).
+    """
+    cdef int64_t n = x.shape[0]
+    cdef double stat = 0.0
+    cdef int status
+    z = np.empty(n, dtype=np.float64)
+    rho = np.empty(n, dtype=np.float64)
+    cdef double[::1] z_mv = z
+    cdef double[::1] rho_mv = rho
+    cdef double *x_ptr = &x[0] if n > 0 else NULL
+    cdef double *z_ptr = &z_mv[0] if n > 0 else NULL
+    cdef double *rho_ptr = &rho_mv[0] if n > 0 else NULL
+    with nogil:
+        status = sdsge_lb_stat(x_ptr, n, L, z_ptr, rho_ptr, &stat)
+    return status, stat
 
 
 def hac_estimator_matmul(double[:, ::1] r, int kernel_id, int64_t L):

--- a/SymbolicDSGE/_ckernels/diag/diag.c
+++ b/SymbolicDSGE/_ckernels/diag/diag.c
@@ -4,379 +4,474 @@
 
 /* Breusch-Godfrey: regress eps on [1 | X | lagged eps], statistic n * R^2 (no
  * intercept removal -- TSS is sum(eps^2), matching the numba kernel). */
-int sdsge_bg_stat(const f64 *eps, const f64 *X, i64 n, i64 K, i64 lags,
-                  f64 *stat_out) {
-    if (n <= lags) {
-        *stat_out = NAN;
-        return DIAG_INSUFFICIENT_SAMPLES;
-    }
+int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
+                  i64 n, i64 K, i64 lags, f64 *SDSGE_RESTRICT stat_out) {
+  if (n <= lags) {
+    *stat_out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
 
-    const i64 p = K + lags + 1; /* intercept + regressors + lagged residuals */
+  const i64 p = K + lags + 1; /* intercept + regressors + lagged residuals */
 
-    /* arena: design(n*p) + G(p*p) + L(p*p) + g(p) + coef(p) */
-    const i64 total = n * p + 2 * p * p + 2 * p;
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return DIAG_LINALG;
-    f64 *ptr = arena;
-    f64 *design = ptr; ptr += n * p;
-    f64 *G = ptr; ptr += p * p;
-    f64 *L = ptr; ptr += p * p;
-    f64 *g = ptr; ptr += p;
-    f64 *coef = ptr; ptr += p;
+  /* arena: design(n*p) + G(p*p) + L(p*p) + g(p) + coef(p) */
+  const i64 total = n * p + 2 * p * p + 2 * p;
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return DIAG_LINALG;
+  f64 *ptr = arena;
+  f64 *design = ptr;
+  ptr += n * p;
+  f64 *G = ptr;
+  ptr += p * p;
+  f64 *L = ptr;
+  ptr += p * p;
+  f64 *g = ptr;
+  ptr += p;
+  f64 *coef = ptr;
+  ptr += p;
 
-    /* Build the design row by row: [1, X[r, :], eps[r-1], ..., eps[r-lags]]. */
-    for (i64 r = 0; r < n; ++r) {
-        f64 *row = design + r * p;
-        row[0] = 1.0;
-        for (i64 j = 0; j < K; ++j)
-            row[1 + j] = X[r * K + j];
-        for (i64 lag = 1; lag <= lags; ++lag)
-            row[K + lag] = (r >= lag) ? eps[r - lag] : 0.0;
-    }
+  /* Build the design row by row: [1, X[r, :], eps[r-1], ..., eps[r-lags]]. */
+  for (i64 r = 0; r < n; ++r) {
+    f64 *row = design + r * p;
+    row[0] = 1.0;
+    for (i64 j = 0; j < K; ++j)
+      row[1 + j] = X[r * K + j];
+    for (i64 lag = 1; lag <= lags; ++lag)
+      row[K + lag] = (r >= lag) ? eps[r - lag] : 0.0;
+  }
 
-    sdsge_gram(design, G, n, p);
-    sdsge_gram_rhs(design, eps, g, n, p);
-    if (sdsge_chol_solve(G, g, coef, L, p) != SDSGE_OK) {
-        free(arena);
-        return DIAG_FALLBACK;
-    }
-
-    f64 rss = 0.0, tss = 0.0;
-    for (i64 r = 0; r < n; ++r) {
-        const f64 *row = design + r * p;
-        f64 fit = 0.0;
-        for (i64 j = 0; j < p; ++j)
-            fit += row[j] * coef[j];
-        f64 resid = eps[r] - fit;
-        rss += resid * resid;
-        tss += eps[r] * eps[r];
-    }
-
-    *stat_out = (tss > 0.0) ? (f64)n * (1.0 - rss / tss) : 0.0;
+  sdsge_gram(design, G, n, p);
+  sdsge_gram_rhs(design, eps, g, n, p);
+  if (sdsge_chol_solve(G, g, coef, L, p) != SDSGE_OK) {
     free(arena);
-    return DIAG_OK;
+    return DIAG_FALLBACK;
+  }
+
+  f64 rss = 0.0, tss = 0.0;
+  for (i64 r = 0; r < n; ++r) {
+    const f64 *row = design + r * p;
+    f64 fit = 0.0;
+    for (i64 j = 0; j < p; ++j)
+      fit += row[j] * coef[j];
+    f64 resid = eps[r] - fit;
+    rss += resid * resid;
+    tss += eps[r] * eps[r];
+  }
+
+  *stat_out = (tss > 0.0) ? (f64)n * (1.0 - rss / tss) : 0.0;
+  free(arena);
+  return DIAG_OK;
 }
 
 /* Breusch-Pagan auxiliary regression of the scaled squared residuals on X_aug.
  * Returns the fit's RSS and centered TSS; the caller shapes them into bp_stat /
  * robust_bp_stat. */
-int sdsge_bp_aux(const f64 *eps, const f64 *X_aug, i64 n, i64 p, f64 *rss_out,
-                 f64 *tss_out) {
-    if (n == 0)
-        return DIAG_INSUFFICIENT_SAMPLES;
+int sdsge_bp_aux(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X_aug,
+                 i64 n, i64 p, f64 *SDSGE_RESTRICT rss_out,
+                 f64 *SDSGE_RESTRICT tss_out) {
+  if (n == 0)
+    return DIAG_INSUFFICIENT_SAMPLES;
 
-    /* sigma2 = mean(eps^2); g = eps^2 / sigma2. */
-    f64 sum_sq = 0.0;
-    for (i64 r = 0; r < n; ++r)
-        sum_sq += eps[r] * eps[r];
-    f64 sigma2 = sum_sq / (f64)n;
-    if (!isfinite(sigma2) || sigma2 <= 0.0)
-        return DIAG_UDEF_VARIANCE;
+  /* sigma2 = mean(eps^2); g = eps^2 / sigma2. */
+  f64 sum_sq = 0.0;
+  for (i64 r = 0; r < n; ++r)
+    sum_sq += eps[r] * eps[r];
+  f64 sigma2 = sum_sq / (f64)n;
+  if (!isfinite(sigma2) || sigma2 <= 0.0)
+    return DIAG_UDEF_VARIANCE;
 
-    /* arena: g(n) + G(p*p) + L(p*p) + rhs(p) + coef(p) */
-    const i64 total = n + 2 * p * p + 2 * p;
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return DIAG_LINALG;
-    f64 *ptr = arena;
-    f64 *gvec = ptr; ptr += n;
-    f64 *G = ptr; ptr += p * p;
-    f64 *L = ptr; ptr += p * p;
-    f64 *rhs = ptr; ptr += p;
-    f64 *coef = ptr; ptr += p;
+  /* arena: g(n) + G(p*p) + L(p*p) + rhs(p) + coef(p) */
+  const i64 total = n + 2 * p * p + 2 * p;
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return DIAG_LINALG;
+  f64 *ptr = arena;
+  f64 *gvec = ptr;
+  ptr += n;
+  f64 *G = ptr;
+  ptr += p * p;
+  f64 *L = ptr;
+  ptr += p * p;
+  f64 *rhs = ptr;
+  ptr += p;
+  f64 *coef = ptr;
+  ptr += p;
 
-    for (i64 r = 0; r < n; ++r)
-        gvec[r] = (eps[r] * eps[r]) / sigma2;
+  for (i64 r = 0; r < n; ++r)
+    gvec[r] = (eps[r] * eps[r]) / sigma2;
 
-    sdsge_gram(X_aug, G, n, p);
-    sdsge_gram_rhs(X_aug, gvec, rhs, n, p);
-    if (sdsge_chol_solve(G, rhs, coef, L, p) != SDSGE_OK) {
-        free(arena);
-        return DIAG_FALLBACK;
-    }
-
-    f64 g_sum = 0.0;
-    for (i64 r = 0; r < n; ++r)
-        g_sum += gvec[r];
-    f64 g_mean = g_sum / (f64)n;
-
-    f64 rss = 0.0, tss = 0.0;
-    for (i64 r = 0; r < n; ++r) {
-        const f64 *row = X_aug + r * p;
-        f64 fit = 0.0;
-        for (i64 j = 0; j < p; ++j)
-            fit += row[j] * coef[j];
-        f64 resid = gvec[r] - fit;
-        rss += resid * resid;
-        f64 centered = gvec[r] - g_mean;
-        tss += centered * centered;
-    }
-
-    *rss_out = rss;
-    *tss_out = tss;
+  sdsge_gram(X_aug, G, n, p);
+  sdsge_gram_rhs(X_aug, gvec, rhs, n, p);
+  if (sdsge_chol_solve(G, rhs, coef, L, p) != SDSGE_OK) {
     free(arena);
-    return DIAG_OK;
+    return DIAG_FALLBACK;
+  }
+
+  f64 g_sum = 0.0;
+  for (i64 r = 0; r < n; ++r)
+    g_sum += gvec[r];
+  f64 g_mean = g_sum / (f64)n;
+
+  f64 rss = 0.0, tss = 0.0;
+  for (i64 r = 0; r < n; ++r) {
+    const f64 *row = X_aug + r * p;
+    f64 fit = 0.0;
+    for (i64 j = 0; j < p; ++j)
+      fit += row[j] * coef[j];
+    f64 resid = gvec[r] - fit;
+    rss += resid * resid;
+    f64 centered = gvec[r] - g_mean;
+    tss += centered * centered;
+  }
+
+  *rss_out = rss;
+  *tss_out = tss;
+  free(arena);
+  return DIAG_OK;
 }
 
 /* Residual sum of squares of the OLS fit of y_seg(rows) on X_seg(rows, p), via
  * the normal equations. Returns SDSGE_OK / SDSGE_NOT_PD. Scratch G/L/g/coef are
  * caller-provided (all length p / p*p). */
-static int chow_segment_rss(const f64 *y_seg, const f64 *X_seg, i64 rows, i64 p,
-                            f64 *G, f64 *L, f64 *g, f64 *coef, f64 *rss_out) {
-    sdsge_gram(X_seg, G, rows, p);
-    sdsge_gram_rhs(X_seg, y_seg, g, rows, p);
-    int status = sdsge_chol_solve(G, g, coef, L, p);
-    if (status != SDSGE_OK)
-        return status;
+static int chow_segment_rss(const f64 *SDSGE_RESTRICT y_seg,
+                            const f64 *SDSGE_RESTRICT X_seg, i64 rows, i64 p,
+                            f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT L,
+                            f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT coef,
+                            f64 *SDSGE_RESTRICT rss_out) {
+  sdsge_gram(X_seg, G, rows, p);
+  sdsge_gram_rhs(X_seg, y_seg, g, rows, p);
+  int status = sdsge_chol_solve(G, g, coef, L, p);
+  if (status != SDSGE_OK)
+    return status;
 
-    f64 rss = 0.0;
-    for (i64 r = 0; r < rows; ++r) {
-        const f64 *row = X_seg + r * p;
-        f64 fit = 0.0;
-        for (i64 j = 0; j < p; ++j)
-            fit += row[j] * coef[j];
-        f64 resid = y_seg[r] - fit;
-        rss += resid * resid;
-    }
-    *rss_out = rss;
-    return SDSGE_OK;
+  f64 rss = 0.0;
+  for (i64 r = 0; r < rows; ++r) {
+    const f64 *row = X_seg + r * p;
+    f64 fit = 0.0;
+    for (i64 j = 0; j < p; ++j)
+      fit += row[j] * coef[j];
+    f64 resid = y_seg[r] - fit;
+    rss += resid * resid;
+  }
+  *rss_out = rss;
+  return SDSGE_OK;
 }
 
-int sdsge_chow_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 t_break,
-                    f64 *stat_out) {
-    if (T <= 2 * p) {
-        *stat_out = NAN;
-        return DIAG_INSUFFICIENT_SAMPLES;
-    }
-    if (t_break <= 0 || t_break >= T) {
-        *stat_out = NAN;
-        return DIAG_BAD_PARAMETER;
-    }
+int sdsge_chow_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                    i64 T, i64 p, i64 t_break, f64 *SDSGE_RESTRICT stat_out) {
+  if (T <= 2 * p) {
+    *stat_out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
+  if (t_break <= 0 || t_break >= T) {
+    *stat_out = NAN;
+    return DIAG_BAD_PARAMETER;
+  }
 
-    /* arena: G(p*p) + L(p*p) + g(p) + coef(p), reused across the three fits. */
-    const i64 total = 2 * p * p + 2 * p;
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return DIAG_LINALG;
-    f64 *ptr = arena;
-    f64 *G = ptr; ptr += p * p;
-    f64 *L = ptr; ptr += p * p;
-    f64 *g = ptr; ptr += p;
-    f64 *coef = ptr; ptr += p;
+  /* arena: G(p*p) + L(p*p) + g(p) + coef(p), reused across the three fits. */
+  const i64 total = 2 * p * p + 2 * p;
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return DIAG_LINALG;
+  f64 *ptr = arena;
+  f64 *G = ptr;
+  ptr += p * p;
+  f64 *L = ptr;
+  ptr += p * p;
+  f64 *g = ptr;
+  ptr += p;
+  f64 *coef = ptr;
+  ptr += p;
 
-    const i64 n1 = t_break;
-    const i64 n2 = T - t_break;
-    f64 rss_c = 0.0, rss_1 = 0.0, rss_2 = 0.0;
+  const i64 n1 = t_break;
+  const i64 n2 = T - t_break;
+  f64 rss_c = 0.0, rss_1 = 0.0, rss_2 = 0.0;
 
-    if (chow_segment_rss(y, X, T, p, G, L, g, coef, &rss_c) != SDSGE_OK ||
-        chow_segment_rss(y, X, n1, p, G, L, g, coef, &rss_1) != SDSGE_OK ||
-        chow_segment_rss(y + n1, X + n1 * p, n2, p, G, L, g, coef, &rss_2)
-            != SDSGE_OK) {
-        free(arena);
-        return DIAG_FALLBACK;
-    }
-
-    f64 num = (rss_c - (rss_1 + rss_2)) / (f64)p;
-    f64 denom = (rss_1 + rss_2) / (f64)(T - 2 * p);
-    *stat_out = num / denom;
+  if (chow_segment_rss(y, X, T, p, G, L, g, coef, &rss_c) != SDSGE_OK ||
+      chow_segment_rss(y, X, n1, p, G, L, g, coef, &rss_1) != SDSGE_OK ||
+      chow_segment_rss(y + n1, X + n1 * p, n2, p, G, L, g, coef, &rss_2) !=
+          SDSGE_OK) {
     free(arena);
-    return DIAG_OK;
+    return DIAG_FALLBACK;
+  }
+
+  f64 num = (rss_c - (rss_1 + rss_2)) / (f64)p;
+  f64 denom = (rss_1 + rss_2) / (f64)(T - 2 * p);
+  *stat_out = num / denom;
+  free(arena);
+  return DIAG_OK;
 }
 
 /* Full-sample OLS residual std (sqrt(SSR / (T-p))) via the normal equations.
  * G/L/g/coef are caller scratch (length p / p*p). Returns SDSGE_OK / NOT_PD. */
-static int ols_residual_sigma(const f64 *y, const f64 *X, i64 T, i64 p,
-                              f64 *G, f64 *L, f64 *g, f64 *coef, f64 *sigma_out) {
-    sdsge_gram(X, G, T, p);
-    sdsge_gram_rhs(X, y, g, T, p);
-    int status = sdsge_chol_solve(G, g, coef, L, p);
-    if (status != SDSGE_OK)
-        return status;
+static int ols_residual_sigma(const f64 *SDSGE_RESTRICT y,
+                              const f64 *SDSGE_RESTRICT X, i64 T, i64 p,
+                              f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT L,
+                              f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT coef,
+                              f64 *SDSGE_RESTRICT sigma_out) {
+  sdsge_gram(X, G, T, p);
+  sdsge_gram_rhs(X, y, g, T, p);
+  int status = sdsge_chol_solve(G, g, coef, L, p);
+  if (status != SDSGE_OK)
+    return status;
 
-    f64 ssr = 0.0;
-    for (i64 r = 0; r < T; ++r) {
-        const f64 *row = X + r * p;
-        f64 fit = 0.0;
-        for (i64 j = 0; j < p; ++j)
-            fit += row[j] * coef[j];
-        f64 resid = y[r] - fit;
-        ssr += resid * resid;
-    }
-    *sigma_out = sqrt(ssr / (f64)(T - p));
-    return SDSGE_OK;
+  f64 ssr = 0.0;
+  for (i64 r = 0; r < T; ++r) {
+    const f64 *row = X + r * p;
+    f64 fit = 0.0;
+    for (i64 j = 0; j < p; ++j)
+      fit += row[j] * coef[j];
+    f64 resid = y[r] - fit;
+    ssr += resid * resid;
+  }
+  *sigma_out = sqrt(ssr / (f64)(T - p));
+  return SDSGE_OK;
 }
 
-int sdsge_cusum_series(const f64 *y, const f64 *X, i64 T, i64 p,
-                       f64 *series_out) {
-    if (T == 0 || T <= p)
-        return DIAG_INSUFFICIENT_SAMPLES;
+int sdsge_cusum_series(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                       i64 T, i64 p, f64 *SDSGE_RESTRICT series_out) {
+  if (T == 0 || T <= p)
+    return DIAG_INSUFFICIENT_SAMPLES;
 
-    /* arena: w(T-p) + G(p*p) + L(p*p) + g(p) + coef(p) */
-    const i64 nrec = T - p;
-    const i64 total = nrec + 2 * p * p + 2 * p;
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return DIAG_LINALG;
-    f64 *ptr = arena;
-    f64 *w = ptr; ptr += nrec;
-    f64 *G = ptr; ptr += p * p;
-    f64 *L = ptr; ptr += p * p;
-    f64 *g = ptr; ptr += p;
-    f64 *coef = ptr; ptr += p;
+  /* arena: w(T-p) + G(p*p) + L(p*p) + g(p) + coef(p) */
+  const i64 nrec = T - p;
+  const i64 total = nrec + 2 * p * p + 2 * p;
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return DIAG_LINALG;
+  f64 *ptr = arena;
+  f64 *w = ptr;
+  ptr += nrec;
+  f64 *G = ptr;
+  ptr += p * p;
+  f64 *L = ptr;
+  ptr += p * p;
+  f64 *g = ptr;
+  ptr += p;
+  f64 *coef = ptr;
+  ptr += p;
 
-    int status = sdsge_recursive_residuals(y, X, T, p, w);
-    if (status != DIAG_OK) {
-        free(arena);
-        return status; /* INSUFFICIENT_SAMPLES or FALLBACK */
-    }
-
-    f64 sigma = 0.0;
-    if (ols_residual_sigma(y, X, T, p, G, L, g, coef, &sigma) != SDSGE_OK) {
-        free(arena);
-        return DIAG_FALLBACK;
-    }
-
-    f64 acc = 0.0;
-    for (i64 i = 0; i < nrec; ++i) {
-        acc += w[i];
-        series_out[i] = acc / sigma;
-    }
+  int status = sdsge_recursive_residuals(y, X, T, p, w);
+  if (status != DIAG_OK) {
     free(arena);
-    return DIAG_OK;
+    return status; /* INSUFFICIENT_SAMPLES or FALLBACK */
+  }
+
+  f64 sigma = 0.0;
+  if (ols_residual_sigma(y, X, T, p, G, L, g, coef, &sigma) != SDSGE_OK) {
+    free(arena);
+    return DIAG_FALLBACK;
+  }
+
+  f64 acc = 0.0;
+  for (i64 i = 0; i < nrec; ++i) {
+    acc += w[i];
+    series_out[i] = acc / sigma;
+  }
+  free(arena);
+  return DIAG_OK;
 }
 
-int sdsge_cusum_stat(const f64 *y, const f64 *X, i64 T, i64 p, f64 *stat_out) {
-    if (T == 0 || T <= p) {
-        *stat_out = NAN;
-        return DIAG_INSUFFICIENT_SAMPLES;
-    }
+int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                     i64 T, i64 p, f64 *SDSGE_RESTRICT stat_out) {
+  if (T == 0 || T <= p) {
+    *stat_out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
 
-    const i64 nrec = T - p;
-    f64 *series = (f64 *)malloc((size_t)nrec * sizeof(f64));
-    if (series == NULL)
-        return DIAG_LINALG;
+  const i64 nrec = T - p;
+  f64 *series = (f64 *)malloc((size_t)nrec * sizeof(f64));
+  if (series == NULL)
+    return DIAG_LINALG;
 
-    int status = sdsge_cusum_series(y, X, T, p, series);
-    if (status != DIAG_OK) {
-        *stat_out = NAN;
-        free(series);
-        return status;
-    }
-
-    const f64 sqrt_Tp = sqrt((f64)nrec);
-    f64 best = 0.0;
-    for (i64 i = 0; i < nrec; ++i) {
-        f64 denom = sqrt_Tp + (2.0 * (f64)i / sqrt_Tp);
-        f64 val = fabs(series[i]) / denom;
-        if (i == 0 || val > best)
-            best = val;
-    }
-    *stat_out = best;
+  int status = sdsge_cusum_series(y, X, T, p, series);
+  if (status != DIAG_OK) {
+    *stat_out = NAN;
     free(series);
-    return DIAG_OK;
+    return status;
+  }
+
+  const f64 sqrt_Tp = sqrt((f64)nrec);
+  f64 best = 0.0;
+  for (i64 i = 0; i < nrec; ++i) {
+    f64 denom = sqrt_Tp + (2.0 * (f64)i / sqrt_Tp);
+    f64 val = fabs(series[i]) / denom;
+    if (i == 0 || val > best)
+      best = val;
+  }
+  *stat_out = best;
+  free(series);
+  return DIAG_OK;
 }
 
-int sdsge_cusumsq_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 *n_out,
-                       f64 *stat_out) {
-    const i64 nrec = (T > p) ? (T - p) : 0;
-    *n_out = nrec;
-    if (T == 0 || T <= p) {
-        *stat_out = NAN;
-        return DIAG_INSUFFICIENT_SAMPLES;
-    }
+int sdsge_cusumsq_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                       i64 T, i64 p, i64 *SDSGE_RESTRICT n_out,
+                       f64 *SDSGE_RESTRICT stat_out) {
+  const i64 nrec = (T > p) ? (T - p) : 0;
+  *n_out = nrec;
+  if (T == 0 || T <= p) {
+    *stat_out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
 
-    f64 *w = (f64 *)malloc((size_t)nrec * sizeof(f64));
-    if (w == NULL)
-        return DIAG_LINALG;
+  f64 *w = (f64 *)malloc((size_t)nrec * sizeof(f64));
+  if (w == NULL)
+    return DIAG_LINALG;
 
-    int status = sdsge_recursive_residuals(y, X, T, p, w);
-    if (status != DIAG_OK) {
-        *stat_out = NAN;
-        free(w);
-        return status;
-    }
-
-    f64 total_sq = 0.0;
-    for (i64 i = 0; i < nrec; ++i)
-        total_sq += w[i] * w[i];
-
-    f64 acc = 0.0, best = 0.0;
-    for (i64 i = 0; i < nrec; ++i) {
-        acc += w[i] * w[i];
-        f64 s = acc / total_sq;
-        f64 expected = (f64)(i + 1) / (f64)nrec;
-        f64 dev = fabs(s - expected);
-        if (i == 0 || dev > best)
-            best = dev;
-    }
-    *stat_out = best / sqrt(2.0);
+  int status = sdsge_recursive_residuals(y, X, T, p, w);
+  if (status != DIAG_OK) {
+    *stat_out = NAN;
     free(w);
-    return DIAG_OK;
+    return status;
+  }
+
+  f64 total_sq = 0.0;
+  for (i64 i = 0; i < nrec; ++i)
+    total_sq += w[i] * w[i];
+
+  f64 acc = 0.0, best = 0.0;
+  for (i64 i = 0; i < nrec; ++i) {
+    acc += w[i] * w[i];
+    f64 s = acc / total_sq;
+    f64 expected = (f64)(i + 1) / (f64)nrec;
+    f64 dev = fabs(s - expected);
+    if (i == 0 || dev > best)
+      best = dev;
+  }
+  *stat_out = best / sqrt(2.0);
+  free(w);
+  return DIAG_OK;
 }
 
-int sdsge_recursive_residuals(const f64 *y, const f64 *X, i64 T, i64 p,
-                              f64 *w_out) {
-    if (T == 0 || T <= p)
-        return DIAG_INSUFFICIENT_SAMPLES;
+int sdsge_recursive_residuals(const f64 *SDSGE_RESTRICT y,
+                              const f64 *SDSGE_RESTRICT X, i64 T, i64 p,
+                              f64 *SDSGE_RESTRICT w_out) {
+  if (T == 0 || T <= p)
+    return DIAG_INSUFFICIENT_SAMPLES;
 
-    /* arena: G(p*p) + L(p*p) + P(p*p) + Xty(p) + beta(p) + Px(p) */
-    const i64 total = 3 * p * p + 3 * p;
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return DIAG_LINALG;
-    f64 *ptr = arena;
-    f64 *G = ptr; ptr += p * p;
-    f64 *L = ptr; ptr += p * p;
-    f64 *P = ptr; ptr += p * p;
-    f64 *Xty = ptr; ptr += p;
-    f64 *beta = ptr; ptr += p;
-    f64 *Px = ptr; ptr += p;
+  /* arena: G(p*p) + L(p*p) + P(p*p) + Xty(p) + beta(p) + Px(p) */
+  const i64 total = 3 * p * p + 3 * p;
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return DIAG_LINALG;
+  f64 *ptr = arena;
+  f64 *G = ptr;
+  ptr += p * p;
+  f64 *L = ptr;
+  ptr += p * p;
+  f64 *P = ptr;
+  ptr += p * p;
+  f64 *Xty = ptr;
+  ptr += p;
+  f64 *beta = ptr;
+  ptr += p;
+  f64 *Px = ptr;
+  ptr += p;
 
-    /* Seed from the first p rows: P = (X_p' X_p)^-1, beta = P X_p' y_p. */
-    sdsge_gram(X, G, p, p);
-    sdsge_gram_rhs(X, y, Xty, p, p);
-    if (sdsge_chol_inv(G, P, L, p) != SDSGE_OK) {
-        free(arena);
-        return DIAG_FALLBACK;
-    }
-    for (i64 a = 0; a < p; ++a) {
-        f64 s = 0.0;
-        for (i64 b = 0; b < p; ++b)
-            s += P[a * p + b] * Xty[b];
-        beta[a] = s;
-    }
-
-    /* Recursive residuals via the symmetric rank-1 downdate of P. */
-    for (i64 i = 0; i < T - p; ++i) {
-        const f64 *xt = X + (p + i) * p;
-
-        f64 e = y[p + i];
-        for (i64 a = 0; a < p; ++a)
-            e -= xt[a] * beta[a];
-
-        f64 quad = 0.0;
-        for (i64 a = 0; a < p; ++a) {
-            f64 s = 0.0;
-            for (i64 b = 0; b < p; ++b)
-                s += P[a * p + b] * xt[b];
-            Px[a] = s;
-            quad += xt[a] * s;
-        }
-
-        f64 ft = 1.0 + quad;
-        w_out[i] = e / sqrt(ft);
-
-        f64 inv_ft = 1.0 / ft;
-        f64 coef = e * inv_ft;
-        for (i64 a = 0; a < p; ++a) {
-            f64 pa = Px[a];
-            beta[a] += pa * coef;
-            for (i64 b = 0; b < p; ++b)
-                P[a * p + b] -= pa * Px[b] * inv_ft;
-        }
-    }
-
+  /* Seed from the first p rows: P = (X_p' X_p)^-1, beta = P X_p' y_p. */
+  sdsge_gram(X, G, p, p);
+  sdsge_gram_rhs(X, y, Xty, p, p);
+  if (sdsge_chol_inv(G, P, L, p) != SDSGE_OK) {
     free(arena);
-    return DIAG_OK;
+    return DIAG_FALLBACK;
+  }
+  for (i64 a = 0; a < p; ++a) {
+    f64 s = 0.0;
+    for (i64 b = 0; b < p; ++b)
+      s += P[a * p + b] * Xty[b];
+    beta[a] = s;
+  }
+
+  /* Recursive residuals via the symmetric rank-1 downdate of P. */
+  for (i64 i = 0; i < T - p; ++i) {
+    const f64 *xt = X + (p + i) * p;
+
+    f64 e = y[p + i];
+    for (i64 a = 0; a < p; ++a)
+      e -= xt[a] * beta[a];
+
+    f64 quad = 0.0;
+    for (i64 a = 0; a < p; ++a) {
+      f64 s = 0.0;
+      for (i64 b = 0; b < p; ++b)
+        s += P[a * p + b] * xt[b];
+      Px[a] = s;
+      quad += xt[a] * s;
+    }
+
+    f64 ft = 1.0 + quad;
+    w_out[i] = e / sqrt(ft);
+
+    f64 inv_ft = 1.0 / ft;
+    f64 coef = e * inv_ft;
+    for (i64 a = 0; a < p; ++a) {
+      f64 pa = Px[a];
+      beta[a] += pa * coef;
+      for (i64 b = 0; b < p; ++b)
+        P[a * p + b] -= pa * Px[b] * inv_ft;
+    }
+  }
+
+  free(arena);
+  return DIAG_OK;
+}
+
+int sdsge_acorr(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 L,
+                f64 *SDSGE_RESTRICT z_scratch, f64 *SDSGE_RESTRICT out) {
+  f64 mu = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    mu += x[i];
+  }
+  mu /= (f64)n;
+
+  f64 denom = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    z_scratch[i] = x[i] - mu;
+    denom += z_scratch[i] * z_scratch[i];
+  }
+
+  if (denom <= 0.0 || !isfinite(denom)) {
+    for (i64 l = 0; l <= L; ++l)
+      out[l] = NAN;
+    return DIAG_UDEF_VARIANCE;
+  }
+
+  out[0] = 1.0;
+  for (i64 ell = 1; ell <= L; ++ell) {
+    f64 num = 0.0;
+    for (i64 t = ell; t < n; ++t) {
+      num += z_scratch[t] * z_scratch[t - ell];
+    }
+    out[ell] = num / denom;
+  }
+  return DIAG_OK;
+}
+
+int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
+                  f64 *SDSGE_RESTRICT z_scratch,
+                  f64 *SDSGE_RESTRICT acorr_scratch, f64 *SDSGE_RESTRICT out) {
+  if (n <= 1) {
+    *out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
+  if (L >= n) {
+    L = n - 1;
+  } else if (L <= 0) {
+    *out = NAN;
+    return DIAG_BAD_LAG;
+  }
+
+  int acorr_err = sdsge_acorr(x, n, L, z_scratch, acorr_scratch);
+  if (acorr_err != DIAG_OK) {
+    *out = NAN;
+    return acorr_err;
+  }
+
+  f64 stat = 0.0;
+  for (i64 ell = 1; ell <= L; ++ell) {
+    stat += (acorr_scratch[ell] * acorr_scratch[ell]) / (f64)(n - ell);
+  }
+  stat *= (f64)n * (f64)(n + 2);
+  *out = stat;
+  return DIAG_OK;
 }

--- a/SymbolicDSGE/_ckernels/diag/diag.h
+++ b/SymbolicDSGE/_ckernels/diag/diag.h
@@ -28,39 +28,53 @@
 
 /* Breusch-Godfrey LM statistic. eps(n), X(n,K). Builds the auxiliary design
  * [1 | X | lagged eps] internally. Writes the statistic to *stat_out. */
-int sdsge_bg_stat(const f64 *eps, const f64 *X, i64 n, i64 K, i64 lags,
-                  f64 *stat_out);
+int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
+                  i64 n, i64 K, i64 lags, f64 *SDSGE_RESTRICT stat_out);
 
 /* Breusch-Pagan auxiliary regression. eps(n), X_aug(n,p) already augmented with
  * the intercept column (the augment + constant-column validation stay in the
  * Python wrapper). Writes RSS and centered TSS of the auxiliary fit. */
-int sdsge_bp_aux(const f64 *eps, const f64 *X_aug, i64 n, i64 p, f64 *rss_out,
-                 f64 *tss_out);
+int sdsge_bp_aux(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X_aug,
+                 i64 n, i64 p, f64 *SDSGE_RESTRICT rss_out,
+                 f64 *SDSGE_RESTRICT tss_out);
 
 /* Chow break-point F statistic. y(T), X(T,p), split at t_break. Fits the pooled
- * and the two sub-sample regressions; DIAG_FALLBACK if any is rank-deficient. */
-int sdsge_chow_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 t_break,
-                    f64 *stat_out);
+ * and the two sub-sample regressions; DIAG_FALLBACK if any is rank-deficient.
+ */
+int sdsge_chow_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                    i64 T, i64 p, i64 t_break, f64 *SDSGE_RESTRICT stat_out);
 
 /* Brown-Durbin-Evans recursive residuals (the w series, length T-p). y(T),
  * X(T,p). Fully native: seeds beta/P from the first p rows via an SPD inverse,
  * then the rank-1 downdate recursion. DIAG_FALLBACK if the seed Gram is
  * singular. */
-int sdsge_recursive_residuals(const f64 *y, const f64 *X, i64 T, i64 p,
-                              f64 *w_out);
+int sdsge_recursive_residuals(const f64 *SDSGE_RESTRICT y,
+                              const f64 *SDSGE_RESTRICT X, i64 T, i64 p,
+                              f64 *SDSGE_RESTRICT w_out);
 
 /* Standardized CUSUM series (length T-p): cumsum(recursive residuals) / sigma,
  * where sigma is the full-sample OLS residual std. DIAG_FALLBACK if the seed
  * Gram or the full-sample normal equations are rank-deficient. */
-int sdsge_cusum_series(const f64 *y, const f64 *X, i64 T, i64 p, f64 *series_out);
+int sdsge_cusum_series(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                       i64 T, i64 p, f64 *SDSGE_RESTRICT series_out);
 
-/* CUSUM statistic: max over t of |series_t| / (sqrt(T-p) + 2 (t-p) / sqrt(T-p)). */
-int sdsge_cusum_stat(const f64 *y, const f64 *X, i64 T, i64 p, f64 *stat_out);
+/* CUSUM statistic: max over t of |series_t| / (sqrt(T-p) + 2 (t-p) /
+ * sqrt(T-p)). */
+int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                     i64 T, i64 p, f64 *SDSGE_RESTRICT stat_out);
 
 /* CUSUM-of-squares statistic. Writes the residual count n = T-p and the
  * Kolmogorov-type max deviation of the normalized squared-residual partial sums
  * from the t/n line, divided by sqrt(2). */
-int sdsge_cusumsq_stat(const f64 *y, const f64 *X, i64 T, i64 p, i64 *n_out,
-                       f64 *stat_out);
+int sdsge_cusumsq_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
+                       i64 T, i64 p, i64 *SDSGE_RESTRICT n_out,
+                       f64 *SDSGE_RESTRICT stat_out);
+
+int sdsge_acorr(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 L,
+                f64 *SDSGE_RESTRICT z_scratch, f64 *SDSGE_RESTRICT out);
+
+int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
+                  f64 *SDSGE_RESTRICT z_scratch,
+                  f64 *SDSGE_RESTRICT acorr_scratch, f64 *SDSGE_RESTRICT out);
 
 #endif /* SDSGE_DIAG_H */

--- a/SymbolicDSGE/_diag_tests/ljung_box.py
+++ b/SymbolicDSGE/_diag_tests/ljung_box.py
@@ -9,11 +9,14 @@ from .distributions import PvalMethod, ReferenceDistribution
 from .result import TestResult
 from .status import TestStatus
 
+from ._native import native as _native
+
 NDF = NDArray[float64]
 LOOP_LIMIT_N = 1e6
 
 OK = int(TestStatus.OK)
 UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
+INSUFFICIENT_SAMPLES = int(TestStatus.INSUFFICIENT_SAMPLES)
 BAD_SHAPE = int(TestStatus.BAD_SHAPE)
 BAD_LAG = int(TestStatus.BAD_LAG)
 
@@ -42,7 +45,7 @@ def acorr(x: NDF, L: int) -> tuple[int, NDF]:
         z = x - mu
         denom = np.dot(z, z)
 
-    if denom <= 0.0:
+    if denom <= 0.0 or not np.isfinite(denom):
         for ell in range(L + 1):
             out[ell] = np.nan
         return UDEF_VARIANCE, out
@@ -65,7 +68,7 @@ def lb_stat(x: NDF, L: int) -> tuple[int, float64]:
 
     n = x.size
     if n <= 1:
-        return UDEF_VARIANCE, float64(np.nan)
+        return INSUFFICIENT_SAMPLES, float64(np.nan)
 
     if L >= n:
         L = n - 1
@@ -88,7 +91,18 @@ def ljung_box(
     x: NDF, L: int, alpha: float = 0.05, _auto_pval: bool = True
 ) -> TestResult:
     """Ljung-Box test for x up to lag L."""
-    err, stat = lb_stat(x, L)
+    if x.ndim != 1:
+        err, stat = (BAD_SHAPE, float64(np.nan))
+    else:
+        # Coerce once to canonical f64/C-contiguous so both backends behave
+        # identically: the native shim requires it, and the numba kernel fails to
+        # compile for non-f64 inputs (acorr's `z` cannot type-unify), so a raw f32
+        # would work natively but crash under ALWAYS_USE_NUMBA.
+        xc = np.ascontiguousarray(x, dtype=float64)
+        if _native is not None:
+            err, stat = _native.lb_stat(xc, L)
+        else:
+            err, stat = lb_stat(xc, L)
     df = L
     if x.ndim == 1 and x.size > 1 and L >= x.size:
         df = x.size - 1

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -302,3 +302,47 @@ def test_fill_mean_and_centered_parity(shape):
     rcentered = np.empty((n, p), dtype=np.float64)
     jit_fill_centered(x, rmean, rcentered)
     np.testing.assert_allclose(ncentered, rcentered, rtol=RTOL, atol=ATOL)
+
+
+# ---------------------------------------------------------------- Ljung-Box
+
+from SymbolicDSGE._diag_tests.ljung_box import (  # noqa: E402
+    BAD_LAG,
+    INSUFFICIENT_SAMPLES,
+    UDEF_VARIANCE,
+    acorr as jit_acorr,
+    lb_stat as jit_lb_stat,
+)
+
+
+@pytest.mark.parametrize("n,L", [(50, 5), (160, 10), (8, 3), (20, 25)])
+def test_acorr_parity(n, L):
+    """Native autocorrelation matches numba, including the L >= n case."""
+    rng = np.random.default_rng([n, L, 3])
+    x = np.ascontiguousarray(rng.standard_normal(n))
+    ns, nout = diag.acorr(x, L)
+    rs, rout = jit_acorr(x, L)
+    assert ns == rs == 0
+    np.testing.assert_allclose(nout, rout, rtol=RTOL, atol=ATOL)
+
+
+def test_acorr_constant_series_reports_undefined_variance():
+    assert diag.acorr(np.ones(5, dtype=np.float64), 2)[0] == UDEF_VARIANCE
+
+
+@pytest.mark.parametrize("n,L", [(50, 5), (160, 10), (8, 3), (20, 25)])
+def test_lb_stat_parity(n, L):
+    """Native Ljung-Box statistic matches numba, including the L >= n clamp."""
+    rng = np.random.default_rng([n, L, 4])
+    x = np.ascontiguousarray(rng.standard_normal(n))
+    ns, nstat = diag.lb_stat(x, L)
+    rs, rstat = jit_lb_stat(x, L)
+    assert ns == rs == 0
+    assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_lb_stat_status_paths():
+    """n<=1 -> INSUFFICIENT, constant series -> UDEF_VARIANCE, L<=0 -> BAD_LAG."""
+    assert diag.lb_stat(np.array([1.0], dtype=np.float64), 1)[0] == INSUFFICIENT_SAMPLES
+    assert diag.lb_stat(np.ones(3, dtype=np.float64), 1)[0] == UDEF_VARIANCE
+    assert diag.lb_stat(np.array([1.0, 2.0], dtype=np.float64), 0)[0] == BAD_LAG

--- a/tests/diag_tests/test_ljung_box.py
+++ b/tests/diag_tests/test_ljung_box.py
@@ -9,6 +9,7 @@ from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribu
 from SymbolicDSGE._diag_tests.ljung_box import (
     BAD_LAG,
     BAD_SHAPE,
+    INSUFFICIENT_SAMPLES,
     OK,
     UDEF_VARIANCE,
     acorr,
@@ -94,7 +95,8 @@ def test_lb_stat_reports_input_status_codes() -> None:
     assert np.isnan(stat)
 
     err, stat = lb_stat.py_func(np.array([1.0], dtype=np.float64), 1)
-    assert err == UDEF_VARIANCE
+    assert err == INSUFFICIENT_SAMPLES
+    assert INSUFFICIENT_SAMPLES == TestStatus.INSUFFICIENT_SAMPLES
     assert np.isnan(stat)
 
     err, stat = lb_stat.py_func(np.array([1.0, 2.0], dtype=np.float64), 0)


### PR DESCRIPTION
This pull request introduces two new statistical diagnostic functions: autocorrelation (`acorr`) and Ljung-Box statistic (`lb_stat`); to the native diagnostics kernel, and exposes them through the Python interface. It also improves memory safety and code clarity by consistently applying the `SDSGE_RESTRICT` qualifier to pointer arguments in C functions, and refactors workspace allocation for better readability.

The most important changes are:

**New statistical diagnostics:**

* Added a native implementation of the autocorrelation function (`sdsge_acorr`) and the Ljung-Box statistic (`sdsge_lb_stat`) to `diag.c` and exposed them via the Cython and Python interfaces (`_diag.pyx`, `_diag.pyi`, and `__init__.py`). These functions provide efficient, native autocorrelation and white-noise test statistics for time series residuals. [[1]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bR418-R477) [[2]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0R158-R197) [[3]](diffhunk://#diff-427d54d0fc9696710acc60d0a56fbaf7601d5e51da858086b077e49f3d1e4bbcR40-R45) [[4]](diffhunk://#diff-1da2f873cb221bfdc7439284cddc09edbd05caa843dd1e305149de9ec163807aR10) [[5]](diffhunk://#diff-1da2f873cb221bfdc7439284cddc09edbd05caa843dd1e305149de9ec163807aR21)

* Updated the Python test module `ljung_box.py` to use the new native implementations and improved the autocorrelation function to handle non-finite denominators safely. [[1]](diffhunk://#diff-f8fd85af6f99bb01ac44ad1875f7f5a1f56aace0633b96dda0d991d56eb83453R12-R19) [[2]](diffhunk://#diff-f8fd85af6f99bb01ac44ad1875f7f5a1f56aace0633b96dda0d991d56eb83453L45-R48)

**C/C++ API improvements:**

* Applied the `SDSGE_RESTRICT` qualifier to all relevant pointer arguments in diagnostic kernel functions and their declarations in `diag.c` and `diag.h`, improving potential compiler optimizations and clarifying pointer aliasing. [[1]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL7-R8) [[2]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL64-R71) [[3]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL125-R140) [[4]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL146-R161) [[5]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL189-R211) [[6]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL210-R232) [[7]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL222-R252) [[8]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL249-R276) [[9]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL280-R309) [[10]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL318-R348) [[11]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL329-R369) [[12]](diffhunk://#diff-1777986b0cd8b1961721d18dc906bf2612f668b0c686e489631a915e64cca90bL31-R78)

* Refactored workspace pointer arithmetic in several C functions for clarity, making it easier to follow allocation and usage of scratch buffers. [[1]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL22-R31) [[2]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL83-R98) [[3]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL163-R193) [[4]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL222-R252) [[5]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bL329-R369)

These changes collectively add new statistical tools to the package and improve the maintainability and efficiency of the native diagnostic code.

closes #227 