### PR TITLE
Filt sim optim

### DIFF
--- a/SymbolicDSGE/core/shock_generators.py
+++ b/SymbolicDSGE/core/shock_generators.py
@@ -7,7 +7,9 @@ from scipy.stats import (
 )
 from scipy.stats._distn_infrastructure import rv_generic
 from scipy.stats._multivariate import multi_rv_generic
+import numpy as np
 from numpy import asarray, ndarray, float64, random, zeros, generic
+from numpy.linalg import cholesky, eigh, LinAlgError
 from numpy.typing import NDArray
 from typing import Any, Literal, Callable, Mapping, cast, overload
 
@@ -36,6 +38,76 @@ def abstract_shock_array(
     return asarray(shocks, dtype=float64)
 
 
+# --- numpy Generator fast paths --------------------------------------------
+# scipy's generic ``.rvs`` is ~9x slower than ``np.random.Generator`` here (and
+# ``multivariate_normal.rvs`` re-factorizes the covariance every call). These
+# draw the known shock families directly off a Generator; ``abstract_shock_array``
+# above stays as the fallback for arbitrary scipy distribution objects.
+
+
+def _gaussian_factor(cov: ndarray) -> ndarray:
+    """A factor ``F`` with ``F @ F.T == cov``.
+
+    Cholesky on the common positive-definite path, with an eigh-based fallback so
+    positive-semidefinite (but not strictly PD) covariances still sample -- the
+    robustness scipy's ``_PSD`` gives us, without scipy.
+    """
+    try:
+        return cholesky(cov)
+    except LinAlgError:
+        w, V = eigh(cov)
+        return cast(ndarray, V * np.sqrt(np.clip(w, 0.0, None)))
+
+
+def _draw_normal(
+    T: int, seed: int | None, mu: float | float64, sigma: float | float64
+) -> ndarray:
+    return random.default_rng(seed).normal(loc=mu, scale=sigma, size=T).astype(float64)
+
+
+def _draw_normal_mv(
+    T: int, seed: int | None, mean: ndarray | None, cov: ndarray
+) -> ndarray:
+    cov = asarray(cov, dtype=float64)
+    k = cov.shape[0]
+    mean_vec = zeros(k, dtype=float64) if mean is None else asarray(mean, dtype=float64)
+    z = random.default_rng(seed).standard_normal((T, k))
+    return cast(ndarray, (mean_vec + z @ _gaussian_factor(cov).T).astype(float64))
+
+
+def _draw_t(
+    T: int,
+    seed: int | None,
+    df: float,
+    loc: float | float64,
+    scale: float | float64,
+) -> ndarray:
+    draws = random.default_rng(seed).standard_t(df, size=T)
+    return (loc + scale * draws).astype(float64)
+
+
+def _draw_t_mv(
+    T: int, seed: int | None, df: float, loc: ndarray | None, shape: ndarray
+) -> ndarray:
+    shape = asarray(shape, dtype=float64)
+    k = shape.shape[0]
+    loc_vec = zeros(k, dtype=float64) if loc is None else asarray(loc, dtype=float64)
+    rng = random.default_rng(seed)
+    z = rng.standard_normal((T, k)) @ _gaussian_factor(shape).T
+    g = rng.chisquare(df, size=T) / df
+    return cast(ndarray, (loc_vec + z / np.sqrt(g)[:, None]).astype(float64))
+
+
+def _draw_uniform(
+    T: int, seed: int | None, loc: float | float64, scale: float | float64
+) -> ndarray:
+    return (
+        random.default_rng(seed)
+        .uniform(low=loc, high=loc + scale, size=T)
+        .astype(float64)
+    )
+
+
 def normal_shock_array(
     T: int,
     seed: int,
@@ -53,7 +125,7 @@ def normal_shock_array(
     Returns:
     np.ndarray: An array of normally distributed shocks of length T.
     """
-    return abstract_shock_array(T, seed, norm, loc=mu, scale=sigma)
+    return _draw_normal(T, seed, mu, sigma)
 
 
 def normal_multivariate_shock_array(
@@ -76,8 +148,7 @@ def normal_multivariate_shock_array(
     np.ndarray: An array of shape (T, k) of multivariate normally distributed shocks.
     """
 
-    shocks = abstract_shock_array(T, seed, mnorm, mean=asarray(mus), cov=cov_mat)
-    return asarray(shocks, dtype=float64)
+    return _draw_normal_mv(T, seed, asarray(mus, dtype=float64), asarray(cov_mat))
 
 
 def t_shock_array(
@@ -100,7 +171,7 @@ def t_shock_array(
     Returns:
     np.ndarray: An array of t-distributed shocks of length T.
     """
-    return abstract_shock_array(T, seed, t, df=df, loc=loc, scale=scale)
+    return _draw_t(T, seed, df, loc, scale)
 
 
 def t_multivariate_shock_array(
@@ -124,7 +195,7 @@ def t_multivariate_shock_array(
     Returns:
     np.ndarray: An array of shape (T, k) of multivariate t-distributed shocks.
     """
-    return abstract_shock_array(T, seed, mt, df=df, loc=asarray(locs), shape=cov_mat)
+    return _draw_t_mv(T, seed, df, asarray(locs, dtype=float64), asarray(cov_mat))
 
 
 def uniform_shock_array(
@@ -142,7 +213,7 @@ def uniform_shock_array(
     Returns:
     np.ndarray: An array of uniformly distributed shocks of length T.
     """
-    return abstract_shock_array(T, seed, uniform, loc=loc, scale=scale)
+    return _draw_uniform(T, seed, loc, scale)
 
 
 def uniform_multivariate_shock_array(
@@ -241,6 +312,13 @@ class Shock:
     def shock_generator(self) -> Callable[[float | NDArray[float64]], NDArray[float64]]:
         self._assert_generator()
         kwargs = self.dist_kwargs.copy()
+
+        # Known string families go through the numpy Generator fast paths. A raw
+        # scipy distribution object (or a string with positional dist_args, which
+        # the fast path doesn't model) keeps the scipy ``.rvs`` route.
+        if isinstance(self.dist, str) and not self.dist_args:
+            return self._numpy_shock_generator(kwargs)
+
         scale_key = "scale"
         if self.multivar:
             scale_key = "shape" if self.dist == "t" else "cov"
@@ -253,6 +331,45 @@ class Shock:
         )
 
         return fun
+
+    def _numpy_shock_generator(
+        self, kwargs: dict
+    ) -> Callable[[float | NDArray[float64]], NDArray[float64]]:
+        """Build the per-scale draw closure for a string family on numpy.
+
+        The returned callable takes the scale argument ``s`` (a scalar std for
+        univariate families, a covariance/shape matrix for multivariate ones),
+        mirroring the scipy-path contract.
+        """
+        family = self.dist
+        T, seed, multivar = self.T, self.seed, self.multivar
+
+        if family == "norm":
+            if multivar:
+                mean = kwargs.get("mean")
+                return lambda s: _draw_normal_mv(T, seed, mean, cast(ndarray, s))
+            loc = kwargs.get("loc", 0.0)
+            return lambda s: _draw_normal(T, seed, loc, cast(float, s))
+
+        if family == "t":
+            if "df" not in kwargs:
+                raise ValueError("Student-t shocks require 'df' in dist_kwargs.")
+            df = kwargs["df"]
+            if multivar:
+                loc = kwargs.get("loc")
+                return lambda s: _draw_t_mv(T, seed, df, loc, cast(ndarray, s))
+            loc = kwargs.get("loc", 0.0)
+            return lambda s: _draw_t(T, seed, df, loc, cast(float, s))
+
+        if family == "uni":
+            if multivar:
+                raise NotImplementedError(
+                    "Multivariate uniform shocks are not implemented."
+                )
+            loc = kwargs.get("loc", 0.0)
+            return lambda s: _draw_uniform(T, seed, loc, cast(float, s))
+
+        raise ValueError(f"Unknown shock distribution family: {family!r}")
 
     @overload
     def place_shocks(self, shock_spec: ShockSpecUni) -> ndarray: ...

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -28,7 +28,7 @@ from .compiled_model import CompiledModel
 from .config import ModelConfig, SymbolGetterDict
 from .simulation import affine_observations_into, simulate_linear_states_into
 from ..kalman.config import KalmanConfig
-from ..kalman.interface import KalmanInterface
+from ..kalman.interface import KalmanInterface, _KFMatrices
 from ..kalman.filter import FilterResult
 
 if TYPE_CHECKING:
@@ -68,6 +68,48 @@ class SolvedModel:
     @property
     def kalman_config(self) -> KalmanConfig | None:
         return self.compiled.kalman
+
+    def _calibration_fingerprint(self) -> int:
+        """Hashable snapshot of calibration parameter values.
+
+        Keys the Kalman matrix cache so a parameter change (MLE/MCMC) is a cache
+        miss -- the rebuilt matrices stay correct -- while a repeated parameter
+        vector (Monte Carlo, a revisited proposal) is a hit. Cheap: a tuple hash
+        over the handful of scalar parameters, dwarfed by the matrix builds it
+        guards.
+        """
+        params = self.config.calibration.parameters
+        return hash((tuple(params.keys()), tuple(float(v) for v in params.values())))
+
+    def _kf_cache_get(self, key: tuple) -> _KFMatrices | None:
+        """Cached Kalman matrices for ``key``, or ``None`` on miss.
+
+        The cache is a plain dict attached lazily: this is a frozen dataclass, so
+        it lives outside the declared fields and stays invisible to ``asdict`` /
+        bundle serialization.
+        """
+        cache = self.__dict__.get("_kf_cache")
+        return None if cache is None else cache.get(key)
+
+    def _kf_cache_put(self, key: tuple, matrices: _KFMatrices) -> None:
+        cache = self.__dict__.get("_kf_cache")
+        if cache is None:
+            cache = {}
+            object.__setattr__(self, "_kf_cache", cache)
+        cache[key] = matrices
+
+    def clear_kf_cache(self) -> None:
+        """Drop cached Kalman matrices.
+
+        Needed only when a model is mutated in place after a filter call in a way
+        the calibration fingerprint cannot see -- e.g. overwriting a hardcoded
+        ``kalman_config.R`` / ``P0`` matrix (a parametric R built from calibration
+        is covered automatically). The expected lifecycle (solve once, filter
+        many) never needs this.
+        """
+        cache = self.__dict__.get("_kf_cache")
+        if cache is not None:
+            cache.clear()
 
     def sim(
         self,

--- a/SymbolicDSGE/kalman/interface.py
+++ b/SymbolicDSGE/kalman/interface.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 from ..core.config import ModelConfig, SymbolGetterDict
 
 
+from dataclasses import dataclass
 from functools import cached_property
 
 import numpy as np
@@ -23,6 +24,27 @@ import pandas as pd
 
 NDF = NDArray[float64]
 Float64Like = float | float64 | int | int64
+
+
+@dataclass
+class _KFMatrices:
+    """Cached model-constant Kalman matrices for one cache key.
+
+    Stored on the :class:`SolvedModel` (see ``SolvedModel._kf_cache``) and shared
+    across repeated filter calls so the per-call interface stops rebuilding
+    ``C``/``d``/``Q``/``P0``/``R`` for a fixed calibration. ``R_const`` is filled
+    lazily on the first constant-R call for the key (a key first seen via a
+    user-supplied or estimated ``R`` leaves it ``None``). ``validated`` flips to
+    ``True`` once the constant covariances pass the symmetry / non-negative-
+    diagonal checks, letting subsequent constant-R calls skip them.
+    """
+
+    C: NDF | None
+    d: NDF | None
+    Q: NDF
+    P0: NDF
+    R_const: NDF | None = None
+    validated: bool = False
 
 
 class KalmanInterface(KalmanFilter):
@@ -57,19 +79,49 @@ class KalmanInterface(KalmanFilter):
         self.y = y
 
         self.A, self.B = model.A, model.B
-        if self.mode == FilterMode.LINEAR:
-            self.C, self.d = self._get_C_d()
-        else:
-            self.C, self.d = None, None  # type: ignore[assignment]
 
-        self.Q = self._build_Q()
-        self.P0 = self._build_P0(p0_mode=p0_mode, p0_scale=p0_scale)
-        if R is not None:
+        # C/d/Q/P0 (and, on the default path, R) are model-constant: rebuilt
+        # identically on every call for a fixed calibration. Resolve them through
+        # the model's cache so repeated filtering (Monte Carlo, MLE/MCMC that
+        # revisits a parameter vector) skips the rebuild. The key carries every
+        # dependency; the calibration fingerprint turns a parameter change into a
+        # cache miss, so estimation that varies parameters stays correct.
+        self._uses_const_R = R is None and not self.estimate_R_diag
+        cache_key = (
+            self.mode,
+            tuple(self.observables),
+            p0_mode,
+            None if p0_scale is None else float(p0_scale),
+            model._calibration_fingerprint(),
+        )
+        record = model._kf_cache_get(cache_key)
+        if record is None:
+            if self.mode == FilterMode.LINEAR:
+                C, d = self._get_C_d()
+            else:
+                C, d = None, None
+            record = _KFMatrices(
+                C=C,
+                d=d,
+                Q=self._build_Q(),
+                P0=self._build_P0(p0_mode=p0_mode, p0_scale=p0_scale),
+            )
+            model._kf_cache_put(cache_key, record)
+        self._cache_record = record
+
+        self.C, self.d = record.C, record.d
+        self.Q = record.Q
+        self.P0 = record.P0
+        if self._uses_const_R:
+            # Fill R lazily so a key first seen with a user/estimated R still
+            # gets a constant R when later reused on the default path.
+            if record.R_const is None:
+                record.R_const = self._build_constant_R(None)
+            self.R = record.R_const
+        elif R is not None:
             self.R = self._build_constant_R(R)
-        elif self.estimate_R_diag:
-            self.R = self._initial_R_diag_guess()
         else:
-            self.R = self._build_constant_R(None)
+            self.R = self._initial_R_diag_guess()
 
         self.h_func = h_func
         self.H_jac = H_jac
@@ -103,15 +155,27 @@ class KalmanInterface(KalmanFilter):
             raise ValueError(f"Unrecognized filter mode: {self.mode}")
 
         validated_args = base_args | _arg_overrides
+
+        # The covariance-sanity checks (symmetry + non-negative diagonals) run on
+        # the model-constant Q/P0/R and dominate per-call validation. Skip them
+        # once they've passed for cached constant matrices; y/x0 and every shape
+        # check still run on each call. A user-supplied or estimated R (and any
+        # explicit override) is not cache-validated and keeps the full checks.
+        const_validated = (
+            self._cache_record.validated and self._uses_const_R and not _arg_overrides
+        )
+        run_const_checks = not const_validated
         validate_kf_inputs(
             **validated_args,
             x0=x0,
             filter_mode=self.mode,
-            check_nonneg_diag=True,
-            check_symmetry=True,
+            check_nonneg_diag=run_const_checks,
+            check_symmetry=run_const_checks,
             probe_measurement=(self.mode == FilterMode.EXTENDED),
             probe_state=("x0" if x0 is not None else "zeros"),
         )
+        if run_const_checks and self._uses_const_R and not _arg_overrides:
+            self._cache_record.validated = True
 
         if self.mode == FilterMode.LINEAR:
 

--- a/tests/kalman/test_interface.py
+++ b/tests/kalman/test_interface.py
@@ -90,6 +90,18 @@ def _make_stub_model(
         kalman_config=kalman_config,
     )
     model._build_C_d_from_obs = build_measurement
+
+    # Mirror SolvedModel's Kalman-matrix cache contract so the interface's
+    # cache-aware construction path works against the stub.
+    _cache: dict = {}
+
+    def _calibration_fingerprint():
+        p = calibration.parameters
+        return hash((tuple(p.keys()), tuple(float(v) for v in p.values())))
+
+    model._calibration_fingerprint = _calibration_fingerprint
+    model._kf_cache_get = _cache.get
+    model._kf_cache_put = _cache.__setitem__
     return model
 
 


### PR DESCRIPTION
This pull request introduces significant performance improvements and caching to the shock generation and Kalman filter matrix construction code. The main changes are the addition of fast NumPy-based paths for common shock distributions (normal, t, uniform), and a new caching mechanism for model-constant Kalman matrices, which avoids redundant computation during repeated filtering with unchanged parameters.

**Shock generation improvements:**

* Fast NumPy-based implementations for normal, multivariate normal, t, multivariate t, and uniform shock generators are added, bypassing slower generic SciPy distribution paths for these common cases. This greatly speeds up simulation and estimation workflows. [[1]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844R41-R110) [[2]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844L56-R128) [[3]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844L79-R151) [[4]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844L103-R174) [[5]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844L127-R198) [[6]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844L145-R216)
* The shock generator selection logic was updated to use these fast paths automatically when possible, falling back to the generic path only for less common or custom distributions. [[1]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844R315-R321) [[2]](diffhunk://#diff-31f3b30c0b68ac16ffd3e0510ef3a4a547aabeca1ad0742a9648a465d23aa844R335-R373)

**Kalman filter caching and validation:**

* A new `_KFMatrices` dataclass is introduced to cache model-constant Kalman matrices (`C`, `d`, `Q`, `P0`, and `R_const`) for each unique calibration and filter configuration. This cache is stored on the `SolvedModel` object and keyed by a fingerprint of calibration parameters and other filter options, ensuring correctness when parameters change. [[1]](diffhunk://#diff-210374c397e1b2484fef28fd345a2cbe7054b2e03b3b7c0dbf6fb43bf8015f10R29-R49) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadR72-R113) [[3]](diffhunk://#diff-210374c397e1b2484fef28fd345a2cbe7054b2e03b3b7c0dbf6fb43bf8015f10R82-R124)
* The Kalman filter interface (`KalmanInterface`) now uses this cache to avoid redundant matrix construction on repeated filter calls with the same configuration, significantly improving performance in Monte Carlo, MLE, and MCMC scenarios.
* Validation of matrix symmetry and non-negative diagonals is now performed only once per cached set of constant matrices, rather than on every filter call, further reducing overhead.

**Testing and compatibility:**

* The Kalman filter interface test stubs are updated to mirror the new caching contract, ensuring that tests exercise the cache-aware construction path.

These changes collectively improve both the speed and correctness of simulation and estimation routines in the codebase.

closes #231 