### PR TITLE
Add c128 complex-number type and arithmetic helpers

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
@@ -1,0 +1,40 @@
+#include "sdsge_complex.h"
+#include <math.h>
+
+c128 c128_make(f64 re, f64 im) {
+  c128 result;
+  result.re = re;
+  result.im = im;
+  return result;
+}
+
+c128 c128_from_real(f64 re) { return c128_make(re, 0.0); }
+
+c128 c128_add(c128 a, c128 b) { return c128_make(a.re + b.re, a.im + b.im); }
+
+c128 c128_sub(c128 a, c128 b) { return c128_make(a.re - b.re, a.im - b.im); }
+
+c128 c128_mul(c128 a, c128 b) {
+  return c128_make(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re);
+}
+
+c128 c128_div(c128 a, c128 b) {
+  c128 result;
+  f64 r;
+  if (fabs(b.re) >= fabs(b.im)) {
+    r = b.im / b.re;
+    result.re = (a.re + a.im * r) / (b.re + b.im * r);
+    result.im = (a.im - a.re * r) / (b.re + b.im * r);
+  } else {
+    r = b.re / b.im;
+    result.re = (a.im + a.re * r) / (b.im + b.re * r);
+    result.im = (-a.re + a.im * r) / (b.im + b.re * r);
+  }
+  return result;
+}
+
+f64 c128_abs(c128 a) { return hypot(a.re, a.im); }
+
+f64 c128_real(c128 a) { return a.re; }
+
+f64 c128_imag(c128 a) { return a.im; }

--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
@@ -1,0 +1,23 @@
+#ifndef SDSGE_COMPLEX_H
+#define SDSGE_COMPLEX_H
+#include "sdsge_common.h"
+
+/* Simple complex number implementation with 64+64 bit representation matching
+ * numpy's complex128 type. */
+
+typedef struct {
+  f64 re;
+  f64 im;
+} c128;
+
+c128 c128_make(f64 re, f64 im);
+c128 c128_from_real(f64 re);
+c128 c128_add(c128 a, c128 b);
+c128 c128_sub(c128 a, c128 b);
+c128 c128_mul(c128 a, c128 b);
+c128 c128_div(c128 a, c128 b);
+f64 c128_abs(c128 a);
+f64 c128_real(c128 a);
+f64 c128_imag(c128 a);
+
+#endif /* SDSGE_COMPLEX_H */


### PR DESCRIPTION
This pull request introduces a new implementation of complex number arithmetic for 64-bit floating point numbers, matching NumPy's `complex128` type. The changes provide a dedicated header and source file for complex number operations, including creation, arithmetic, and accessors.

Complex number support:

* Added a new struct `c128` to represent complex numbers with 64-bit real and imaginary parts, along with function declarations for creating and manipulating complex numbers in `sdsge_complex.h`.
* Implemented functions for complex number creation, addition, subtraction, multiplication, division, absolute value, and accessing real and imaginary parts in `sdsge_complex.c`.

closes #237 