### PR TITLE
Add native Klein post-processing kernel

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.c
@@ -109,7 +109,8 @@ void c128_lu_free(c128_lu *lu) {
 void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
                    const c128 *SDSGE_RESTRICT B, c128 *SDSGE_RESTRICT X,
                    const i64 n, const i64 m) {
-  /* X := B, then replay the factorization's row swaps (k <-> piv[k], forward).
+  /* X := B, then replay the factorization's row swaps (k <-> piv[k],
+   * forward).
    */
   memcpy(X, B, sizeof(c128) * n * m);
   for (i64 k = 0; k < n; ++k) {

--- a/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_complex.h
@@ -74,9 +74,10 @@ i64 c128_lu_factor_inplace(c128 *SDSGE_RESTRICT A, i64 *SDSGE_RESTRICT pivot,
                            const i64 n);
 void c128_lu_free(c128_lu *lu);
 
-/* Solve (L U) X = B for X(n,m) from a factorization (LU(n,n), piv(n)) produced
- * by c128_lu_factor[_inplace]. B(n,m) is the RHS; X(n,m) is the output and must
- * not alias B/LU. m == 1 is a vector solve; B == identity gives the inverse. */
+/* Solve (L U) X = B for X(n,m) from a factorization (LU(n,n),
+ * piv(n)) produced by c128_lu_factor[_inplace]. B(n,m) is the
+ * RHS; X(n,m) is the output and must not alias B/LU. m == 1 is a
+ * vector solve; B == identity gives the inverse. */
 void c128_lu_solve(const c128 *SDSGE_RESTRICT LU, const i64 *SDSGE_RESTRICT piv,
                    const c128 *SDSGE_RESTRICT B, c128 *SDSGE_RESTRICT X,
                    const i64 n, const i64 m);

--- a/SymbolicDSGE/_ckernels/core/__init__.py
+++ b/SymbolicDSGE/_ckernels/core/__init__.py
@@ -7,5 +7,6 @@ importing this module raises ``ImportError`` and the consumer
 
 from ._core import (
     affine_observations_into as affine_observations_into,
+    klein_postprocess as klein_postprocess,
     simulate_linear_states_into as simulate_linear_states_into,
 )

--- a/SymbolicDSGE/_ckernels/core/_core.pyi
+++ b/SymbolicDSGE/_ckernels/core/_core.pyi
@@ -8,10 +8,11 @@ must stay in sync with ``_core.pyx`` / ``core.c`` and the numba reference in
 not this stub.
 """
 
-from numpy import float64
+from numpy import complex128, float64
 from numpy.typing import NDArray
 
 _F64 = NDArray[float64]
+_C128 = NDArray[complex128]
 
 def simulate_linear_states_into(
     A: _F64,
@@ -30,3 +31,11 @@ def affine_observations_into(
     out: _F64,
 ) -> None:
     """out[(T, m)] <- d + C @ states[state_start + t]. Mirrors the numba kernel."""
+
+def klein_postprocess(
+    s: _C128,
+    t: _C128,
+    z: _C128,
+    n_states: int,
+) -> tuple[_C128, _C128, int, _C128]:
+    """(f, p, stab, eig) from the ordered Schur factors. Mirrors the numba path."""

--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -8,6 +8,8 @@ are exactly double/int64_t, so the extern is declared with those.
 
 from libc.stdint cimport int64_t
 
+import numpy as np
+
 cdef extern from "core.h" nogil:
     void sdsge_simulate_linear_states(
         const double *A, const double *B, const double *x0,
@@ -15,6 +17,18 @@ cdef extern from "core.h" nogil:
     void sdsge_affine_observations(
         const double *states, const double *C, const double *d,
         int64_t state_start, double *out, int64_t T, int64_t m, int64_t n)
+
+
+cdef extern from "../_common/sdsge_complex.h":
+    ctypedef struct c128:
+        double re
+        double im
+
+
+cdef extern from "klein_postproc.h" nogil:
+    int64_t klein_postproc(
+        const c128 *s, const c128 *t, const c128 *z, int64_t n_s, int64_t n_cs,
+        c128 *f, c128 *p, int64_t *stab, c128 *eig)
 
 
 def simulate_linear_states_into(
@@ -54,3 +68,46 @@ def affine_observations_into(
         sdsge_affine_observations(
             &states[0, 0], &C[0, 0], &d[0], state_start, &out[0, 0], T, m, n
         )
+
+
+def klein_postprocess(
+    double complex[:, ::1] s,
+    double complex[:, ::1] t,
+    double complex[:, ::1] z,
+    int64_t n_states,
+):
+    """Klein Schur-to-solution post-proc. Returns ``(f, p, stab, eig)``.
+
+    ``s``, ``t``, ``z`` are the ordered generalized-Schur factors (complex128,
+    N x N). Mirrors the live path of ``_linearsolve._klein_postprocess``.
+    """
+    cdef int64_t N = s.shape[0]
+    cdef int64_t n_s = n_states
+    cdef int64_t n_cs = N - n_s
+    if n_s <= 0:
+        raise ValueError("klein_postprocess requires n_states >= 1.")
+    if n_s > N:
+        raise ValueError("n_states exceeds the matrix dimension.")
+
+    f = np.empty((n_cs, n_s), dtype=np.complex128)
+    p = np.empty((n_s, n_s), dtype=np.complex128)
+    eig = np.empty(N, dtype=np.complex128)
+    cdef double complex[:, ::1] fv = f
+    cdef double complex[:, ::1] pv = p
+    cdef double complex[::1] ev = eig
+    cdef int64_t stab = 0
+    cdef int64_t err
+    with nogil:
+        err = klein_postproc(
+            <c128 *>&s[0, 0], <c128 *>&t[0, 0], <c128 *>&z[0, 0], n_s, n_cs,
+            <c128 *>&fv[0, 0] if n_cs > 0 else NULL,
+            <c128 *>&pv[0, 0], &stab, <c128 *>&ev[0])
+    if err == -1:
+        raise MemoryError("klein_postprocess: allocation failed.")
+    if err == -2:
+        raise ValueError(
+            "klein_postprocess: singular z11/s11 (Blanchard-Kahn failure)."
+        )
+    if err == -3:
+        raise ValueError("klein_postprocess: model has no states.")
+    return f, p, int(stab), eig

--- a/SymbolicDSGE/_ckernels/core/klein_postproc.c
+++ b/SymbolicDSGE/_ckernels/core/klein_postproc.c
@@ -1,0 +1,116 @@
+#include "klein_postproc.h"
+#include <stdlib.h>
+
+i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
+                   const c128 *SDSGE_RESTRICT z, const i64 n_s, const i64 n_cs,
+                   c128 *SDSGE_RESTRICT f, c128 *SDSGE_RESTRICT p,
+                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig) {
+  i64 N = n_s + n_cs;
+
+  /* A model with no states has no Klein solution. Fail fast before any
+   * allocation -- the state/inv/solve routines all assume n_s >= 1. */
+  if (n_s <= 0) {
+    return SDSGE_KLEIN_POSTPROC_INVALID;
+  }
+
+  /* Allocate z11, z21, s11, t11 */
+  c128 *SDSGE_RESTRICT z11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+  c128 *SDSGE_RESTRICT z21 = (c128 *)malloc(sizeof(c128) * n_cs * n_s);
+  c128 *SDSGE_RESTRICT s11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+  c128 *SDSGE_RESTRICT t11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+  c128 *SDSGE_RESTRICT z11i = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+
+  c128 *SDSGE_RESTRICT dyn = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+  c128 *SDSGE_RESTRICT tmp = (c128 *)malloc(sizeof(c128) * n_s * n_s);
+
+  if (!z11 || !z21 || !s11 || !t11 || !z11i || !dyn || !tmp) {
+    free(z11);
+    free(z21);
+    free(s11);
+    free(t11);
+    free(z11i);
+    free(dyn);
+    free(tmp);
+    return SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
+  }
+
+  /* Fill z11, s11, t11 */
+  for (i64 i = 0; i < n_s; ++i) {
+    for (i64 j = 0; j < n_s; ++j) {
+      z11[i * n_s + j] = z[i * N + j];
+      s11[i * n_s + j] = s[i * N + j];
+      t11[i * n_s + j] = t[i * N + j];
+    }
+  }
+
+  /* Fill z21 */
+  for (i64 i = 0; i < n_cs; ++i) {
+    for (i64 j = 0; j < n_s; ++j) {
+      z21[i * n_s + j] = z[(n_s + i) * N + j];
+    }
+  }
+
+  /* Invert z11. c128_inv returns SDSGE_LU_SINGULAR when z11 is singular (a
+   * Blanchard-Kahn failure), or SDSGE_LU_ALLOC_FAIL on OOM. */
+  i64 err_z = c128_inv(z11, n_s, z11i);
+  if (err_z != SDSGE_LU_SUCCESS) {
+    free(z11);
+    free(z21);
+    free(s11);
+    free(t11);
+    free(z11i);
+    free(dyn);
+    free(tmp);
+    return (err_z == SDSGE_LU_SINGULAR) ? SDSGE_KLEIN_POSTPROC_SINGULAR
+                                        : SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
+  }
+
+  *stab = 0;
+  if (c128_abs(t[(n_s - 1) * N + (n_s - 1)]) >
+      c128_abs(s[(n_s - 1) * N + (n_s - 1)])) {
+    *stab = -1; /* Too Few stable eigenvalues */
+  }
+
+  if (n_s < N) {
+    if (c128_abs(t[n_s * N + n_s]) < c128_abs(s[n_s * N + n_s])) {
+      *stab = 1; /* Too Many stable eigenvalues */
+    }
+  }
+
+  /* eig[i] = t[i,i] / s[i,i] */
+  for (i64 i = 0; i < N; ++i) {
+    if (c128_abs(s[i * N + i]) > 1e-12) {
+      eig[i] = c128_div(t[i * N + i], s[i * N + i]);
+    } else {
+      eig[i] = c128_make(INFINITY, 0.0);
+    }
+  }
+
+  /* dyn = solve(s11, t11). Singular s11 is again a Blanchard-Kahn failure. */
+  i64 dyn_err = c128_solve(s11, t11, n_s, n_s, dyn);
+  if (dyn_err != SDSGE_LU_SUCCESS) {
+    free(z11);
+    free(z21);
+    free(s11);
+    free(t11);
+    free(z11i);
+    free(dyn);
+    free(tmp);
+    return (dyn_err == SDSGE_LU_SINGULAR) ? SDSGE_KLEIN_POSTPROC_SINGULAR
+                                          : SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
+  }
+
+  c128_matmul(z21, z11i, n_cs, n_s, n_s, f);
+  c128_matmul(z11, dyn, n_s, n_s, n_s, tmp);
+  c128_matmul(tmp, z11i, n_s, n_s, n_s, p);
+
+  free(z11);
+  free(z21);
+  free(s11);
+  free(t11);
+  free(z11i);
+  free(dyn);
+  free(tmp);
+
+  return SDSGE_KLEIN_POSTPROC_SUCCESS;
+}

--- a/SymbolicDSGE/_ckernels/core/klein_postproc.h
+++ b/SymbolicDSGE/_ckernels/core/klein_postproc.h
@@ -1,0 +1,15 @@
+#ifndef SDSGE_KLEIN_POSTPROC_H
+#define SDSGE_KLEIN_POSTPROC_H
+#include "../_common/sdsge_common.h"
+#include "../_common/sdsge_complex.h"
+
+i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
+                   const c128 *SDSGE_RESTRICT z, const i64 n_s, const i64 n_cs,
+                   c128 *SDSGE_RESTRICT f, c128 *SDSGE_RESTRICT p,
+                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig);
+
+#define SDSGE_KLEIN_POSTPROC_SUCCESS 0
+#define SDSGE_KLEIN_POSTPROC_ALLOC_FAIL -1
+#define SDSGE_KLEIN_POSTPROC_SINGULAR -2
+#define SDSGE_KLEIN_POSTPROC_INVALID -3
+#endif /* SDSGE_KLEIN_POSTPROC_H */

--- a/tests/ckernels/test_klein_postproc.py
+++ b/tests/ckernels/test_klein_postproc.py
@@ -1,0 +1,61 @@
+"""Parity: native klein post-proc vs the numba ``_klein_postprocess`` (live path).
+
+The native C kernel in ``_ckernels/core/klein_postproc.c`` consumes the ordered
+generalized-Schur factors (from ``scipy.linalg.ordqz``) and must reproduce the
+``f``, ``p``, ``stab``, ``eig`` of the numba reference. Both are fed the *same*
+Schur factors, so the only difference is the post-proc arithmetic (hand-rolled
+complex LU vs numpy/LAPACK) -- tolerance, not bit-exact.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.linalg import ordqz
+
+from SymbolicDSGE._ckernels.core import klein_postprocess as native_kp
+from SymbolicDSGE._linearsolve import _klein_postprocess as numba_kp
+
+RTOL = 1e-8
+ATOL = 1e-10
+
+
+def _schur(seed: int, N: int):
+    """Ordered complex Schur factors of a random real pencil (a, b)."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(N, N))
+    b = rng.normal(size=(N, N))
+    s, t, _alpha, _beta, q, z = ordqz(a, b, sort="ouc", output="complex")
+    cc = np.ascontiguousarray
+    return cc(s), cc(t), cc(q), cc(z)
+
+
+@pytest.mark.parametrize("N,n_states", [(3, 1), (4, 2), (5, 3), (6, 2), (6, 4)])
+def test_klein_postproc_parity(N, n_states):
+    s, t, q, z = _schur(seed=N * 100 + n_states, N=N)
+    empty = np.empty((0, 0), dtype=np.complex128)
+
+    nf, _n, npp, _l, nstab, neig = numba_kp(s, t, q, z, empty, empty, n_states)
+    f, p, stab, eig = native_kp(s, t, z, n_states)
+
+    assert int(stab) == int(nstab)
+    np.testing.assert_allclose(f, nf, rtol=RTOL, atol=ATOL)
+    np.testing.assert_allclose(p, npp, rtol=RTOL, atol=ATOL)
+    np.testing.assert_allclose(eig, neig, rtol=RTOL, atol=ATOL)
+
+
+def test_klein_postproc_shapes():
+    s, t, _q, z = _schur(seed=7, N=5)
+    f, p, stab, eig = native_kp(s, t, z, 3)
+    assert f.shape == (2, 3)  # (n_costates, n_states)
+    assert p.shape == (3, 3)
+    assert eig.shape == (5,)
+    assert isinstance(stab, int)
+
+
+def test_klein_postproc_rejects_no_states():
+    s, t, _q, z = _schur(seed=1, N=4)
+    with pytest.raises(ValueError, match="n_states"):
+        native_kp(s, t, z, 0)
+    with pytest.raises(ValueError, match="matrix dimension"):
+        native_kp(s, t, z, 5)


### PR DESCRIPTION
This pull request adds a new native C implementation for the Klein Schur-to-solution post-processing routine, exposes it to Python, and introduces comprehensive tests to ensure parity with the existing numba implementation. The main addition is a fast, memory-safe C kernel for processing the ordered generalized Schur factors, which is now available as `klein_postprocess` in the Python API. Several supporting changes were made to integrate and document this new functionality.

**New Klein post-processing kernel and Python bindings:**

* Added a new C implementation of the Klein post-processing algorithm in `klein_postproc.c` and its header `klein_postproc.h`, providing a robust and efficient native routine for transforming Schur factors into solution matrices and eigenvalues. [[1]](diffhunk://#diff-f30aec3bf4f1f98d50466787493a423dd0218c111f44b975c46866da8de8701dR1-R116) [[2]](diffhunk://#diff-81123b30e9ca9c4bae21980a8f875c131d81b1b40d5174b2b99844f120887462R1-R15)
* Exposed the native routine to Python via Cython in `_core.pyx`, with a new function `klein_postprocess` that mirrors the live numba path and includes input validation and error handling. [[1]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bR22-R33) [[2]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bR71-R113)
* Updated the Python module `__init__.py` and the type stub `_core.pyi` to include the new `klein_postprocess` function, making it available for import and type checking. [[1]](diffhunk://#diff-212b2cec290a2839e09782fdbef61ae9ab71fded4d76f96d8de431826dd348abR10) [[2]](diffhunk://#diff-b2fb5deb3fda7326338ce142cf5903f37b0fa3ba771607715102ca26166f36b6L11-R15) [[3]](diffhunk://#diff-b2fb5deb3fda7326338ce142cf5903f37b0fa3ba771607715102ca26166f36b6R34-R41)

**Testing and validation:**

* Added a new test module `test_klein_postproc.py` that checks the native implementation against the numba reference for correctness, shape, and error handling, ensuring numerical results match within tolerance.

**Supporting changes and documentation:**

* Updated C struct and function declarations in headers and Cython to support complex types and ensure correct memory layout for the new kernel. [[1]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bR22-R33) [[2]](diffhunk://#diff-b2fb5deb3fda7326338ce142cf5903f37b0fa3ba771607715102ca26166f36b6L11-R15)
* Improved code comments and formatting for clarity in both C and header files, including minor formatting tweaks in unrelated LU-solver documentation. [[1]](diffhunk://#diff-6123ea4a363598e3b696d52592b7c058aeab0a2048f5baa511961c8b3495ee30L112-R113) [[2]](diffhunk://#diff-26cc18eb34820518a5c8b02184abad46fbcb8723b5c0327bd75f3612a89fcca6L77-R80)

These changes collectively provide a high-performance, well-tested native solution for Klein post-processing, improving maintainability and performance of the codebase.

closes #240 