### PR TITLE
Fix prior support validation

### DIFF
--- a/SymbolicDSGE/bayesian/priors.py
+++ b/SymbolicDSGE/bayesian/priors.py
@@ -95,12 +95,19 @@ class Prior:
         )
 
     def _confirm_bound_match(self) -> None:
+        # logpdf evaluates dist.logpdf(transform.inverse(z)), where inverse(z)
+        # ranges over transform.support (the parameter domain). So the
+        # distribution must be defined over every value the transform can produce:
+        # dist.support must CONTAIN transform.support (not the other way round).
         _sup = self.dist.support
         _trans_sup = self.transform.support
-        if not _trans_sup << _sup:
+        if not _sup << _trans_sup:
             raise ValueError(
-                "Distribution support does not match transform support. "
-                "When priors are defined in parameter space, transform.support must match dist.support. "
+                "Distribution support does not contain the transform support. "
+                "The prior distribution lives in parameter space, so it must cover "
+                "every value the transform can map to: dist.support must contain "
+                f"transform.support (got dist.support={_sup}, "
+                f"transform.support={_trans_sup})."
             )
 
     @property

--- a/tests/bayesian/test_priors.py
+++ b/tests/bayesian/test_priors.py
@@ -411,23 +411,39 @@ def test_prior_grad_logpdf_uses_inverse_chain_rule_and_jacobian_gradient():
     assert np.allclose(dist.grad_x, adjusted_z - 1.0)
 
 
-def test_confirm_bound_match_allows_transform_support_that_contains_distribution_support():
+def test_confirm_bound_match_allows_distribution_wider_than_transform():
+    # normal (support R) with a log transform (parameter domain (0, inf)) is
+    # valid: the distribution covers every value log^{-1} can produce, so the
+    # prior is a normal constrained to the positive reals.
     prior = make_prior(
-        distribution="gamma",
-        parameters={"mean": 2.0, "std": np.sqrt(2.0)},
-        transform="identity",
+        distribution="normal",
+        parameters={"mean": 0.0, "std": 1.0},
+        transform="log",
     )
+    # dist.support contains transform.support
+    assert prior.support << prior.transform.support
 
-    assert prior.support.contains(float64(0.0))
-    assert prior.transform.support << prior.support
 
-
-def test_confirm_bound_match_raises_on_dist_support_vs_transform_support_mismatch_normal_log():
-    with pytest.raises(ValueError, match="does not match transform support"):
+def test_confirm_bound_match_rejects_transform_wider_than_distribution():
+    # identity maps R -> R, but gamma is only defined on (0, inf): a proposed
+    # negative parameter would fall outside the distribution support.
+    with pytest.raises(ValueError, match="does not contain the transform support"):
         make_prior(
-            distribution="normal",
-            parameters={"mean": 0.0, "std": 1.0},
-            transform="log",
+            distribution="gamma",
+            parameters={"mean": 2.0, "std": np.sqrt(2.0)},
+            transform="identity",
+        )
+
+
+def test_confirm_bound_match_rejects_distribution_narrower_than_transform():
+    # beta lives on (0, 1) but affine_logit(-1, 1) can produce parameters in
+    # (-1, 0] -> outside beta support.
+    with pytest.raises(ValueError, match="does not contain the transform support"):
+        make_prior(
+            distribution="beta",
+            parameters={"a": 2.0, "b": 2.0},
+            transform="affine_logit",
+            transform_kwargs={"low": -1.0, "high": 1.0},
         )
 
 

--- a/tests/ckernels/test_prior_program.py
+++ b/tests/ckernels/test_prior_program.py
@@ -19,7 +19,10 @@ from SymbolicDSGE._ckernels.estimation import (
     transform_inverse_and_logjac as native_transform,
 )
 from SymbolicDSGE.bayesian import make_prior
+from SymbolicDSGE.bayesian.distributions.distribution_dispatch import get_distribution
 from SymbolicDSGE.bayesian.distributions.lkj_chol import _log_lkj_normalizer_C
+from SymbolicDSGE.bayesian.distributions.param_builder import get_dist_params
+from SymbolicDSGE.bayesian.transforms import Identity
 from SymbolicDSGE.estimation.prior_program import (
     DistCode,
     N_DIST_PARAMS,
@@ -36,6 +39,14 @@ from SymbolicDSGE.estimation.prior_program import (
 
 RTOL = 1e-12
 ATOL = 1e-12
+
+
+def _build_dist(family, params):
+    """Distribution instance without the Prior wrapper -- these kernels pack and
+    evaluate the distribution/transform directly, below the Prior abstraction, so
+    they must be exercisable with (dist, transform) pairs that Prior's support
+    check would reject (e.g. a distribution with an identity transform)."""
+    return get_distribution(family)(**(get_dist_params(family) | params))
 
 
 def _agree(native: float, numba: float) -> None:
@@ -69,8 +80,9 @@ _X_SWEEP = (-2.0, -0.5, 0.0, 0.25, 0.5, 0.7, 1.0, 1.5, 3.0)
 @pytest.mark.parametrize("code,spec", list(_DIST_SPECS.items()))
 def test_dist_logpdf_parity(code, spec):
     family, params = spec
-    prior = make_prior(family, params, "identity")
-    packed_code, packed_params = _pack_distribution(prior.dist)
+    # Only the distribution is packed/evaluated here (the x-sweep deliberately
+    # probes out-of-support values), so build the dist directly.
+    packed_code, packed_params = _pack_distribution(_build_dist(family, params))
     assert int(packed_code) == int(code)
     parr = np.asarray(packed_params, dtype=np.float64)
 
@@ -141,17 +153,17 @@ def _empty_block_arrays():
     )
 
 
-def _pack_scalars(specs):
+def _pack_pairs(pairs):
+    """Pack ``(dist, transform)`` object pairs into the program's scalar arrays."""
     codes_d, codes_t, dp, tp = [], [], [], []
-    for fam, params, transform in specs:
-        prior = make_prior(fam, params, transform)
-        dc, dpar = _pack_distribution(prior.dist)
-        tc, tpar = _pack_transform(prior.transform)
+    for dist, transform in pairs:
+        dc, dpar = _pack_distribution(dist)
+        tc, tpar = _pack_transform(transform)
         codes_d.append(int(dc))
         codes_t.append(int(tc))
         dp.append(dpar)
         tp.append(tpar)
-    n = len(specs)
+    n = len(pairs)
     return dict(
         scalar_dist_codes=np.asarray(codes_d, dtype=np.int64),
         scalar_transform_codes=np.asarray(codes_t, dtype=np.int64),
@@ -160,6 +172,14 @@ def _pack_scalars(specs):
             n, N_TRANSFORM_PARAMS
         ),
     )
+
+
+def _pack_scalars(specs):
+    pairs = []
+    for fam, params, transform in specs:
+        prior = make_prior(fam, params, transform)
+        pairs.append((prior.dist, prior.transform))
+    return _pack_pairs(pairs)
 
 
 def _call_both(theta, scalar_indices, packed, block):
@@ -222,9 +242,11 @@ def test_logprior_program_with_lkj_block_parity():
 
 
 def test_logprior_program_out_of_support_is_nan():
-    # gamma + identity with negative theta -> x < 0 -> NaN short-circuit.
-    specs = [("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "identity")]
-    packed = _pack_scalars(specs)
+    # gamma + identity with negative theta -> x < 0 -> NaN short-circuit. This is
+    # not a valid Prior (identity can emit x outside gamma's support), so pack the
+    # dist/transform objects directly to reach the program's out-of-support guard.
+    gamma = _build_dist("gamma", {"mean": 2.0, "std": 1.0, "random_state": 1})
+    packed = _pack_pairs([(gamma, Identity())])
     scalar_indices = np.array([0], dtype=np.int64)
     theta = np.array([-1.0], dtype=np.float64)
     native, numba = _call_both(theta, scalar_indices, packed, _empty_block_arrays())

--- a/tests/estimation/test_estimator.py
+++ b/tests/estimation/test_estimator.py
@@ -11,7 +11,10 @@ import SymbolicDSGE.estimation.backend as est_backend
 from SymbolicDSGE.bayesian.distributions.lkj_chol import LKJChol
 from SymbolicDSGE.estimation import Estimator
 from SymbolicDSGE.bayesian.priors import Prior
-from SymbolicDSGE.bayesian.transforms import CholeskyCorrTransform, Identity
+from SymbolicDSGE.bayesian.transforms import (
+    AffineLogitTransform,
+    CholeskyCorrTransform,
+)
 from SymbolicDSGE.core.config import PairGetterDict, SymbolGetterDict
 from SymbolicDSGE.estimation.estimator import MissingConfigError, _MatrixPriorResolution
 
@@ -793,9 +796,12 @@ def test_estimator_constructor_and_lkj_prior_validation_error_branches():
             y=np.zeros((4, 2), dtype=np.float64),
             estimated_params=["R_corr"],
             priors={
+                # Support-valid but not a CholeskyCorrTransform: exercises the
+                # estimator's LKJ-transform check (AffineLogit(-1,1) matches the
+                # LKJChol (-1, 1) support so Prior construction itself succeeds).
                 "R_corr": Prior(
                     dist=LKJChol(eta=2.0, K=2, random_state=None),
-                    transform=Identity(),
+                    transform=AffineLogitTransform(low=-1.0, high=1.0),
                 )
             },
         )

--- a/tests/estimation/test_prior_program.py
+++ b/tests/estimation/test_prior_program.py
@@ -372,33 +372,41 @@ def test_prior_program_scalar_transform_helpers_cover_all_branches():
 
 
 def test_prior_program_distribution_logpdf_dispatch_and_support_edges():
+    # The test only packs/evaluates prior.dist, but Prior now requires the
+    # distribution support to contain the transform support, so each family is
+    # paired with its natural transform (identity/log/logit/affine_logit).
+    _pm1p1 = {"low": -1.0, "high": 1.0}
     scalar_priors = {
         "normal": make_prior(
             "normal", {"mean": 0.0, "std": 1.0, "random_state": 1}, "identity"
         ),
         "log_normal": make_prior(
-            "log_normal", {"mean": 0.0, "std": 0.5, "random_state": 1}, "identity"
+            "log_normal", {"mean": 0.0, "std": 0.5, "random_state": 1}, "log"
         ),
         "half_normal": make_prior(
-            "half_normal", {"std": 1.0, "random_state": 1}, "identity"
+            "half_normal", {"std": 1.0, "random_state": 1}, "log"
         ),
         "trunc_normal": make_prior(
             "trunc_normal",
             {"mean": 0.0, "std": 1.0, "low": -1.0, "high": 1.0, "random_state": 1},
-            "identity",
+            "affine_logit",
+            _pm1p1,
         ),
         "half_cauchy": make_prior(
-            "half_cauchy", {"gamma": 1.0, "random_state": 1}, "identity"
+            "half_cauchy", {"gamma": 1.0, "random_state": 1}, "log"
         ),
-        "beta": make_prior("beta", {"a": 2.0, "b": 3.0, "random_state": 1}, "identity"),
+        "beta": make_prior("beta", {"a": 2.0, "b": 3.0, "random_state": 1}, "logit"),
         "gamma": make_prior(
-            "gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "identity"
+            "gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "log"
         ),
         "inv_gamma": make_prior(
-            "inv_gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "identity"
+            "inv_gamma", {"mean": 2.0, "std": 1.0, "random_state": 1}, "log"
         ),
         "uniform": make_prior(
-            "uniform", {"low": -1.0, "high": 1.0, "random_state": 1}, "identity"
+            "uniform",
+            {"low": -1.0, "high": 1.0, "random_state": 1},
+            "affine_logit",
+            _pm1p1,
         ),
     }
     valid_x = {


### PR DESCRIPTION
Correct the support check in `Prior` so the distribution must contain the transform support, matching how priors are evaluated in parameter space. Update tests to use compatible transforms for each distribution family and cover the estimator LKJ validation path.

closes #252 