### PR TITLE
Remove Kalman config defaults

### DIFF
--- a/MODELS/POST82.yaml
+++ b/MODELS/POST82.yaml
@@ -95,7 +95,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -117,5 +116,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/classes/augmented.yaml
+++ b/MODELS/classes/augmented.yaml
@@ -50,7 +50,6 @@ calibration:
     corr:
       e_g, e_z: rho_gz
 kalman:
-  y: [OutGap, Infl, Rate]
   R:
     std:
       OutGap: meas_outgap
@@ -69,5 +68,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/classes/augmented_reestimated.yaml
+++ b/MODELS/classes/augmented_reestimated.yaml
@@ -52,7 +52,6 @@ calibration:
     corr:
       e_g, e_z: rho_gz
 kalman:
-  y: [OutGap, Infl, Rate]
   R:
     std:
       OutGap: meas_outgap
@@ -71,5 +70,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/classes/base.yaml
+++ b/MODELS/classes/base.yaml
@@ -50,7 +50,6 @@ calibration:
     corr:
       e_g, e_z: rho_gz
 kalman:
-  y: [OutGap, Infl, Rate]
   R:
     std:
       OutGap: meas_outgap
@@ -69,5 +68,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/classes/reference.yaml
+++ b/MODELS/classes/reference.yaml
@@ -95,7 +95,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -117,5 +116,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/linearization_test.yaml
+++ b/MODELS/linearization_test.yaml
@@ -104,7 +104,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -126,5 +125,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/augmented_cleaned.yaml
+++ b/MODELS/misspec_test/augmented_cleaned.yaml
@@ -51,7 +51,6 @@ calibration:
     corr:
       e_g, e_z: rho_gz
 kalman:
-  y: [OutGap, Infl, Rate]
   R:
     std:
       OutGap: meas_outgap
@@ -70,5 +69,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/augmented_reference.yaml
+++ b/MODELS/misspec_test/augmented_reference.yaml
@@ -118,7 +118,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -140,5 +139,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/augmented_reference_infl.yaml
+++ b/MODELS/misspec_test/augmented_reference_infl.yaml
@@ -86,7 +86,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -107,5 +106,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/augmented_reference_outgap.yaml
+++ b/MODELS/misspec_test/augmented_reference_outgap.yaml
@@ -86,7 +86,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -107,5 +106,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/augmented_reference_rate.yaml
+++ b/MODELS/misspec_test/augmented_reference_rate.yaml
@@ -86,7 +86,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -107,5 +106,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/misspec.yaml
+++ b/MODELS/misspec_test/misspec.yaml
@@ -95,7 +95,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -117,5 +116,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/MODELS/misspec_test/reference.yaml
+++ b/MODELS/misspec_test/reference.yaml
@@ -95,7 +95,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -117,5 +116,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/SymbolicDSGE/core/model_parser.py
+++ b/SymbolicDSGE/core/model_parser.py
@@ -51,7 +51,7 @@ _ALLOWED_TOP_LEVEL_KEYS = frozenset(
 _ALLOWED_EQUATION_KEYS = frozenset({"model", "constraint", "observables"})
 _ALLOWED_CALIBRATION_KEYS = frozenset({"parameters", "shocks"})
 _ALLOWED_SHOCK_KEYS = frozenset({"std", "corr"})
-_ALLOWED_KALMAN_KEYS = frozenset({"y", "jitter", "symmetrize", "P0", "R"})
+_ALLOWED_KALMAN_KEYS = frozenset({"P0", "R"})
 _ALLOWED_P0_KEYS = frozenset({"mode", "scale", "diag"})
 _ALLOWED_R_KEYS = frozenset({"std", "corr"})
 
@@ -601,14 +601,7 @@ class ModelParser:
             return None
 
         y_order = [_LOCALS[o] for o in data["observables"]]
-        y_cfg = kalman_data.get("y", [])
-        if not y_cfg:
-            y_str = [o.name for o in y_order]
-        else:
-            y_str = y_cfg
-
-        jit = kalman_data.get("jitter", None)
-        symm = kalman_data.get("symmetrize", None)
+        obs_names = [o.name for o in y_order]
 
         P0 = kalman_data.get("P0", {}) or {}
         P0_mode = P0.get("mode", "diag")
@@ -647,9 +640,9 @@ class ModelParser:
                 R_corr_param_map[frozenset((names[0], names[1]))] = param_name
             obs_corr_sym: PairGetterDict[Symbol] = PairGetterDict(obs_corr_sym_dict)
 
-            for i in range(len(y_str)):
-                for j in range(i + 1, len(y_str)):
-                    pair = frozenset((y_str[i], y_str[j]))
+            for i in range(len(obs_names)):
+                for j in range(i + 1, len(obs_names)):
+                    pair = frozenset((obs_names[i], obs_names[j]))
                     R_corr_param_map.setdefault(pair, None)
 
             n_obs = len(y_order)
@@ -706,10 +699,7 @@ class ModelParser:
         )
 
         return KalmanConfig(
-            y_names=y_str,
             R=R,
-            jitter=jit,
-            symmetrize=symm,
             P0=P0_cfg,
             R_symbolic=R_symbolic,
             R_param_symbols=r_param_symbols,

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -719,10 +719,7 @@ class SolvedModel:
         if filter_mode == "extended":
             obs_idx = {name: i for i, name in enumerate(self.compiled.observable_names)}
             if observables is None:
-                if self.kalman_config is not None and self.kalman_config.y_names:
-                    selected_obs = list(self.kalman_config.y_names)
-                else:
-                    selected_obs = list(self.compiled.observable_names)
+                selected_obs = list(self.compiled.observable_names)
             else:
                 selected_obs = list(observables)
             selected_obs = sorted(selected_obs, key=lambda name: obs_idx[name])

--- a/SymbolicDSGE/estimation/backend.py
+++ b/SymbolicDSGE/estimation/backend.py
@@ -80,10 +80,7 @@ def reorder_observables(
     canon_idx = {name: i for i, name in enumerate(canon)}
 
     if observables is None:
-        if kalman is not None and kalman.y_names:
-            obs_given = list(kalman.y_names)
-        else:
-            obs_given = list(canon)
+        obs_given = list(canon)
     else:
         obs_given = list(observables)
 
@@ -127,13 +124,9 @@ def infer_filter_mode(
     compiled: CompiledModel,
     observables: list[str] | None,
 ) -> str:
-    kalman = getattr(compiled, "kalman", None)
     canon = getattr(compiled, "observable_names", [])
     if observables is None:
-        if kalman is not None and getattr(kalman, "y_names", None):
-            obs = list(kalman.y_names)
-        else:
-            obs = list(canon)
+        obs = list(canon)
     else:
         obs = list(observables)
 
@@ -259,22 +252,8 @@ def resolve_filter_options(
     jitter: float | float64 | None,
     symmetrize: bool | None,
 ) -> tuple[float64, bool]:
-    if jitter is None:
-        if kalman is not None and getattr(kalman, "jitter", None) is not None:
-            kf_jitter = float64(kalman.jitter)
-        else:
-            kf_jitter = float64(0.0)
-    else:
-        kf_jitter = float64(jitter)
-
-    if symmetrize is None:
-        if kalman is not None and getattr(kalman, "symmetrize", None) is not None:
-            kf_sym = bool(kalman.symmetrize)
-        else:
-            kf_sym = False
-    else:
-        kf_sym = bool(symmetrize)
-
+    kf_jitter = float64(0.0) if jitter is None else float64(jitter)
+    kf_sym = False if symmetrize is None else bool(symmetrize)
     return kf_jitter, kf_sym
 
 

--- a/SymbolicDSGE/estimation/estimator.py
+++ b/SymbolicDSGE/estimation/estimator.py
@@ -721,14 +721,11 @@ class Estimator:
     def _effective_observables(self) -> list[str]:
         canon = list(self.compiled.observable_names)
         canon_idx = {name: i for i, name in enumerate(canon)}
-        kalman = getattr(self.compiled, "kalman", None)
         prepared = self._prepared_filter
 
         if self.observables is None:
             if prepared is not None:
                 obs_given = list(prepared.observables)
-            elif kalman is not None and getattr(kalman, "y_names", None):
-                obs_given = list(kalman.y_names)
             else:
                 obs_given = list(canon)
         else:

--- a/SymbolicDSGE/kalman/config.py
+++ b/SymbolicDSGE/kalman/config.py
@@ -17,10 +17,7 @@ class P0Config:
 
 @dataclass(frozen=True)
 class KalmanConfig:
-    y_names: list[str]
     R: NDArray | None
-    jitter: float
-    symmetrize: bool
     P0: P0Config
     R_symbolic: Matrix | None = None
     R_param_symbols: list[Symbol] | None = None

--- a/SymbolicDSGE/kalman/interface.py
+++ b/SymbolicDSGE/kalman/interface.py
@@ -212,23 +212,10 @@ class KalmanInterface(KalmanFilter):
         return run
 
     def _get_symmetrize(self, symmetrize_arg: bool | None) -> bool:
-        if symmetrize_arg is not None:
-            return bool(symmetrize_arg)
-
-        conf = self.kalman_config
-        if (sym_conf := getattr(conf, "symmetrize", None)) is not None:
-            return bool(sym_conf)
-        return False
+        return bool(symmetrize_arg) if symmetrize_arg is not None else False
 
     def _get_jitter(self, jitter_arg: Float64Like | None) -> float64:
-        if jitter_arg is not None:
-            return float64(jitter_arg)
-
-        conf = self.kalman_config
-        if (jitter_conf := getattr(conf, "jitter", None)) is not None:
-            return float64(jitter_conf)
-
-        return float64(0.0)
+        return float64(jitter_arg) if jitter_arg is not None else float64(0.0)
 
     def _validate_user_R(self, R: NDF | None) -> NDF | None:
         if R is None:
@@ -449,10 +436,7 @@ class KalmanInterface(KalmanFilter):
         canon_idx = self._obs_idx
 
         if obs is None:
-            if (obs_ls := getattr(self.kalman_config, "y_names", None)) is not None:
-                obs_given = list(obs_ls)
-            else:
-                obs_given = list(canon)  # default: all observables in canonical order
+            obs_given = list(canon)  # default: all observables in canonical order
         else:
             obs_given = list(obs)
 

--- a/docs/assets/test.yaml
+++ b/docs/assets/test.yaml
@@ -76,7 +76,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [Infl, Rate, Out_HP]
 
   R:
     std:
@@ -97,5 +96,3 @@ kalman:
       Pi: 1.0
       x: 1.0
 
-  jitter: 1e-10
-  symmetrize: true

--- a/tests/core/test_canonical_variable_layout.py
+++ b/tests/core/test_canonical_variable_layout.py
@@ -25,7 +25,6 @@ def _write_misordered_test_model(tmp_path):
     # states, controls].
     data["variables"] = ["Pi", "x", "r_star", "u", "v", "r"]
     data["kalman"] = {
-        "y": ["Infl", "Rate"],
         "P0": {
             "mode": "diag",
             "scale": 1.0,

--- a/tests/core/test_linearizer.py
+++ b/tests/core/test_linearizer.py
@@ -98,7 +98,6 @@ def _mixed_methods_nonlinear_yaml() -> str:
               e_z: sig_z
             corr: {}
         kalman:
-          y: [ZObs]
           R:
             std:
               ZObs: meas_z
@@ -107,8 +106,6 @@ def _mixed_methods_nonlinear_yaml() -> str:
             mode: eye
             scale: 1.0
             diag: {}
-          jitter: 1e-10
-          symmetrize: true
         """
     )
 
@@ -148,7 +145,6 @@ def _mixed_methods_hand_linearized_yaml() -> str:
               e_z: sig_z
             corr: {}
         kalman:
-          y: [ZObs]
           R:
             std:
               ZObs: meas_z
@@ -157,8 +153,6 @@ def _mixed_methods_hand_linearized_yaml() -> str:
             mode: eye
             scale: 1.0
             diag: {}
-          jitter: 1e-10
-          symmetrize: true
         """
     )
 

--- a/tests/core/test_model_parser.py
+++ b/tests/core/test_model_parser.py
@@ -31,7 +31,7 @@ def test_parsed_config_is_iterable(parsed_post82):
 
     assert model.name == "NK_LS_POST82"
     assert kalman is not None
-    assert kalman.y_names == ["OutGap", "Infl", "Rate"]
+    assert kalman.R is not None
 
 
 def test_validate_constraints_errors_on_unknown_symbols(parsed_test):

--- a/tests/core/test_model_serialization.py
+++ b/tests/core/test_model_serialization.py
@@ -38,9 +38,6 @@ def test_kalman_config_round_trips_via_reparse() -> None:
     assert k0 is not None and k1 is not None
 
     # Authored fields survive verbatim.
-    assert k1.y_names == k0.y_names
-    assert k1.jitter == k0.jitter
-    assert k1.symmetrize == k0.symmetrize
     assert k1.P0.mode == k0.P0.mode
     assert k1.P0.scale == k0.P0.scale
     assert k1.P0.diag == k0.P0.diag

--- a/tests/estimation/test_backend.py
+++ b/tests/estimation/test_backend.py
@@ -297,20 +297,14 @@ def test_build_P0_branches():
     assert np.allclose(eye, 2.0 * np.eye(2))
 
     kalman = KalmanConfig(
-        y_names=["Infl"],
         R=np.eye(1, dtype=np.float64),
-        jitter=0.0,
-        symmetrize=False,
         P0=P0Config(mode="diag", scale=3.0, diag={"g": 1.0, "z": 2.0}),
     )
     p0 = backend.build_P0(compiled, kalman, None, None)
     assert np.allclose(p0, np.diag([3.0, 6.0]))
 
     bad_kalman = KalmanConfig(
-        y_names=["Infl"],
         R=np.eye(1, dtype=np.float64),
-        jitter=0.0,
-        symmetrize=False,
         P0=P0Config(mode="diag", scale=1.0, diag={"g": 1.0}),
     )
     with pytest.raises(ValueError, match="Missing P0 diagonal entry"):
@@ -351,12 +345,9 @@ def test_resolve_R_branches():
     assert np.allclose(out_direct, R_ok)
 
     kalman = KalmanConfig(
-        y_names=["Infl", "Rate", "Out"],
         R=np.array(
             [[1.0, 2.0, 3.0], [2.0, 5.0, 6.0], [3.0, 6.0, 9.0]], dtype=np.float64
         ),
-        jitter=0.0,
-        symmetrize=False,
         P0=P0Config(mode="eye", scale=1.0, diag=None),
     )
     subset = backend.resolve_R(
@@ -687,21 +678,19 @@ def test_build_Q_symbolic_matches_numeric_Q(post82_bundle):
 
 def test_resolve_filter_options_prefers_defaults_and_honors_overrides():
     kalman = KalmanConfig(
-        y_names=["y"],
         R=np.eye(1, dtype=np.float64),
-        jitter=0.25,
-        symmetrize=True,
         P0=P0Config(mode="eye", scale=1.0, diag=None),
     )
 
+    # jitter/symmetrize are call-site concerns now; the config never feeds them.
     assert backend.resolve_filter_options(None, None, None) == pytest.approx(
         (0.0, False)
     )
     assert backend.resolve_filter_options(kalman, None, None) == pytest.approx(
-        (0.25, True)
+        (0.0, False)
     )
-    assert backend.resolve_filter_options(kalman, 0.5, False) == pytest.approx(
-        (0.5, False)
+    assert backend.resolve_filter_options(kalman, 0.5, True) == pytest.approx(
+        (0.5, True)
     )
 
 

--- a/tests/estimation/test_estimator_lkj_integration.py
+++ b/tests/estimation/test_estimator_lkj_integration.py
@@ -205,8 +205,8 @@ def test_packed_logprior_matches_python_path_with_notebook_like_estimator_golden
     )
 
     expected_logprior = -3.677756133346315
-    expected_loglik = -89.36502293810241
-    expected_logpost = -93.04277907144873
+    expected_loglik = -89.36502293741962
+    expected_logpost = -93.04277907076594
 
     assert est._packed_logprior is not None
     assert float(est._logprior_python(theta)) == pytest.approx(
@@ -327,10 +327,10 @@ def test_seeded_mcmc_output_is_unchanged_by_packed_logprior(dense_lkj_bundle):
     )
     expected_logpost = np.asarray(
         [
-            -89.11289967919815,
-            -89.56901008861455,
-            -89.61414761191483,
-            -89.43170424868838,
+            -89.11289967831583,
+            -89.56901008775299,
+            -89.61414761105306,
+            -89.43170424781582,
         ],
         dtype=np.float64,
     )

--- a/tests/fixtures/models/LKJ_DENSE.yaml
+++ b/tests/fixtures/models/LKJ_DENSE.yaml
@@ -67,7 +67,6 @@ calibration:
       e_z, e_r: rho_zr_shock
 
 kalman:
-  y: [OutGap, Infl, Rate]
   R:
     std:
       OutGap: meas_outgap
@@ -86,5 +85,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-  jitter: 1e-10
-  symmetrize: true

--- a/tests/fixtures/models/POST82.yaml
+++ b/tests/fixtures/models/POST82.yaml
@@ -75,7 +75,6 @@ calibration:
       e_g, e_z: rho_gz
 
 kalman:
-  y: [OutGap, Infl, Rate]
 
   R:
     std:
@@ -95,6 +94,3 @@ kalman:
       r: 1.0
       Pi: 1.0
       x: 1.0
-
-  jitter: 1e-10
-  symmetrize: true

--- a/tests/kalman/test_interface.py
+++ b/tests/kalman/test_interface.py
@@ -121,6 +121,8 @@ def test_interface_init_reorders_obs_and_builds_state_space():
         observables=["ObsB", "ObsA"],
         y=y,
         return_shocks=1,
+        jitter=0.125,
+        symmetrize=True,
     )
 
     assert ki.observables == ["ObsA", "ObsB"]


### PR DESCRIPTION
This pull request removes support for the `y`, `jitter`, and `symmetrize` keys from the Kalman filter configuration in YAML model files and simplifies related code throughout the codebase. The changes ensure that observable selection, jitter, and symmetrization are now handled exclusively by code logic or user arguments, rather than being specified in the model configuration files.

**Kalman filter configuration simplification:**

* Removed support for the `y`, `jitter`, and `symmetrize` keys from the Kalman filter sections in all YAML model files, including `MODELS/POST82.yaml`, `MODELS/classes/base.yaml`, `MODELS/classes/augmented.yaml`, `MODELS/classes/augmented_reestimated.yaml`, `MODELS/classes/reference.yaml`, `MODELS/linearization_test.yaml`, and various files in `MODELS/misspec_test/` and `docs/assets/test.yaml`. [[1]](diffhunk://#diff-fecfd226c541d6eafae03a26815eba6d1c4cf8e29d5e8e4420217a0e34cb14dcL98) [[2]](diffhunk://#diff-c6ca5a86e5667799ed76570407e4e64e53eee8318eaa049a3b2fbb621499282bL53) [[3]](diffhunk://#diff-ad26c24ab3b3ef86934c916ee287bed36dc4a555df7f7bb5dd934cb193dd4f7eL55) [[4]](diffhunk://#diff-fecfd226c541d6eafae03a26815eba6d1c4cf8e29d5e8e4420217a0e34cb14dcL98) [[5]](diffhunk://#diff-9700374278b14cc18201c36083e036fe99539285d86dd2227018f536e9f25fccL107) [[6]](diffhunk://#diff-a49586b2187a5d9d446d68d975295ae731111d52c4f6a8cb4aedbe199667746bL54) [[7]](diffhunk://#diff-503afbaba1a2f86e22f21808a06361c236b5d1006905172529e39e1491d1673aL121) [[8]](diffhunk://#diff-618fd195668ece71be4f68b91533adad79605c6fa75eecc1b1fbaa85f9c2b732L89) [[9]](diffhunk://#diff-01bb2c856b8049722524b5c028fbdec02069dea4a5d52f9234bacd869a666b58L89) [[10]](diffhunk://#diff-e329508d9a98b2610f1630088b8aa8ec5f01ea68d602892a0ba17077050586a8L89) [[11]](diffhunk://#diff-2c1b33ab48e023a995309400f6814eed1887bb39465e82a4a39de2db624d5281L98) [[12]](diffhunk://#diff-c21ccb716d05d7a7516dcf75597c1be0571b56a428ca418852bbea82da3d04a3L98) [[13]](diffhunk://#diff-89ae22e272778e0968b9ae301aecb62aea1fa142911aeea794137f0ae9a7826fL79) etc.)

* Updated `SymbolicDSGE/core/model_parser.py` to reject these keys during parsing and to remove all logic related to them, ensuring only `P0` and `R` are accepted in the Kalman configuration. [[1]](diffhunk://#diff-ca4cb170cf61bf5720dc263ec6288313a912c81aa361141a17f5b5435aebe7b9L54-R54) [[2]](diffhunk://#diff-ca4cb170cf61bf5720dc263ec6288313a912c81aa361141a17f5b5435aebe7b9L604-R604) [[3]](diffhunk://#diff-ca4cb170cf61bf5720dc263ec6288313a912c81aa361141a17f5b5435aebe7b9L650-R645) [[4]](diffhunk://#diff-ca4cb170cf61bf5720dc263ec6288313a912c81aa361141a17f5b5435aebe7b9L709-L712)

**Codebase cleanup and refactoring:**

* Removed the `y_names`, `jitter`, and `symmetrize` fields from the `KalmanConfig` dataclass in `SymbolicDSGE/kalman/config.py`, and updated all usages accordingly.

* Refactored observable selection logic in `SymbolicDSGE/kalman/interface.py`, `SymbolicDSGE/core/solved_model.py`, `SymbolicDSGE/estimation/backend.py`, and `SymbolicDSGE/estimation/estimator.py` to use only canonical observable names or user-provided arguments, eliminating references to the removed configuration fields. [[1]](diffhunk://#diff-210374c397e1b2484fef28fd345a2cbe7054b2e03b3b7c0dbf6fb43bf8015f10L452-L454) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL722-L724) [[3]](diffhunk://#diff-5495ef3cc3b524e51a3b635ebc93666c7cee14a6bf9382c85116b377194dc1bbL83-L85) [[4]](diffhunk://#diff-bee20cc185daf6f1ff7b9828f1513c49d200144cdbce166699d53f19920ca714L724-L731)

* Simplified the handling of `jitter` and `symmetrize` options throughout the codebase, so they are now controlled solely by function arguments with sensible defaults, rather than being settable via model configuration. [[1]](diffhunk://#diff-210374c397e1b2484fef28fd345a2cbe7054b2e03b3b7c0dbf6fb43bf8015f10L215-R218) [[2]](diffhunk://#diff-5495ef3cc3b524e51a3b635ebc93666c7cee14a6bf9382c85116b377194dc1bbL262-R256)

These changes make the configuration and usage of the Kalman filter more consistent and reduce the potential for confusion or misconfiguration.

closes #245 