### PR TITLE
Implement LU factorization and solve for complex matrices

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
@@ -147,3 +147,37 @@ void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
     }
   }
 }
+
+i64 c128_solve(const c128 *SDSGE_RESTRICT A, const c128 *SDSGE_RESTRICT B,
+               const i64 n, const i64 m, c128 *SDSGE_RESTRICT X) {
+  c128_lu lu = c128_lu_factor(A, n);
+  if (lu.err != SDSGE_LU_SUCCESS) {
+    i64 err = lu.err;
+    c128_lu_free(&lu);
+    return err;
+  }
+  c128_lu_solve(lu.lu, lu.piv, B, X, n, m);
+  c128_lu_free(&lu);
+  return SDSGE_LU_SUCCESS;
+}
+
+i64 c128_inv(const c128 *SDSGE_RESTRICT A, const i64 n,
+             c128 *SDSGE_RESTRICT Ainv) {
+  c128 *I = (c128 *)malloc(sizeof(c128) * n * n);
+  if (!I) {
+    return SDSGE_LU_ALLOC_FAIL;
+  }
+
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < n; ++j) {
+      I[i * n + j] = (i == j) ? c128_make(1.0, 0.0) : c128_make(0.0, 0.0);
+    }
+  }
+
+  i64 err = c128_solve(A, I, n, n, Ainv);
+  free(I);
+  if (err != SDSGE_LU_SUCCESS) {
+    return err;
+  }
+  return SDSGE_LU_SUCCESS;
+}

--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
@@ -1,40 +1,149 @@
 #include "sdsge_complex.h"
-#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
-c128 c128_make(f64 re, f64 im) {
-  c128 result;
-  result.re = re;
-  result.im = im;
-  return result;
-}
+/* Scalar c128 arithmetic is now defined `static inline` in sdsge_complex.h. */
 
-c128 c128_from_real(f64 re) { return c128_make(re, 0.0); }
+/* Linalg (LU, Matmul, Solve, Inverse) */
 
-c128 c128_add(c128 a, c128 b) { return c128_make(a.re + b.re, a.im + b.im); }
+void c128_matmul(const c128 *SDSGE_RESTRICT A, const c128 *SDSGE_RESTRICT B,
+                 const i64 m, const i64 n, const i64 p,
+                 c128 *SDSGE_RESTRICT out) {
+  /* GEMM row-major */
 
-c128 c128_sub(c128 a, c128 b) { return c128_make(a.re - b.re, a.im - b.im); }
+  for (i64 i = 0; i < m; ++i) {
+    for (i64 j = 0; j < p; ++j) {
+      c128 sum = c128_make(0.0, 0.0);
 
-c128 c128_mul(c128 a, c128 b) {
-  return c128_make(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re);
-}
-
-c128 c128_div(c128 a, c128 b) {
-  c128 result;
-  f64 r;
-  if (fabs(b.re) >= fabs(b.im)) {
-    r = b.im / b.re;
-    result.re = (a.re + a.im * r) / (b.re + b.im * r);
-    result.im = (a.im - a.re * r) / (b.re + b.im * r);
-  } else {
-    r = b.re / b.im;
-    result.re = (a.im + a.re * r) / (b.im + b.re * r);
-    result.im = (-a.re + a.im * r) / (b.im + b.re * r);
+      for (i64 k = 0; k < n; ++k) {
+        sum = c128_add(sum, c128_mul(A[i * n + k], B[k * p + j]));
+      }
+      out[i * p + j] = sum;
+    }
   }
+}
+
+i64 c128_lu_factor_inplace(c128 *SDSGE_RESTRICT A, i64 *SDSGE_RESTRICT pivot,
+                           const i64 n) {
+  if (!A || !pivot || n <= 0) {
+    return SDSGE_LU_ALLOC_FAIL;
+  }
+
+  for (i64 k = 0; k < n; ++k) {
+    i64 piv = k;
+    f64 best = c128_abs2(A[k * n + k]);
+
+    for (i64 i = k + 1; i < n; ++i) {
+      f64 v = c128_abs2(A[i * n + k]);
+      if (v > best) {
+        best = v;
+        piv = i;
+      }
+    }
+    pivot[k] = piv;
+
+    if (best == 0.0) {
+      return SDSGE_LU_SINGULAR;
+    }
+
+    if (piv != k) {
+      for (i64 j = 0; j < n; ++j) {
+        c128 tmp = A[k * n + j];
+        A[k * n + j] = A[piv * n + j];
+        A[piv * n + j] = tmp;
+      }
+    }
+
+    c128 Akk = A[k * n + k];
+    for (i64 i = k + 1; i < n; ++i) {
+      A[i * n + k] = c128_div(A[i * n + k], Akk);
+
+      c128 Lik = A[i * n + k];
+      for (i64 j = k + 1; j < n; ++j) {
+        A[i * n + j] = c128_sub(A[i * n + j], c128_mul(Lik, A[k * n + j]));
+      }
+    }
+  }
+  return SDSGE_LU_SUCCESS;
+}
+
+c128_lu c128_lu_factor(const c128 *A, const i64 n) {
+  c128_lu result;
+  result.lu = NULL;
+  result.piv = NULL;
+  result.n = n;
+  result.err = SDSGE_LU_SUCCESS;
+
+  if (!A || n <= 0) {
+    result.err = SDSGE_LU_ALLOC_FAIL;
+    return result;
+  }
+
+  result.lu = (c128 *)malloc(sizeof(c128) * n * n);
+  result.piv = (i64 *)malloc(sizeof(i64) * n);
+  if (!result.lu || !result.piv) {
+    result.err = SDSGE_LU_ALLOC_FAIL;
+    free(result.lu);
+    free(result.piv);
+    result.lu = NULL;
+    result.piv = NULL;
+    return result;
+  }
+
+  memcpy(result.lu, A, sizeof(c128) * n * n);
+  result.err = c128_lu_factor_inplace(result.lu, result.piv, n);
   return result;
 }
 
-f64 c128_abs(c128 a) { return hypot(a.re, a.im); }
+void c128_lu_free(c128_lu *lu) {
+  if (!lu)
+    return;
+  free(lu->lu);
+  free(lu->piv);
+  lu->lu = NULL;
+  lu->piv = NULL;
+  lu->n = 0;
+  lu->err = 0;
+}
 
-f64 c128_real(c128 a) { return a.re; }
+void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
+                   const c128 *SDSGE_RESTRICT B, c128 *SDSGE_RESTRICT X,
+                   const i64 n, const i64 m) {
+  /* X := B, then replay the factorization's row swaps (k <-> piv[k], forward).
+   */
+  memcpy(X, B, sizeof(c128) * n * m);
+  for (i64 k = 0; k < n; ++k) {
+    i64 pk = piv[k];
+    if (pk != k) {
+      for (i64 j = 0; j < m; ++j) {
+        c128 tmp = X[k * m + j];
+        X[k * m + j] = X[pk * m + j];
+        X[pk * m + j] = tmp;
+      }
+    }
+  }
 
-f64 c128_imag(c128 a) { return a.im; }
+  /* Forward substitution: L Y = PB, with L unit lower-triangular. */
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 k = 0; k < i; ++k) {
+      c128 Lik = LU[i * n + k];
+      for (i64 j = 0; j < m; ++j) {
+        X[i * m + j] = c128_sub(X[i * m + j], c128_mul(Lik, X[k * m + j]));
+      }
+    }
+  }
+
+  /* Back substitution: U X = Y. */
+  for (i64 i = n - 1; i >= 0; --i) {
+    for (i64 k = i + 1; k < n; ++k) {
+      c128 Uik = LU[i * n + k];
+      for (i64 j = 0; j < m; ++j) {
+        X[i * m + j] = c128_sub(X[i * m + j], c128_mul(Uik, X[k * m + j]));
+      }
+    }
+    c128 Uii = LU[i * n + i];
+    for (i64 j = 0; j < m; ++j) {
+      X[i * m + j] = c128_div(X[i * m + j], Uii);
+    }
+  }
+}

--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
@@ -74,12 +74,18 @@ i64 c128_lu_factor_inplace(c128 *SDSGE_RESTRICT A, i64 *SDSGE_RESTRICT pivot,
                            const i64 n);
 void c128_lu_free(c128_lu *lu);
 
-/* Solve (L U) X = B for X(n,m) from a factorization (LU(n,n), piv(n)) produced by
- * c128_lu_factor[_inplace]. B(n,m) is the RHS; X(n,m) is the output and must not
- * alias B/LU. m == 1 is a vector solve; B == identity gives the inverse. */
+/* Solve (L U) X = B for X(n,m) from a factorization (LU(n,n), piv(n)) produced
+ * by c128_lu_factor[_inplace]. B(n,m) is the RHS; X(n,m) is the output and must
+ * not alias B/LU. m == 1 is a vector solve; B == identity gives the inverse. */
 void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
                    const c128 *SDSGE_RESTRICT B, c128 *SDSGE_RESTRICT X,
                    const i64 n, const i64 m);
+
+i64 c128_solve(const c128 *SDSGE_RESTRICT A, const c128 *SDSGE_RESTRICT B,
+               const i64 n, const i64 m, c128 *SDSGE_RESTRICT X);
+
+i64 c128_inv(const c128 *SDSGE_RESTRICT A, const i64 n,
+             c128 *SDSGE_RESTRICT Ainv);
 
 /* ERROR CODES */
 #define SDSGE_LU_SUCCESS 0

--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
@@ -10,14 +10,80 @@ typedef struct {
   f64 im;
 } c128;
 
-c128 c128_make(f64 re, f64 im);
-c128 c128_from_real(f64 re);
-c128 c128_add(c128 a, c128 b);
-c128 c128_sub(c128 a, c128 b);
-c128 c128_mul(c128 a, c128 b);
-c128 c128_div(c128 a, c128 b);
-f64 c128_abs(c128 a);
-f64 c128_real(c128 a);
-f64 c128_imag(c128 a);
+typedef struct {
+  c128 *lu;
+  i64 *piv;
+  i64 n;
+  i64 err;
+} c128_lu;
+
+/* Arithmetic. Defined `static inline` in the header so every translation unit
+ * inlines them; math.h (fabs/hypot) comes in via sdsge_common.h. */
+
+static inline c128 c128_make(const f64 re, const f64 im) {
+  c128 result;
+  result.re = re;
+  result.im = im;
+  return result;
+}
+
+static inline c128 c128_from_real(const f64 re) { return c128_make(re, 0.0); }
+
+static inline c128 c128_add(const c128 a, const c128 b) {
+  return c128_make(a.re + b.re, a.im + b.im);
+}
+
+static inline c128 c128_sub(const c128 a, const c128 b) {
+  return c128_make(a.re - b.re, a.im - b.im);
+}
+
+static inline c128 c128_mul(const c128 a, const c128 b) {
+  return c128_make(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re);
+}
+
+static inline c128 c128_div(const c128 a, const c128 b) {
+  c128 result;
+  f64 r;
+  if (fabs(b.re) >= fabs(b.im)) {
+    r = b.im / b.re;
+    result.re = (a.re + a.im * r) / (b.re + b.im * r);
+    result.im = (a.im - a.re * r) / (b.re + b.im * r);
+  } else {
+    r = b.re / b.im;
+    result.re = (a.im + a.re * r) / (b.im + b.re * r);
+    result.im = (-a.re + a.im * r) / (b.im + b.re * r);
+  }
+  return result;
+}
+
+static inline f64 c128_abs(const c128 a) { return hypot(a.re, a.im); }
+
+static inline f64 c128_abs2(const c128 a) { return a.re * a.re + a.im * a.im; }
+
+static inline f64 c128_real(const c128 a) { return a.re; }
+
+static inline f64 c128_imag(const c128 a) { return a.im; }
+
+/* Linalg */
+void c128_matmul(const c128 *SDSGE_RESTRICT A, const c128 *SDSGE_RESTRICT B,
+                 const i64 m, const i64 n, const i64 p,
+                 c128 *SDSGE_RESTRICT out);
+
+c128_lu c128_lu_factor(const c128 *A, const i64 n);
+i64 c128_lu_factor_inplace(c128 *SDSGE_RESTRICT A, i64 *SDSGE_RESTRICT pivot,
+                           const i64 n);
+void c128_lu_free(c128_lu *lu);
+
+/* Solve (L U) X = B for X(n,m) from a factorization (LU(n,n), piv(n)) produced by
+ * c128_lu_factor[_inplace]. B(n,m) is the RHS; X(n,m) is the output and must not
+ * alias B/LU. m == 1 is a vector solve; B == identity gives the inverse. */
+void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
+                   const c128 *SDSGE_RESTRICT B, c128 *SDSGE_RESTRICT X,
+                   const i64 n, const i64 m);
+
+/* ERROR CODES */
+#define SDSGE_LU_SUCCESS 0
+#define SDSGE_LU_ALLOC_FAIL -1
+#define SDSGE_LU_SINGULAR -2
 
 #endif /* SDSGE_COMPLEX_H */


### PR DESCRIPTION
This pull request refactors and extends the complex number (`c128`) support in the codebase, focusing on linear algebra operations. The main changes are the migration of basic arithmetic functions to `static inline` definitions in the header for better inlining and performance, and the addition of new linear algebra routines for complex matrices, including LU decomposition, matrix multiplication, solving linear systems, and matrix inversion.

The most important changes are:

**Complex Arithmetic Refactor:**
* Moved all basic `c128` arithmetic functions (`c128_make`, `c128_add`, `c128_sub`, `c128_mul`, `c128_div`, etc.) to be `static inline` in `sdsge_complex.h`, removing their previous implementations from `sdsge_complex.c`. This allows the compiler to inline these small functions, improving performance and simplifying the translation units. [[1]](diffhunk://#diff-26cc18eb34820518a5c8b02184abad46fbcb8723b5c0327bd75f3612a89fcca6L13-R93) [[2]](diffhunk://#diff-6123ea4a363598e3b696d52592b7c058aeab0a2048f5baa511961c8b3495ee30L2-R183)

**Linear Algebra Functionality:**
* Added new linear algebra routines for complex matrices, including:
  - `c128_matmul` for matrix multiplication,
  - `c128_lu_factor` and `c128_lu_factor_inplace` for LU decomposition with partial pivoting,
  - `c128_lu_solve` to solve systems using LU factors,
  - `c128_solve` as a high-level solve routine,
  - `c128_inv` for matrix inversion, and
  - `c128_lu_free` to release LU factorization resources.
  These routines are declared in the header and implemented in the source file. [[1]](diffhunk://#diff-26cc18eb34820518a5c8b02184abad46fbcb8723b5c0327bd75f3612a89fcca6L13-R93) [[2]](diffhunk://#diff-6123ea4a363598e3b696d52592b7c058aeab0a2048f5baa511961c8b3495ee30L2-R183)

* Introduced the `c128_lu` struct to encapsulate LU factorization results, including storage for the LU matrix, pivot indices, matrix size, and error code.

**Error Handling:**
* Added error codes (`SDSGE_LU_SUCCESS`, `SDSGE_LU_ALLOC_FAIL`, `SDSGE_LU_SINGULAR`) for robust error handling in LU and solve routines, and updated all relevant functions to return and propagate these codes. [[1]](diffhunk://#diff-26cc18eb34820518a5c8b02184abad46fbcb8723b5c0327bd75f3612a89fcca6L13-R93) [[2]](diffhunk://#diff-6123ea4a363598e3b696d52592b7c058aeab0a2048f5baa511961c8b3495ee30L2-R183)

closes #237 