### PR TITLE
Add Jarque-Bera statistic to diag kernel

### DIFF
--- a/SymbolicDSGE/_ckernels/diag/__init__.py
+++ b/SymbolicDSGE/_ckernels/diag/__init__.py
@@ -18,6 +18,7 @@ from ._diag import (
     fill_mean_ax0 as fill_mean_ax0,
     fill_symmetric_target_vec as fill_symmetric_target_vec,
     hac_estimator_matmul as hac_estimator_matmul,
+    jb_stat as jb_stat,
     lb_stat as lb_stat,
     recursive_residuals as recursive_residuals,
     symmetric_outer_prod_2dim as symmetric_outer_prod_2dim,

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyi
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyi
@@ -37,6 +37,9 @@ def cusum_stat(y: _F64, X: _F64) -> tuple[int, float]:
 def cusumsq_stat(y: _F64, X: _F64) -> tuple[int, int, float]:
     """CUSUM-of-squares statistic. Returns (status, n, stat)."""
 
+def jb_stat(x: _F64) -> tuple[int, float]:
+    """Jarque-Bera normality statistic. Returns (status, stat)."""
+
 def acorr(x: _F64, L: int) -> tuple[int, _F64]:
     """Autocorrelation of x up to lag L. Returns (status, out(L+1))."""
 

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -35,6 +35,7 @@ cdef extern from "diag.h":
     int sdsge_lb_stat(const double *x, const int64_t n, int64_t L,
                       double *z_scratch, double *acorr_scratch,
                       double *out) nogil
+    int sdsge_jb_stat(const double *x, int64_t n, double *out) nogil
 cdef extern from "diag_wald.h":
     ctypedef enum KernelID:
         BARTLETT
@@ -153,6 +154,17 @@ def cusumsq_stat(double[::1] y, double[:, ::1] X):
     with nogil:
         status = sdsge_cusumsq_stat(&y[0], &X[0, 0], T, p, &n, &stat)
     return status, n, stat
+
+
+def jb_stat(double[::1] x):
+    """Jarque-Bera normality statistic. Returns (status, stat)."""
+    cdef int64_t n = x.shape[0]
+    cdef double stat = 0.0
+    cdef int status
+    cdef double *x_ptr = &x[0] if n > 0 else NULL
+    with nogil:
+        status = sdsge_jb_stat(x_ptr, n, &stat)
+    return status, stat
 
 
 def acorr(double[::1] x, int64_t L):

--- a/SymbolicDSGE/_ckernels/diag/diag.c
+++ b/SymbolicDSGE/_ckernels/diag/diag.c
@@ -475,3 +475,44 @@ int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
   *out = stat;
   return DIAG_OK;
 }
+
+/* Jarque-Bera normality statistic n * (skew^2/6 + (kurt-3)^2/24), mirroring the
+ * numba jb_stat. The statistic is computed whenever the variance is defined;
+ * the small-sample (n < 10) result is still returned, only with an
+ * INSUFFICIENT_SAMPLES status (matching the numba reference). */
+int sdsge_jb_stat(const f64 *SDSGE_RESTRICT x, i64 n, f64 *SDSGE_RESTRICT out) {
+  if (n == 0) {
+    *out = NAN;
+    return DIAG_INSUFFICIENT_SAMPLES;
+  }
+
+  f64 mean = 0.0;
+  for (i64 i = 0; i < n; ++i)
+    mean += x[i];
+  mean /= (f64)n;
+
+  f64 m2 = 0.0, m3 = 0.0, m4 = 0.0;
+  for (i64 i = 0; i < n; ++i) {
+    f64 centered = x[i] - mean;
+    f64 centered2 = centered * centered;
+    m2 += centered2;
+    m3 += centered2 * centered;
+    m4 += centered2 * centered2;
+  }
+  m2 /= (f64)n;
+  m3 /= (f64)n;
+  m4 /= (f64)n;
+
+  if (m2 <= 0.0) {
+    *out = NAN;
+    return DIAG_UDEF_VARIANCE;
+  }
+
+  f64 skew = m3 / pow(m2, 1.5);
+  f64 kurt = m4 / (m2 * m2);
+  f64 kurt_minus_3 = kurt - 3.0;
+
+  f64 inner = (skew * skew) / 6.0 + (kurt_minus_3 * kurt_minus_3) / 24.0;
+  *out = (f64)n * inner;
+  return (n >= 10) ? DIAG_OK : DIAG_INSUFFICIENT_SAMPLES;
+}

--- a/SymbolicDSGE/_ckernels/diag/diag.h
+++ b/SymbolicDSGE/_ckernels/diag/diag.h
@@ -77,4 +77,9 @@ int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
                   f64 *SDSGE_RESTRICT z_scratch,
                   f64 *SDSGE_RESTRICT acorr_scratch, f64 *SDSGE_RESTRICT out);
 
+/* Jarque-Bera normality statistic. x(n). Writes the statistic to *out; returns
+ * INSUFFICIENT_SAMPLES (still writing the stat) when n < 10, UDEF_VARIANCE when
+ * the variance is zero, OK otherwise. */
+int sdsge_jb_stat(const f64 *SDSGE_RESTRICT x, i64 n, f64 *SDSGE_RESTRICT out);
+
 #endif /* SDSGE_DIAG_H */

--- a/SymbolicDSGE/_diag_tests/jarque_bera.py
+++ b/SymbolicDSGE/_diag_tests/jarque_bera.py
@@ -12,6 +12,8 @@ from .distributions import PvalMethod, ReferenceDistribution
 from .result import TestResult
 from .status import TestStatus
 
+from ._native import native as _native
+
 OK = int(TestStatus.OK)
 UDEF_VARIANCE = int(TestStatus.UDEF_VARIANCE)
 BAD_SHAPE = int(TestStatus.BAD_SHAPE)
@@ -68,7 +70,16 @@ def jarque_bera(
     _auto_pval: bool = True,
 ) -> TestResult:
     """Perform the Jarque-Bera test for normality."""
-    status, stat = jb_stat(x)
+    if x.ndim != 1:
+        status, stat = BAD_SHAPE, float64(np.nan)
+    else:
+        # Coerce once to canonical f64/C-contiguous so both backends agree (the
+        # native shim requires it; the numba kernel computes in the input dtype).
+        xc = np.ascontiguousarray(x, dtype=float64)
+        if _native is not None:
+            status, stat = _native.jb_stat(xc)
+        else:
+            status, stat = jb_stat(xc)
     return TestResult(
         test_name="jarque_bera",
         dist=ReferenceDistribution.JB_LOOKUP,

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -346,3 +346,37 @@ def test_lb_stat_status_paths():
     assert diag.lb_stat(np.array([1.0], dtype=np.float64), 1)[0] == INSUFFICIENT_SAMPLES
     assert diag.lb_stat(np.ones(3, dtype=np.float64), 1)[0] == UDEF_VARIANCE
     assert diag.lb_stat(np.array([1.0, 2.0], dtype=np.float64), 0)[0] == BAD_LAG
+
+
+# ---------------------------------------------------------------- Jarque-Bera
+
+from SymbolicDSGE._diag_tests.jarque_bera import jb_stat as jit_jb_stat  # noqa: E402
+
+
+@pytest.mark.parametrize("n", [10, 50, 200])
+def test_jb_stat_parity(n):
+    """Native Jarque-Bera statistic matches numba on the OK path."""
+    rng = np.random.default_rng([n, 13])
+    x = np.ascontiguousarray(rng.standard_normal(n))
+    ns, nstat = diag.jb_stat(x)
+    rs, rstat = jit_jb_stat(x)
+    assert ns == rs == 0
+    assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_jb_stat_status_paths():
+    """n<10 -> INSUFFICIENT (stat still computed), constant -> UDEF, empty ->
+    INSUFFICIENT -- matching numba in both status and value."""
+    cases = [
+        np.ascontiguousarray(np.random.default_rng(1).standard_normal(8)),
+        np.ones(20, dtype=np.float64),
+        np.empty(0, dtype=np.float64),
+    ]
+    for x in cases:
+        ns, nstat = diag.jb_stat(x)
+        rs, rstat = jit_jb_stat(x)
+        assert ns == rs
+        if np.isnan(nstat) or np.isnan(rstat):
+            assert np.isnan(nstat) and np.isnan(rstat)
+        else:
+            assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
This pull request adds a native implementation of the Jarque-Bera normality statistic (`jb_stat`) to the diagnostics kernel, exposes it to Python, and ensures it matches the reference numba implementation. It includes C, Cython, and Python bindings, and adds comprehensive tests for correctness and status code parity.

**New Jarque-Bera statistic implementation:**

* Implemented the native C function `sdsge_jb_stat` in `diag.c` and declared it in `diag.h`, which computes the Jarque-Bera normality statistic and returns appropriate status codes for insufficient samples and undefined variance. [[1]](diffhunk://#diff-8c2054f0e91feb5e4552b250d0779efb230292f2f5fff8d1655fa60fcb72303bR478-R518) [[2]](diffhunk://#diff-1777986b0cd8b1961721d18dc906bf2612f668b0c686e489631a915e64cca90bR80-R84)
* Added Cython bindings for `jb_stat` in `_diag.pyx`, exposing it as a Python-callable function that returns both status and statistic. [[1]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0R38) [[2]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0R159-R169)
* Updated the Python interface in `_diag.pyi` to include the new `jb_stat` function with a clear docstring.
* Registered the new function in the module's `__init__.py` to make it available for import.

**Integration and testing:**

* Updated the `jarque_bera` test in `_diag_tests/jarque_bera.py` to use the new native implementation when available, ensuring consistent behavior and proper input coercion. [[1]](diffhunk://#diff-2a1313249926c0ff9664fa8d70f03f7d7ed3519093ddaeb53f14b3628d051c2bR15-R16) [[2]](diffhunk://#diff-2a1313249926c0ff9664fa8d70f03f7d7ed3519093ddaeb53f14b3628d051c2bL71-R82)
* Added thorough tests in `test_diag.py` to verify that the native implementation matches the numba reference for both statistic values and status codes, including edge cases (small n, constant input, empty input).

closes #229 