### PR TITLE
Add native C prior_program kernels and Cython shim

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -30,6 +30,7 @@ typedef double f64;
  * the kalman / distribution / transform kernels. */
 #define TWO_PI 6.283185307179586
 #define PI 3.141592653589793
+#define SQRT2 1.4142135623730951
 
 /* Shared status codes for the dense linear-algebra primitives in sdsge_linalg.
  * Subsystems map these onto their own error conventions (e.g. the kalman hot

--- a/SymbolicDSGE/_ckernels/estimation/__init__.py
+++ b/SymbolicDSGE/_ckernels/estimation/__init__.py
@@ -1,0 +1,14 @@
+"""Native estimation kernels (the packed log-prior program).
+
+Re-exports the compiled ``_prior_program`` extension. If it is not built,
+importing this module raises ``ImportError`` and the consumer
+(``SymbolicDSGE.estimation.prior_program``) falls back to its numba kernel.
+"""
+
+from ._prior_program import (
+    dist_logpdf as dist_logpdf,
+    lkj_chol_logjac as lkj_chol_logjac,
+    lkj_chol_logpdf_from_z as lkj_chol_logpdf_from_z,
+    logprior_program as logprior_program,
+    transform_inverse_and_logjac as transform_inverse_and_logjac,
+)

--- a/SymbolicDSGE/_ckernels/estimation/_prior_program.pyi
+++ b/SymbolicDSGE/_ckernels/estimation/_prior_program.pyi
@@ -1,0 +1,36 @@
+"""Type stubs for the compiled ``_prior_program`` extension.
+
+The native kernels carry no inspectable type information, so these signatures
+exist solely for the LSP / mypy. They must stay in sync with
+``_prior_program.pyx`` / ``prior_program.c`` and the numba references in
+``SymbolicDSGE.estimation.prior_program``; the parity tests guard the runtime
+behavior, not this stub.
+"""
+
+from numpy import float64, int64
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+_I64 = NDArray[int64]
+
+def dist_logpdf(code: int, params: _F64, x: float) -> float: ...
+def transform_inverse_and_logjac(
+    code: int, params: _F64, z: float
+) -> tuple[float, float]: ...
+def lkj_chol_logjac(z: _F64, dim: int, length: int) -> float: ...
+def lkj_chol_logpdf_from_z(
+    z: _F64, dim: int, length: int, eta: float, log_const: float
+) -> float: ...
+def logprior_program(
+    theta: _F64,
+    scalar_indices: _I64,
+    scalar_dist_codes: _I64,
+    scalar_transform_codes: _I64,
+    scalar_dist_params: _F64,
+    scalar_transform_params: _F64,
+    matrix_indices: _I64,
+    matrix_dims: _I64,
+    matrix_lengths: _I64,
+    matrix_etas: _F64,
+    matrix_log_constants: _F64,
+) -> float: ...

--- a/SymbolicDSGE/_ckernels/estimation/_prior_program.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_prior_program.pyx
@@ -1,0 +1,107 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Thin Cython shim for the native packed log-prior kernels.
+
+No numeric logic here -- only buffer->pointer marshalling and the GIL release.
+The algorithms live in prior_program.c; each ``def`` mirrors the matching numba
+helper in SymbolicDSGE/estimation/prior_program.py. The leaves are exposed so the
+parity tests can hit them directly; ``logprior_program`` is the per-replication
+hot path the estimator dispatches to. A NaN result means "fall back to the numba
+path" (out-of-support / unknown code), matching the numba kernel.
+"""
+
+from libc.stdint cimport int64_t
+
+
+cdef extern from "prior_program.h":
+    void sdsge_dist_logpdf(int64_t code, double *params, double x,
+                           double *out_logpdf) nogil
+    void sdsge_transform_inverse_and_logjac(int64_t code, double *params,
+                                            double z, double *out_x,
+                                            double *out_logjac) nogil
+    void sdsge_lkj_chol_logjac(double *z, int64_t dim, int64_t length,
+                               double *out_logjac) nogil
+    void sdsge_lkj_chol_logpdf_from_z(double *z, int64_t dim, int64_t length,
+                                      double eta, double log_const,
+                                      double *out_logpdf) nogil
+    double sdsge_logprior_program(
+        double *theta, int64_t *scalar_indices, int64_t *scalar_dist_codes,
+        int64_t *scalar_transform_codes, double *scalar_dist_params,
+        double *scalar_transform_params, int64_t n_scalar,
+        int64_t *matrix_indices, int64_t *matrix_dims, int64_t *matrix_lengths,
+        double *matrix_etas, double *matrix_log_constants, int64_t n_blocks,
+        int64_t max_matrix_len) nogil
+
+
+def dist_logpdf(int64_t code, double[::1] params, double x):
+    """Scalar family log-density at x. Returns the logpdf (NaN out-of-support)."""
+    cdef double out = 0.0
+    with nogil:
+        sdsge_dist_logpdf(code, &params[0], x, &out)
+    return out
+
+
+def transform_inverse_and_logjac(int64_t code, double[::1] params, double z):
+    """Inverse transform z -> x and its log-jacobian. Returns (x, logjac)."""
+    cdef double out_x = 0.0
+    cdef double out_logjac = 0.0
+    with nogil:
+        sdsge_transform_inverse_and_logjac(code, &params[0], z, &out_x,
+                                           &out_logjac)
+    return out_x, out_logjac
+
+
+def lkj_chol_logjac(double[::1] z, int64_t dim, int64_t length):
+    """LKJ-Cholesky log-jacobian. Returns the logjac (NaN if length too short)."""
+    cdef double *zp = &z[0] if z.shape[0] > 0 else NULL
+    cdef double out = 0.0
+    with nogil:
+        sdsge_lkj_chol_logjac(zp, dim, length, &out)
+    return out
+
+
+def lkj_chol_logpdf_from_z(double[::1] z, int64_t dim, int64_t length,
+                           double eta, double log_const):
+    """LKJ-Cholesky log-density from the unconstrained z block."""
+    cdef double *zp = &z[0] if z.shape[0] > 0 else NULL
+    cdef double out = 0.0
+    with nogil:
+        sdsge_lkj_chol_logpdf_from_z(zp, dim, length, eta, log_const, &out)
+    return out
+
+
+def logprior_program(double[::1] theta,
+                     int64_t[::1] scalar_indices,
+                     int64_t[::1] scalar_dist_codes,
+                     int64_t[::1] scalar_transform_codes,
+                     double[:, ::1] scalar_dist_params,
+                     double[:, ::1] scalar_transform_params,
+                     int64_t[:, ::1] matrix_indices,
+                     int64_t[::1] matrix_dims,
+                     int64_t[::1] matrix_lengths,
+                     double[::1] matrix_etas,
+                     double[::1] matrix_log_constants):
+    """Full packed log-prior. Returns the scalar logprior (NaN -> numba fallback)."""
+    cdef int64_t n_scalar = scalar_indices.shape[0]
+    cdef int64_t n_blocks = matrix_dims.shape[0]
+    cdef int64_t max_matrix_len = (
+        matrix_indices.shape[1] if matrix_indices.shape[0] > 0 else 0
+    )
+
+    cdef double *theta_p = &theta[0] if theta.shape[0] > 0 else NULL
+    cdef int64_t *si = &scalar_indices[0] if n_scalar > 0 else NULL
+    cdef int64_t *sdc = &scalar_dist_codes[0] if n_scalar > 0 else NULL
+    cdef int64_t *stc = &scalar_transform_codes[0] if n_scalar > 0 else NULL
+    cdef double *sdp = &scalar_dist_params[0, 0] if n_scalar > 0 else NULL
+    cdef double *stp = &scalar_transform_params[0, 0] if n_scalar > 0 else NULL
+    cdef int64_t *mi = &matrix_indices[0, 0] if n_blocks > 0 else NULL
+    cdef int64_t *md = &matrix_dims[0] if n_blocks > 0 else NULL
+    cdef int64_t *ml = &matrix_lengths[0] if n_blocks > 0 else NULL
+    cdef double *me = &matrix_etas[0] if n_blocks > 0 else NULL
+    cdef double *mlc = &matrix_log_constants[0] if n_blocks > 0 else NULL
+
+    cdef double out
+    with nogil:
+        out = sdsge_logprior_program(theta_p, si, sdc, stc, sdp, stp, n_scalar,
+                                     mi, md, ml, me, mlc, n_blocks,
+                                     max_matrix_len)
+    return out

--- a/SymbolicDSGE/_ckernels/estimation/prior_program.c
+++ b/SymbolicDSGE/_ckernels/estimation/prior_program.c
@@ -1,0 +1,275 @@
+#include "prior_program.h"
+#include <math.h>
+#include <stdlib.h>
+
+f64 sdsge_softplus_scalar(f64 x) {
+  if (x > 0.0) {
+    return x + log1p(exp(-x));
+  } else {
+    return log1p(exp(x));
+  }
+}
+
+f64 sdsge_log_sigmoid_scalar(f64 x) {
+  if (x > 0.0) {
+    return -log1p(exp(-x));
+  } else {
+    return x - log1p(exp(x));
+  }
+}
+
+f64 sdsge_sigmoid_scalar(f64 x) {
+  if (x >= 0.0) {
+    return 1.0 / (1.0 + exp(-x));
+  } else {
+    f64 exp_x = exp(x);
+    return exp_x / (1.0 + exp_x);
+  }
+}
+
+f64 sdsge_std_norm_cdf(f64 x) { return 0.5 * (1.0 + erf(x / SQRT2)); }
+
+f64 sdsge_std_norm_logpdf(f64 x) { return -0.5 * x * x - 0.5 * log(TWO_PI); }
+
+void sdsge_transform_inverse_and_logjac(i64 code, f64 *SDSGE_RESTRICT params,
+                                        f64 z, f64 *SDSGE_RESTRICT out_x,
+                                        f64 *SDSGE_RESTRICT out_logjac) {
+
+  switch (code) {
+  case SDSGE_TRANSFORM_IDENTITY:
+    *out_x = z;
+    *out_logjac = 0.0;
+    break;
+  case SDSGE_TRANSFORM_LOG:
+    *out_x = exp(z);
+    *out_logjac = z;
+    break;
+  case SDSGE_TRANSFORM_SOFTPLUS:
+    *out_x = sdsge_softplus_scalar(z);
+    *out_logjac = sdsge_log_sigmoid_scalar(z);
+    break;
+  case SDSGE_TRANSFORM_LOGIT:
+    *out_x = sdsge_sigmoid_scalar(z);
+    *out_logjac = sdsge_log_sigmoid_scalar(z) + sdsge_log_sigmoid_scalar(-z);
+    break;
+  case SDSGE_TRANSFORM_PROBIT:
+    *out_x = sdsge_std_norm_cdf(z);
+    *out_logjac = sdsge_std_norm_logpdf(z);
+    break;
+  case SDSGE_TRANSFORM_AFFINE_LOGIT: {
+    f64 sig = sdsge_sigmoid_scalar(z);
+    *out_x = params[0] + (params[2] * sig);
+    *out_logjac = log(params[2]) + sdsge_log_sigmoid_scalar(z) +
+                  sdsge_log_sigmoid_scalar(-z);
+    break;
+  }
+  case SDSGE_TRANSFORM_AFFINE_PROBIT:
+    *out_x = params[0] + (params[2] * sdsge_std_norm_cdf(z));
+    *out_logjac = log(params[2]) + sdsge_std_norm_logpdf(z);
+    break;
+  case SDSGE_TRANSFORM_LOWER_BOUNDED:
+    *out_x = params[0] + exp(z);
+    *out_logjac = z;
+    break;
+  case SDSGE_TRANSFORM_UPPER_BOUNDED:
+    *out_x = params[0] - exp(z);
+    *out_logjac = z;
+    break;
+  default:
+    *out_x = NAN;
+    *out_logjac = NAN;
+    break;
+  }
+}
+
+void sdsge_dist_logpdf(i64 code, f64 *SDSGE_RESTRICT params, f64 x,
+                       f64 *SDSGE_RESTRICT out_logpdf) {
+  switch (code) {
+  case SDSGE_DIST_NORMAL:
+    *out_logpdf = -0.5 * log(TWO_PI * params[1]) -
+                  0.5 * ((x - params[0]) * (x - params[0])) / params[1];
+    break;
+  case SDSGE_DIST_LOG_NORMAL:
+    if (x <= 0.0) {
+      *out_logpdf = NAN;
+    } else {
+      f64 log_x = log(x);
+      *out_logpdf = -log(params[1]) - log_x - 0.5 * log(TWO_PI) -
+                    0.5 * ((log_x - params[0]) / params[1]) *
+                        ((log_x - params[0]) / params[1]);
+    }
+    break;
+  case SDSGE_DIST_HALF_NORMAL:
+    if (x < 0.0) {
+      *out_logpdf = NAN;
+    } else {
+      *out_logpdf = 0.5 * log(2.0 / PI) - log(params[0]) -
+                    0.5 * (x / params[0]) * (x / params[0]);
+    }
+    break;
+  case SDSGE_DIST_TRUNC_NORMAL:
+    if (x < params[2] || x > params[3]) {
+      *out_logpdf = NAN;
+    } else {
+      f64 z = (x - params[0]) / params[1];
+      *out_logpdf = -0.5 * z * z - params[4];
+    }
+    break;
+  case SDSGE_DIST_HALF_CAUCHY:
+    if (x < 0.0) {
+      *out_logpdf = NAN;
+    } else {
+      f64 centered = x / params[0];
+      *out_logpdf = log(2.0 / PI) - log(params[0]) - log1p(centered * centered);
+    }
+    break;
+  case SDSGE_DIST_BETA:
+    if (x < 0.0 || x > 1.0) {
+      *out_logpdf = NAN;
+    } else {
+      *out_logpdf = 0.0;
+      if (params[0] != 1.0) {
+        *out_logpdf += (params[0] - 1.0) * log(x);
+      }
+      if (params[1] != 1.0) {
+        *out_logpdf += (params[1] - 1.0) * log1p(-x);
+      }
+      *out_logpdf -= params[2];
+    }
+    break;
+  case SDSGE_DIST_GAMMA:
+    if (x < 0.0) {
+      *out_logpdf = NAN;
+    } else {
+      f64 tmp = 0.0;
+      if (params[0] != 1.0) {
+        tmp += (params[0] - 1.0) * log(x);
+      }
+      *out_logpdf = tmp - x / params[1] - params[2];
+    }
+    break;
+  case SDSGE_DIST_INV_GAMMA:
+    if (x <= 0.0) {
+      *out_logpdf = NAN;
+    } else {
+      *out_logpdf = params[2] - (params[0] + 1.0) * log(x) - params[1] / x;
+    }
+    break;
+  case SDSGE_DIST_UNIFORM:
+    if (x < params[0] || x > params[1]) {
+      *out_logpdf = NAN;
+    } else {
+      *out_logpdf = -log(params[2]);
+    }
+    break;
+  default:
+    *out_logpdf = NAN;
+    break;
+  }
+}
+
+f64 sdsge_lkj_chol_logjac_return(f64 *SDSGE_RESTRICT z, i64 dim, i64 len) {
+  f64 logjac = 0.0;
+  i64 idx = 0;
+  for (i64 k = 1; k < dim; ++k) {
+    f64 rem = 1.0;
+    for (i64 j = 0; j < k; ++j) {
+      if (idx >= len) {
+        return NAN; // Out of bounds
+      }
+      f64 cpc_i = tanh(z[idx]);
+      logjac += 0.5 * log(max_f64(rem, 1e-300)); // Avoid log(0)
+      logjac += log1p(-(cpc_i * cpc_i));
+      rem *= (1.0 - cpc_i * cpc_i);
+      idx++;
+    }
+  }
+  return logjac;
+}
+
+void sdsge_lkj_chol_logjac(f64 *SDSGE_RESTRICT z, i64 dim, i64 len,
+                           f64 *SDSGE_RESTRICT out_logjac) {
+  *out_logjac = sdsge_lkj_chol_logjac_return(z, dim, len);
+}
+
+void sdsge_lkj_chol_logpdf_from_z(f64 *SDSGE_RESTRICT z, i64 dim, i64 len,
+                                  f64 eta, f64 log_const,
+                                  f64 *SDSGE_RESTRICT out_logpdf) {
+  f64 log_kernel = 0.0;
+  i64 idx = 0;
+  for (i64 i = 1; i < dim; ++i) {
+    f64 rem = 1.0;
+    for (i64 j = 0; j < i; ++j) {
+      if (idx >= len) {
+        *out_logpdf = NAN; // Out of bounds
+        return;
+      }
+      f64 cpc_i = tanh(z[idx]);
+      rem *= (1.0 - cpc_i * cpc_i);
+      idx++;
+    }
+    log_kernel +=
+        ((f64)dim - i + 2.0 * eta - 3.0) * log(sqrt(max_f64(rem, 1e-14)));
+  }
+  *out_logpdf =
+      log_const + log_kernel + sdsge_lkj_chol_logjac_return(z, dim, len);
+}
+
+/* Packed log-prior driver: the per-replication hot path. Mirrors the numba
+ * _evaluate_logprior_program -- sums the scalar terms (inverse-transform z -> x,
+ * then dist logpdf + transform log-jacobian) and the LKJ matrix blocks, and
+ * short-circuits to NaN the moment any term is NaN. */
+f64 sdsge_logprior_program(
+    f64 *SDSGE_RESTRICT theta, i64 *SDSGE_RESTRICT scalar_indices,
+    i64 *SDSGE_RESTRICT scalar_dist_codes,
+    i64 *SDSGE_RESTRICT scalar_transform_codes,
+    f64 *SDSGE_RESTRICT scalar_dist_params,
+    f64 *SDSGE_RESTRICT scalar_transform_params, i64 n_scalar,
+    i64 *SDSGE_RESTRICT matrix_indices, i64 *SDSGE_RESTRICT matrix_dims,
+    i64 *SDSGE_RESTRICT matrix_lengths, f64 *SDSGE_RESTRICT matrix_etas,
+    f64 *SDSGE_RESTRICT matrix_log_constants, i64 n_blocks, i64 max_matrix_len) {
+  f64 lp = 0.0;
+
+  for (i64 i = 0; i < n_scalar; ++i) {
+    f64 z = theta[scalar_indices[i]];
+    f64 x, logjac;
+    sdsge_transform_inverse_and_logjac(
+        scalar_transform_codes[i],
+        scalar_transform_params + i * SDSGE_N_TRANSFORM_PARAMS, z, &x, &logjac);
+    if (isnan(x) || isnan(logjac)) {
+      return NAN;
+    }
+    f64 logp;
+    sdsge_dist_logpdf(scalar_dist_codes[i],
+                      scalar_dist_params + i * SDSGE_N_DIST_PARAMS, x, &logp);
+    if (isnan(logp)) {
+      return NAN;
+    }
+    lp += logp + logjac;
+  }
+
+  if (n_blocks > 0) {
+    f64 *z_block = (f64 *)malloc((size_t)max_matrix_len * sizeof(f64));
+    if (z_block == NULL) {
+      return NAN;
+    }
+    for (i64 b = 0; b < n_blocks; ++b) {
+      i64 length = matrix_lengths[b];
+      for (i64 j = 0; j < length; ++j) {
+        z_block[j] = theta[matrix_indices[b * max_matrix_len + j]];
+      }
+      f64 block_lp;
+      sdsge_lkj_chol_logpdf_from_z(z_block, matrix_dims[b], length,
+                                   matrix_etas[b], matrix_log_constants[b],
+                                   &block_lp);
+      if (isnan(block_lp)) {
+        free(z_block);
+        return NAN;
+      }
+      lp += block_lp;
+    }
+    free(z_block);
+  }
+
+  return lp;
+}

--- a/SymbolicDSGE/_ckernels/estimation/prior_program.h
+++ b/SymbolicDSGE/_ckernels/estimation/prior_program.h
@@ -1,0 +1,82 @@
+#ifndef SDSGE_PRIOR_PROGRAM_H
+#define SDSGE_PRIOR_PROGRAM_H
+
+#include "../_common/sdsge_common.h"
+#include "../_common/sdsge_linalg.h"
+
+/* Integer dispatch codes for the packed log-prior kernel.
+ *
+ * These MUST stay in lockstep with the DistCode / TransformCode IntEnums in
+ * prior_program.py (same names, same values): the Python side packs every prior
+ * into int64 code arrays keyed by these values, and the native kernel switches
+ * on them. SDSGE_N_*_PARAMS are the packed-row strides (N_DIST_PARAMS /
+ * N_TRANSFORM_PARAMS in that module). Plain integer enums -- no CPython, no
+ * NumPy -- so the kernel can include this header directly. */
+
+typedef enum {
+  SDSGE_DIST_NORMAL = 1,
+  SDSGE_DIST_LOG_NORMAL = 2,
+  SDSGE_DIST_HALF_NORMAL = 3,
+  SDSGE_DIST_TRUNC_NORMAL = 4,
+  SDSGE_DIST_HALF_CAUCHY = 5,
+  SDSGE_DIST_BETA = 6,
+  SDSGE_DIST_GAMMA = 7,
+  SDSGE_DIST_INV_GAMMA = 8,
+  SDSGE_DIST_UNIFORM = 9
+} SdsgeDistCode;
+
+typedef enum {
+  SDSGE_TRANSFORM_IDENTITY = 1,
+  SDSGE_TRANSFORM_LOG = 2,
+  SDSGE_TRANSFORM_SOFTPLUS = 3,
+  SDSGE_TRANSFORM_LOGIT = 4,
+  SDSGE_TRANSFORM_PROBIT = 5,
+  SDSGE_TRANSFORM_AFFINE_LOGIT = 6,
+  SDSGE_TRANSFORM_AFFINE_PROBIT = 7,
+  SDSGE_TRANSFORM_LOWER_BOUNDED = 8,
+  SDSGE_TRANSFORM_UPPER_BOUNDED = 9
+} SdsgeTransformCode;
+
+/* Packed-row strides (mirror N_DIST_PARAMS / N_TRANSFORM_PARAMS). */
+#define SDSGE_N_DIST_PARAMS 5
+#define SDSGE_N_TRANSFORM_PARAMS 3
+
+/* Scalar helpers (exposed so the parity tests can hit them directly). */
+f64 sdsge_softplus_scalar(f64 x);
+f64 sdsge_log_sigmoid_scalar(f64 x);
+f64 sdsge_sigmoid_scalar(f64 x);
+f64 sdsge_std_norm_cdf(f64 x);
+f64 sdsge_std_norm_logpdf(f64 x);
+
+/* Leaf dispatchers. `code` is an i64 (the value arrives from an int64 array);
+ * it is matched against the Sdsge*Code enum constants. Out-of-support / unknown
+ * codes write NaN, the agreed "fall back to the Python path" sentinel. */
+void sdsge_transform_inverse_and_logjac(i64 code, f64 *SDSGE_RESTRICT params,
+                                        f64 z, f64 *SDSGE_RESTRICT out_x,
+                                        f64 *SDSGE_RESTRICT out_logjac);
+void sdsge_dist_logpdf(i64 code, f64 *SDSGE_RESTRICT params, f64 x,
+                       f64 *SDSGE_RESTRICT out_logpdf);
+
+/* LKJ-Cholesky log-jacobian (out-param and returning variants) and log-density
+ * over the `len` packed lower-triangle entries of a `dim`x`dim` block. */
+void sdsge_lkj_chol_logjac(f64 *SDSGE_RESTRICT z, i64 dim, i64 len,
+                           f64 *SDSGE_RESTRICT out_logjac);
+f64 sdsge_lkj_chol_logjac_return(f64 *SDSGE_RESTRICT z, i64 dim, i64 len);
+void sdsge_lkj_chol_logpdf_from_z(f64 *SDSGE_RESTRICT z, i64 dim, i64 len,
+                                  f64 eta, f64 log_const,
+                                  f64 *SDSGE_RESTRICT out_logpdf);
+
+/* Full packed log-prior (per-replication hot path). scalar_*_params are
+ * row-major n_scalar x stride; matrix_indices is row-major n_blocks x
+ * max_matrix_len. Returns the scalar logprior, or NaN if any term is NaN. */
+f64 sdsge_logprior_program(
+    f64 *SDSGE_RESTRICT theta, i64 *SDSGE_RESTRICT scalar_indices,
+    i64 *SDSGE_RESTRICT scalar_dist_codes,
+    i64 *SDSGE_RESTRICT scalar_transform_codes,
+    f64 *SDSGE_RESTRICT scalar_dist_params,
+    f64 *SDSGE_RESTRICT scalar_transform_params, i64 n_scalar,
+    i64 *SDSGE_RESTRICT matrix_indices, i64 *SDSGE_RESTRICT matrix_dims,
+    i64 *SDSGE_RESTRICT matrix_lengths, f64 *SDSGE_RESTRICT matrix_etas,
+    f64 *SDSGE_RESTRICT matrix_log_constants, i64 n_blocks, i64 max_matrix_len);
+
+#endif /* SDSGE_PRIOR_PROGRAM_H */

--- a/SymbolicDSGE/estimation/prior_program.py
+++ b/SymbolicDSGE/estimation/prior_program.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import IntEnum
 import math
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 import numpy as np
 from numba import njit
 from numpy import float64
 from numpy.typing import NDArray
+
+from .._native_dispatch import FORCE_NUMBA, REQUIRE_NATIVE
 
 from ..bayesian.distributions.beta import Beta
 from ..bayesian.distributions.gamma import Gamma
@@ -34,26 +37,61 @@ from ..bayesian.transforms.upper_bounded import UpperBoundedTransform
 NDF = NDArray[np.float64]
 NDI = NDArray[np.int64]
 
-DIST_NORMAL = 1
-DIST_LOG_NORMAL = 2
-DIST_HALF_NORMAL = 3
-DIST_TRUNC_NORMAL = 4
-DIST_HALF_CAUCHY = 5
-DIST_BETA = 6
-DIST_GAMMA = 7
-DIST_INV_GAMMA = 8
-DIST_UNIFORM = 9
+# Prefer the compiled native log-prior kernel; fall back to the numba kernel
+# below when the extension is not built. ALWAYS_USE_NUMBA / NEVER_USE_NUMBA
+# override the default (see SymbolicDSGE._native_dispatch). Declared explicitly so
+# the FORCE_NUMBA branch (which binds None) doesn't pin the type to None.
+_logprior_program_native: Callable[..., float] | None
+if FORCE_NUMBA:
+    _logprior_program_native = None
+else:
+    try:
+        from .._ckernels.estimation import logprior_program as _logprior_program_native
+    except ImportError:  # pragma: no cover - exercised only without the extension
+        if REQUIRE_NATIVE:
+            raise
+        _logprior_program_native = None
 
-TRANSFORM_IDENTITY = 1
-TRANSFORM_LOG = 2
-TRANSFORM_SOFTPLUS = 3
-TRANSFORM_LOGIT = 4
-TRANSFORM_PROBIT = 5
-TRANSFORM_AFFINE_LOGIT = 6
-TRANSFORM_AFFINE_PROBIT = 7
-TRANSFORM_LOWER_BOUNDED = 8
-TRANSFORM_UPPER_BOUNDED = 9
 
+class DistCode(IntEnum):
+    """Integer dispatch codes for scalar prior families in the packed kernel.
+
+    Mirrors ``SdsgeDistCode`` in ``prior_program.h`` -- the two MUST stay in
+    lockstep (same names, same values). The Python side packs these into the
+    int64 code arrays the native kernel switches on; numba evaluates the members
+    directly inside the cached njit hot loop.
+    """
+
+    NORMAL = 1
+    LOG_NORMAL = 2
+    HALF_NORMAL = 3
+    TRUNC_NORMAL = 4
+    HALF_CAUCHY = 5
+    BETA = 6
+    GAMMA = 7
+    INV_GAMMA = 8
+    UNIFORM = 9
+
+
+class TransformCode(IntEnum):
+    """Integer dispatch codes for prior transforms in the packed kernel.
+
+    Mirrors ``SdsgeTransformCode`` in ``prior_program.h``; see :class:`DistCode`.
+    """
+
+    IDENTITY = 1
+    LOG = 2
+    SOFTPLUS = 3
+    LOGIT = 4
+    PROBIT = 5
+    AFFINE_LOGIT = 6
+    AFFINE_PROBIT = 7
+    LOWER_BOUNDED = 8
+    UPPER_BOUNDED = 9
+
+
+#: Packed-row strides (mirror ``SDSGE_N_DIST_PARAMS`` / ``SDSGE_N_TRANSFORM_PARAMS``
+#: in ``prior_program.h``).
 N_DIST_PARAMS = 5
 N_TRANSFORM_PARAMS = 3
 
@@ -83,6 +121,22 @@ class PackedLogPrior:
         )
 
     def logpdf(self, theta: NDF) -> float64:
+        if _logprior_program_native is not None:
+            return float64(
+                _logprior_program_native(
+                    np.ascontiguousarray(theta, dtype=float64),
+                    self.scalar_indices,
+                    self.scalar_dist_codes,
+                    self.scalar_transform_codes,
+                    self.scalar_dist_params,
+                    self.scalar_transform_params,
+                    self.matrix_indices,
+                    self.matrix_dims,
+                    self.matrix_lengths,
+                    self.matrix_etas,
+                    self.matrix_log_constants,
+                )
+            )
         return float64(
             _evaluate_logprior_program(
                 theta,
@@ -199,75 +253,75 @@ def _pack_distribution(dist: Any) -> tuple[int | None, list[float]]:
     if isinstance(dist, Normal):
         params[0] = float(getattr(dist, "_mean"))
         params[1] = float(getattr(dist, "_var"))
-        return DIST_NORMAL, params
+        return DistCode.NORMAL, params
     if isinstance(dist, LogNormal):
         params[0] = float(getattr(dist, "_meanlog"))
         params[1] = float(getattr(dist, "_stdlog"))
-        return DIST_LOG_NORMAL, params
+        return DistCode.LOG_NORMAL, params
     if isinstance(dist, HalfNormal):
         params[0] = float(getattr(dist, "_std"))
-        return DIST_HALF_NORMAL, params
+        return DistCode.HALF_NORMAL, params
     if isinstance(dist, TruncNormal):
         params[0] = float(getattr(dist, "_mean"))
         params[1] = float(getattr(dist, "_std"))
         params[2] = float(getattr(dist, "_low_trunc"))
         params[3] = float(getattr(dist, "_high_trunc"))
         params[4] = float(getattr(dist, "_log_norm"))
-        return DIST_TRUNC_NORMAL, params
+        return DistCode.TRUNC_NORMAL, params
     if isinstance(dist, HalfCauchy):
         params[0] = float(getattr(dist, "_gamma"))
-        return DIST_HALF_CAUCHY, params
+        return DistCode.HALF_CAUCHY, params
     if isinstance(dist, Beta):
         params[0] = float(getattr(dist, "_a"))
         params[1] = float(getattr(dist, "_b"))
         params[2] = float(getattr(dist, "_log_norm"))
-        return DIST_BETA, params
+        return DistCode.BETA, params
     if isinstance(dist, Gamma):
         params[0] = float(getattr(dist, "_a"))
         params[1] = float(getattr(dist, "_theta"))
         params[2] = float(getattr(dist, "_log_norm"))
-        return DIST_GAMMA, params
+        return DistCode.GAMMA, params
     if isinstance(dist, InvGamma):
         params[0] = float(getattr(dist, "_a"))
         params[1] = float(getattr(dist, "_beta"))
         params[2] = float(getattr(dist, "_log_prefactor"))
-        return DIST_INV_GAMMA, params
+        return DistCode.INV_GAMMA, params
     if isinstance(dist, Uniform):
         params[0] = float(getattr(dist, "_low"))
         params[1] = float(getattr(dist, "_high"))
         params[2] = float(getattr(dist, "_width"))
-        return DIST_UNIFORM, params
+        return DistCode.UNIFORM, params
     return None, params
 
 
 def _pack_transform(transform: Any) -> tuple[int | None, list[float]]:
     params = _blank_transform_params()
     if isinstance(transform, Identity):
-        return TRANSFORM_IDENTITY, params
+        return TransformCode.IDENTITY, params
     if isinstance(transform, LogTransform):
-        return TRANSFORM_LOG, params
+        return TransformCode.LOG, params
     if isinstance(transform, SoftplusTransform):
-        return TRANSFORM_SOFTPLUS, params
+        return TransformCode.SOFTPLUS, params
     if isinstance(transform, LogitTransform):
-        return TRANSFORM_LOGIT, params
+        return TransformCode.LOGIT, params
     if isinstance(transform, ProbitTransform):
-        return TRANSFORM_PROBIT, params
+        return TransformCode.PROBIT, params
     if isinstance(transform, AffineLogitTransform):
         params[0] = float(transform.low)
         params[1] = float(transform.high)
         params[2] = float(transform.high - transform.low)
-        return TRANSFORM_AFFINE_LOGIT, params
+        return TransformCode.AFFINE_LOGIT, params
     if isinstance(transform, AffineProbitTransform):
         params[0] = float(transform.low)
         params[1] = float(transform.high)
         params[2] = float(transform.high - transform.low)
-        return TRANSFORM_AFFINE_PROBIT, params
+        return TransformCode.AFFINE_PROBIT, params
     if isinstance(transform, LowerBoundedTransform):
         params[0] = float(transform.low)
-        return TRANSFORM_LOWER_BOUNDED, params
+        return TransformCode.LOWER_BOUNDED, params
     if isinstance(transform, UpperBoundedTransform):
         params[0] = float(transform.high)
-        return TRANSFORM_UPPER_BOUNDED, params
+        return TransformCode.UPPER_BOUNDED, params
     return None, params
 
 
@@ -310,19 +364,19 @@ def _transform_inverse_and_logjac(
     params: NDF,
     z: float64,
 ) -> tuple[float64, float64]:
-    if code == TRANSFORM_IDENTITY:
+    if code == TransformCode.IDENTITY:
         return z, float64(0.0)
-    if code == TRANSFORM_LOG:
+    if code == TransformCode.LOG:
         return float64(math.exp(float(z))), z
-    if code == TRANSFORM_SOFTPLUS:
+    if code == TransformCode.SOFTPLUS:
         return _softplus_scalar(z), _log_sigmoid_scalar(z)
-    if code == TRANSFORM_LOGIT:
+    if code == TransformCode.LOGIT:
         return _sigmoid_scalar(z), float64(
             _log_sigmoid_scalar(z) + _log_sigmoid_scalar(-z)
         )
-    if code == TRANSFORM_PROBIT:
+    if code == TransformCode.PROBIT:
         return _std_norm_cdf(z), _std_norm_logpdf(z)
-    if code == TRANSFORM_AFFINE_LOGIT:
+    if code == TransformCode.AFFINE_LOGIT:
         low = params[0]
         span = params[2]
         sig = _sigmoid_scalar(z)
@@ -331,29 +385,29 @@ def _transform_inverse_and_logjac(
             math.log(float(span)) + _log_sigmoid_scalar(z) + _log_sigmoid_scalar(-z)
         )
         return x, logjac
-    if code == TRANSFORM_AFFINE_PROBIT:
+    if code == TransformCode.AFFINE_PROBIT:
         low = params[0]
         span = params[2]
         cdf = _std_norm_cdf(z)
         return float64(low + span * cdf), float64(
             math.log(float(span)) + _std_norm_logpdf(z)
         )
-    if code == TRANSFORM_LOWER_BOUNDED:
+    if code == TransformCode.LOWER_BOUNDED:
         return float64(params[0] + math.exp(float(z))), z
-    if code == TRANSFORM_UPPER_BOUNDED:
+    if code == TransformCode.UPPER_BOUNDED:
         return float64(params[0] - math.exp(float(z))), z
     return float64(np.nan), float64(np.nan)
 
 
 @njit(cache=True)
 def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
-    if code == DIST_NORMAL:
+    if code == DistCode.NORMAL:
         mean = params[0]
         var = params[1]
         return float64(
             -0.5 * math.log(2.0 * math.pi * float(var)) - 0.5 * ((x - mean) ** 2) / var
         )
-    if code == DIST_LOG_NORMAL:
+    if code == DistCode.LOG_NORMAL:
         if x <= 0.0:
             return float64(np.nan)
         meanlog = params[0]
@@ -364,14 +418,14 @@ def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
             - 0.5 * math.log(2.0 * math.pi)
             - 0.5 * ((math.log(float(x)) - meanlog) / stdlog) ** 2
         )
-    if code == DIST_HALF_NORMAL:
+    if code == DistCode.HALF_NORMAL:
         if x < 0.0:
             return float64(np.nan)
         std = params[0]
         return float64(
             0.5 * math.log(2.0 / math.pi) - math.log(float(std)) - 0.5 * (x / std) ** 2
         )
-    if code == DIST_TRUNC_NORMAL:
+    if code == DistCode.TRUNC_NORMAL:
         mean = params[0]
         std = params[1]
         low = params[2]
@@ -381,7 +435,7 @@ def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
             return float64(np.nan)
         z = float64((x - mean) / std)
         return float64(-0.5 * z * z - log_norm)
-    if code == DIST_HALF_CAUCHY:
+    if code == DistCode.HALF_CAUCHY:
         if x < 0.0:
             return float64(np.nan)
         gamma = params[0]
@@ -391,7 +445,7 @@ def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
             - math.log(float(gamma))
             - math.log1p(float(centered * centered))
         )
-    if code == DIST_BETA:
+    if code == DistCode.BETA:
         if x < 0.0 or x > 1.0:
             return float64(np.nan)
         a = params[0]
@@ -403,7 +457,7 @@ def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
         if b != 1.0:
             out += float64((b - 1.0) * math.log1p(float(-x)))
         return float64(out - log_norm)
-    if code == DIST_GAMMA:
+    if code == DistCode.GAMMA:
         if x < 0.0:
             return float64(np.nan)
         a = params[0]
@@ -413,14 +467,14 @@ def _dist_logpdf(code: int, params: NDF, x: float64) -> float64:
         if a != 1.0:
             out += float64((a - 1.0) * math.log(float(x)))
         return float64(out - x / theta - log_norm)
-    if code == DIST_INV_GAMMA:
+    if code == DistCode.INV_GAMMA:
         if x <= 0.0:
             return float64(np.nan)
         a = params[0]
         beta = params[1]
         log_prefactor = params[2]
         return float64(log_prefactor - (a + 1.0) * math.log(float(x)) - beta / x)
-    if code == DIST_UNIFORM:
+    if code == DistCode.UNIFORM:
         low = params[0]
         high = params[1]
         width = params[2]

--- a/tests/ckernels/test_prior_program.py
+++ b/tests/ckernels/test_prior_program.py
@@ -1,0 +1,232 @@
+"""Parity tests: native packed log-prior kernels vs the numba reference.
+
+The native C kernels in ``_ckernels/estimation`` must match the compiled numba
+helpers in ``SymbolicDSGE.estimation.prior_program`` bit-for-bit (up to libm).
+The compiled njit kernels are the oracle -- not their ``.py_func`` forms, which
+raise on ``math.log`` domain errors where numba/C return -inf/nan.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE._ckernels.estimation import (
+    dist_logpdf as native_dist_logpdf,
+    lkj_chol_logjac as native_lkj_logjac,
+    lkj_chol_logpdf_from_z as native_lkj_logpdf,
+    logprior_program as native_program,
+    transform_inverse_and_logjac as native_transform,
+)
+from SymbolicDSGE.bayesian import make_prior
+from SymbolicDSGE.bayesian.distributions.lkj_chol import _log_lkj_normalizer_C
+from SymbolicDSGE.estimation.prior_program import (
+    DistCode,
+    N_DIST_PARAMS,
+    N_TRANSFORM_PARAMS,
+    TransformCode,
+    _dist_logpdf,
+    _evaluate_logprior_program,
+    _lkj_chol_logjac,
+    _lkj_chol_logpdf_from_z,
+    _pack_distribution,
+    _pack_transform,
+    _transform_inverse_and_logjac,
+)
+
+RTOL = 1e-12
+ATOL = 1e-12
+
+
+def _agree(native: float, numba: float) -> None:
+    native = float(native)
+    numba = float(numba)
+    if np.isnan(native) or np.isnan(numba):
+        assert np.isnan(native) and np.isnan(numba), (native, numba)
+        return
+    # assert_allclose treats matching infinities as equal.
+    np.testing.assert_allclose(native, numba, rtol=RTOL, atol=ATOL)
+
+
+_DIST_SPECS = {
+    DistCode.NORMAL: ("normal", {"mean": 0.0, "std": 1.0, "random_state": 1}),
+    DistCode.LOG_NORMAL: ("log_normal", {"mean": 0.0, "std": 0.5, "random_state": 1}),
+    DistCode.HALF_NORMAL: ("half_normal", {"std": 1.0, "random_state": 1}),
+    DistCode.TRUNC_NORMAL: (
+        "trunc_normal",
+        {"mean": 0.0, "std": 1.0, "low": -1.0, "high": 1.0, "random_state": 1},
+    ),
+    DistCode.HALF_CAUCHY: ("half_cauchy", {"gamma": 1.0, "random_state": 1}),
+    DistCode.BETA: ("beta", {"a": 2.0, "b": 3.0, "random_state": 1}),
+    DistCode.GAMMA: ("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}),
+    DistCode.INV_GAMMA: ("inv_gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}),
+    DistCode.UNIFORM: ("uniform", {"low": -1.0, "high": 1.0, "random_state": 1}),
+}
+
+_X_SWEEP = (-2.0, -0.5, 0.0, 0.25, 0.5, 0.7, 1.0, 1.5, 3.0)
+
+
+@pytest.mark.parametrize("code,spec", list(_DIST_SPECS.items()))
+def test_dist_logpdf_parity(code, spec):
+    family, params = spec
+    prior = make_prior(family, params, "identity")
+    packed_code, packed_params = _pack_distribution(prior.dist)
+    assert int(packed_code) == int(code)
+    parr = np.asarray(packed_params, dtype=np.float64)
+
+    for x in _X_SWEEP:
+        numba = _dist_logpdf(int(code), parr, np.float64(x))
+        native = native_dist_logpdf(int(code), parr, float(x))
+        _agree(native, numba)
+
+
+def test_dist_logpdf_unknown_code_is_nan():
+    parr = np.zeros(N_DIST_PARAMS, dtype=np.float64)
+    _agree(native_dist_logpdf(999, parr, 0.0), _dist_logpdf(999, parr, np.float64(0.0)))
+
+
+@pytest.mark.parametrize("code", list(TransformCode))
+def test_transform_parity(code):
+    # params = [low, high, span]; only the affine transforms read them.
+    params = np.array([-1.0, 2.0, 3.0], dtype=np.float64)
+    for z in (-3.0, -0.7, 0.0, 0.4, 1.3, 4.0):
+        nx, nj = _transform_inverse_and_logjac(int(code), params, np.float64(z))
+        cx, cj = native_transform(int(code), params, float(z))
+        _agree(cx, nx)
+        _agree(cj, nj)
+
+
+def test_transform_unknown_code_is_nan():
+    params = np.zeros(N_TRANSFORM_PARAMS, dtype=np.float64)
+    cx, cj = native_transform(999, params, 0.5)
+    nx, nj = _transform_inverse_and_logjac(999, params, np.float64(0.5))
+    _agree(cx, nx)
+    _agree(cj, nj)
+
+
+@pytest.mark.parametrize("dim", [2, 3, 4, 5])
+def test_lkj_parity(dim):
+    rng = np.random.default_rng(dim)
+    length = dim * (dim - 1) // 2
+    z = np.ascontiguousarray(rng.normal(size=length), dtype=np.float64)
+
+    _agree(native_lkj_logjac(z, dim, length), _lkj_chol_logjac(z, dim, length))
+
+    for eta in (0.5, 1.0, 2.5):
+        log_const = float(_log_lkj_normalizer_C(dim, eta))
+        _agree(
+            native_lkj_logpdf(z, dim, length, eta, log_const),
+            _lkj_chol_logpdf_from_z(
+                z, dim, length, np.float64(eta), np.float64(log_const)
+            ),
+        )
+
+
+def test_lkj_length_too_short_is_nan(dim=4):
+    z = np.array([0.1, 0.2], dtype=np.float64)
+    _agree(native_lkj_logjac(z, dim, z.size), _lkj_chol_logjac(z, dim, z.size))
+    _agree(
+        native_lkj_logpdf(z, dim, z.size, 1.0, 0.0),
+        _lkj_chol_logpdf_from_z(z, dim, z.size, np.float64(1.0), np.float64(0.0)),
+    )
+
+
+def _empty_block_arrays():
+    return dict(
+        matrix_indices=np.empty((0, 0), dtype=np.int64),
+        matrix_dims=np.empty((0,), dtype=np.int64),
+        matrix_lengths=np.empty((0,), dtype=np.int64),
+        matrix_etas=np.empty((0,), dtype=np.float64),
+        matrix_log_constants=np.empty((0,), dtype=np.float64),
+    )
+
+
+def _pack_scalars(specs):
+    codes_d, codes_t, dp, tp = [], [], [], []
+    for fam, params, transform in specs:
+        prior = make_prior(fam, params, transform)
+        dc, dpar = _pack_distribution(prior.dist)
+        tc, tpar = _pack_transform(prior.transform)
+        codes_d.append(int(dc))
+        codes_t.append(int(tc))
+        dp.append(dpar)
+        tp.append(tpar)
+    n = len(specs)
+    return dict(
+        scalar_dist_codes=np.asarray(codes_d, dtype=np.int64),
+        scalar_transform_codes=np.asarray(codes_t, dtype=np.int64),
+        scalar_dist_params=np.asarray(dp, dtype=np.float64).reshape(n, N_DIST_PARAMS),
+        scalar_transform_params=np.asarray(tp, dtype=np.float64).reshape(
+            n, N_TRANSFORM_PARAMS
+        ),
+    )
+
+
+def _call_both(theta, scalar_indices, packed, block):
+    args = (
+        theta,
+        scalar_indices,
+        packed["scalar_dist_codes"],
+        packed["scalar_transform_codes"],
+        packed["scalar_dist_params"],
+        packed["scalar_transform_params"],
+        block["matrix_indices"],
+        block["matrix_dims"],
+        block["matrix_lengths"],
+        block["matrix_etas"],
+        block["matrix_log_constants"],
+    )
+    return native_program(*args), _evaluate_logprior_program(*args)
+
+
+def test_logprior_program_scalar_only_parity():
+    specs = [
+        ("normal", {"mean": 0.0, "std": 1.0, "random_state": 1}, "identity"),
+        ("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "log"),
+        ("beta", {"a": 2.0, "b": 3.0, "random_state": 1}, "logit"),
+        ("half_normal", {"std": 1.0, "random_state": 1}, "softplus"),
+    ]
+    packed = _pack_scalars(specs)
+    rng = np.random.default_rng(7)
+    scalar_indices = np.arange(len(specs), dtype=np.int64)
+    for _ in range(20):
+        theta = np.ascontiguousarray(rng.normal(size=len(specs)), dtype=np.float64)
+        native, numba = _call_both(theta, scalar_indices, packed, _empty_block_arrays())
+        _agree(native, numba)
+
+
+def test_logprior_program_with_lkj_block_parity():
+    specs = [
+        ("normal", {"mean": 0.0, "std": 1.0, "random_state": 1}, "identity"),
+        ("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "log"),
+    ]
+    packed = _pack_scalars(specs)
+    scalar_indices = np.array([0, 1], dtype=np.int64)
+
+    dim = 3
+    length = dim * (dim - 1) // 2  # 3
+    block = dict(
+        matrix_indices=np.array([[2, 3, 4]], dtype=np.int64),
+        matrix_dims=np.array([dim], dtype=np.int64),
+        matrix_lengths=np.array([length], dtype=np.int64),
+        matrix_etas=np.array([2.0], dtype=np.float64),
+        matrix_log_constants=np.array(
+            [float(_log_lkj_normalizer_C(dim, 2.0))], dtype=np.float64
+        ),
+    )
+    rng = np.random.default_rng(11)
+    for _ in range(20):
+        theta = np.ascontiguousarray(rng.normal(size=5), dtype=np.float64)
+        native, numba = _call_both(theta, scalar_indices, packed, block)
+        _agree(native, numba)
+
+
+def test_logprior_program_out_of_support_is_nan():
+    # gamma + identity with negative theta -> x < 0 -> NaN short-circuit.
+    specs = [("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "identity")]
+    packed = _pack_scalars(specs)
+    scalar_indices = np.array([0], dtype=np.int64)
+    theta = np.array([-1.0], dtype=np.float64)
+    native, numba = _call_both(theta, scalar_indices, packed, _empty_block_arrays())
+    _agree(native, numba)
+    assert np.isnan(float(native))

--- a/tests/estimation/test_prior_program.py
+++ b/tests/estimation/test_prior_program.py
@@ -7,26 +7,10 @@ import pytest
 
 from SymbolicDSGE.bayesian import make_prior
 from SymbolicDSGE.estimation.prior_program import (
-    DIST_BETA,
-    DIST_GAMMA,
-    DIST_HALF_CAUCHY,
-    DIST_HALF_NORMAL,
-    DIST_INV_GAMMA,
-    DIST_LOG_NORMAL,
-    DIST_NORMAL,
-    DIST_TRUNC_NORMAL,
-    DIST_UNIFORM,
+    DistCode,
     N_DIST_PARAMS,
     N_TRANSFORM_PARAMS,
-    TRANSFORM_AFFINE_LOGIT,
-    TRANSFORM_AFFINE_PROBIT,
-    TRANSFORM_IDENTITY,
-    TRANSFORM_LOG,
-    TRANSFORM_LOGIT,
-    TRANSFORM_LOWER_BOUNDED,
-    TRANSFORM_PROBIT,
-    TRANSFORM_SOFTPLUS,
-    TRANSFORM_UPPER_BOUNDED,
+    TransformCode,
     _dist_logpdf,
     _evaluate_logprior_program,
     _lkj_chol_logjac,
@@ -360,15 +344,15 @@ def test_prior_program_scalar_transform_helpers_cover_all_branches():
 
     params = np.array([1.0, 3.0, 2.0], dtype=np.float64)
     for code in (
-        TRANSFORM_IDENTITY,
-        TRANSFORM_LOG,
-        TRANSFORM_SOFTPLUS,
-        TRANSFORM_LOGIT,
-        TRANSFORM_PROBIT,
-        TRANSFORM_AFFINE_LOGIT,
-        TRANSFORM_AFFINE_PROBIT,
-        TRANSFORM_LOWER_BOUNDED,
-        TRANSFORM_UPPER_BOUNDED,
+        TransformCode.IDENTITY,
+        TransformCode.LOG,
+        TransformCode.SOFTPLUS,
+        TransformCode.LOGIT,
+        TransformCode.PROBIT,
+        TransformCode.AFFINE_LOGIT,
+        TransformCode.AFFINE_PROBIT,
+        TransformCode.LOWER_BOUNDED,
+        TransformCode.UPPER_BOUNDED,
     ):
         x, logjac = _transform_inverse_and_logjac.py_func(
             code,
@@ -418,15 +402,15 @@ def test_prior_program_distribution_logpdf_dispatch_and_support_edges():
         ),
     }
     valid_x = {
-        DIST_NORMAL: 0.25,
-        DIST_LOG_NORMAL: 1.2,
-        DIST_HALF_NORMAL: 0.25,
-        DIST_TRUNC_NORMAL: 0.25,
-        DIST_HALF_CAUCHY: 0.25,
-        DIST_BETA: 0.25,
-        DIST_GAMMA: 1.5,
-        DIST_INV_GAMMA: 1.5,
-        DIST_UNIFORM: 0.25,
+        DistCode.NORMAL: 0.25,
+        DistCode.LOG_NORMAL: 1.2,
+        DistCode.HALF_NORMAL: 0.25,
+        DistCode.TRUNC_NORMAL: 0.25,
+        DistCode.HALF_CAUCHY: 0.25,
+        DistCode.BETA: 0.25,
+        DistCode.GAMMA: 1.5,
+        DistCode.INV_GAMMA: 1.5,
+        DistCode.UNIFORM: 0.25,
     }
 
     for prior in scalar_priors.values():
@@ -440,14 +424,14 @@ def test_prior_program_distribution_logpdf_dispatch_and_support_edges():
         assert np.isfinite(out)
 
     for code, params, bad_x in (
-        (DIST_LOG_NORMAL, [0.0, 1.0, 0.0, 0.0, 0.0], -1.0),
-        (DIST_HALF_NORMAL, [1.0, 0.0, 0.0, 0.0, 0.0], -1.0),
-        (DIST_TRUNC_NORMAL, [0.0, 1.0, -1.0, 1.0, 0.0], 2.0),
-        (DIST_HALF_CAUCHY, [1.0, 0.0, 0.0, 0.0, 0.0], -1.0),
-        (DIST_BETA, [1.0, 1.0, 0.0, 0.0, 0.0], 2.0),
-        (DIST_GAMMA, [1.0, 1.0, 0.0, 0.0, 0.0], -1.0),
-        (DIST_INV_GAMMA, [1.0, 1.0, 0.0, 0.0, 0.0], 0.0),
-        (DIST_UNIFORM, [-1.0, 1.0, 2.0, 0.0, 0.0], 2.0),
+        (DistCode.LOG_NORMAL, [0.0, 1.0, 0.0, 0.0, 0.0], -1.0),
+        (DistCode.HALF_NORMAL, [1.0, 0.0, 0.0, 0.0, 0.0], -1.0),
+        (DistCode.TRUNC_NORMAL, [0.0, 1.0, -1.0, 1.0, 0.0], 2.0),
+        (DistCode.HALF_CAUCHY, [1.0, 0.0, 0.0, 0.0, 0.0], -1.0),
+        (DistCode.BETA, [1.0, 1.0, 0.0, 0.0, 0.0], 2.0),
+        (DistCode.GAMMA, [1.0, 1.0, 0.0, 0.0, 0.0], -1.0),
+        (DistCode.INV_GAMMA, [1.0, 1.0, 0.0, 0.0, 0.0], 0.0),
+        (DistCode.UNIFORM, [-1.0, 1.0, 2.0, 0.0, 0.0], 2.0),
         (999, [0.0] * N_DIST_PARAMS, 0.0),
     ):
         assert np.isnan(
@@ -485,8 +469,8 @@ def test_prior_program_lkj_and_evaluator_python_paths_cover_nan_branches():
 
     theta = np.array([0.25], dtype=np.float64)
     scalar_indices = np.array([0], dtype=np.int64)
-    scalar_dist_codes = np.array([DIST_NORMAL], dtype=np.int64)
-    scalar_transform_codes = np.array([TRANSFORM_IDENTITY], dtype=np.int64)
+    scalar_dist_codes = np.array([DistCode.NORMAL], dtype=np.int64)
+    scalar_transform_codes = np.array([TransformCode.IDENTITY], dtype=np.int64)
     scalar_dist_params = np.zeros((1, N_DIST_PARAMS), dtype=np.float64)
     scalar_dist_params[0, 1] = 1.0
     scalar_transform_params = np.zeros((1, N_TRANSFORM_PARAMS), dtype=np.float64)
@@ -513,7 +497,7 @@ def test_prior_program_lkj_and_evaluator_python_paths_cover_nan_branches():
         _evaluate_logprior_program.py_func(
             np.array([-0.25], dtype=np.float64),
             scalar_indices,
-            np.array([DIST_LOG_NORMAL], dtype=np.int64),
+            np.array([DistCode.LOG_NORMAL], dtype=np.int64),
             scalar_transform_codes,
             scalar_dist_params,
             scalar_transform_params,


### PR DESCRIPTION
This pull request introduces a new native (C/Cython) implementation of the packed log-prior kernel for estimation, with Python bindings and type stubs. It replaces the previous Python/Numba-only approach with an optional high-performance native path, while maintaining compatibility and fallback logic. The dispatch codes for distributions and transforms are now defined as `IntEnum` classes to ensure strict parity between Python and C. The main changes are grouped as follows:

### Native kernel implementation and integration

* Added a new C implementation of the packed log-prior kernel and its helpers, including scalar transforms, distribution log-densities, and LKJ-Cholesky matrix block handling (`prior_program.c`, `prior_program.h`). [[1]](diffhunk://#diff-d0a6f68dddb5202698319f8dae8ac0a519ca91dfe0968ed5f08168f3dc826c7dR1-R275) [[2]](diffhunk://#diff-e7f1e956122806219b3b0884a19d7c22f05f29b18f004842a029f08791d49555R1-R82)
* Introduced a Cython shim (`_prior_program.pyx`) to expose the native functions to Python, handling buffer marshalling and GIL management.
* Provided Python type stubs for the native extension (`_prior_program.pyi`).
* Added a Python package initializer to re-export the compiled extension, with fallback to the Numba kernel if unavailable (`__init__.py`).

### Python API and dispatch improvements

* Refactored the Python log-prior program to use the native kernel by default, with explicit fallback and override controls (`FORCE_NUMBA`, `REQUIRE_NATIVE`). [[1]](diffhunk://#diff-5532c552ac6fb1d016cfe2de880e204fe2cad830a2dd6b5fcc23782fea20f6afR4-R14) [[2]](diffhunk://#diff-5532c552ac6fb1d016cfe2de880e204fe2cad830a2dd6b5fcc23782fea20f6afL37-R94)
* Replaced distribution and transform dispatch code constants with `IntEnum` classes (`DistCode`, `TransformCode`) to ensure strict parity and maintainability with the C enums.
* Updated the main log-prior evaluation path to call the native kernel when available, falling back to the Numba implementation otherwise.

### Shared definitions

* Added a missing constant definition for `SQRT2` in the shared C header (`sdsge_common.h`).

These changes collectively provide a robust, high-performance, and maintainable foundation for native log-prior evaluation in the estimation pipeline.

closes #218 