### PR TITLE
Add shock_registry support and validation to simulation catalog

### DIFF
--- a/SymbolicDSGE/bundle/loader.py
+++ b/SymbolicDSGE/bundle/loader.py
@@ -61,13 +61,15 @@ class LoadedEstimation:
 class LoadedMC:
     """Monte-Carlo pipeline + (optional) run result recovered from a bundle.
 
+    ``pipeline`` is the live, runnable :class:`MCPipeline`, rebuilt eagerly at
+    load from ``spec`` + ``resources``. No model is needed to build it (simulation
+    shocks come from the explicit registry, not a model), so it is ready to run
+    against models supplied at ``pipeline.run(reference=..., dgp=...)`` time. The
+    raw ``spec`` stays available for the UI to consume.
+
     ``resources`` reattaches the bulk side-channels the spec references by key:
     each ``raw_data`` ``data_ref`` maps to its restored ``{name: ndarray}`` arrays
     and each ``custom`` ``func_ref`` (transform *or* post-loop) to its callable.
-    Call :meth:`build_pipeline` to rebuild a runnable :class:`MCPipeline` from
-    ``spec`` + ``resources`` (a ``simulation`` datagen also needs a ``dgp``); the
-    raw ``spec`` stays available for inspection and for pipelines whose models
-    aren't in the bundle.
 
     Recovered run artifacts of a POSTPROC phase: ``postproc_arrays`` (bulk ndarray
     artifacts) and ``postproc_tables`` (tabular/DataFrame artifacts as columnar
@@ -76,40 +78,12 @@ class LoadedMC:
     """
 
     spec: PipelineSpec
+    pipeline: MCPipeline
     document: dict[str, Any] | None = None
     traces: dict[str, NDArray[Any]] | None = None
     resources: dict[str, Any] = field(default_factory=dict)
     postproc_arrays: dict[str, NDArray[Any]] = field(default_factory=dict)
     postproc_tables: dict[str, dict[str, list[Any]]] = field(default_factory=dict)
-
-    def build_pipeline(
-        self,
-        *,
-        reference: SolvedModel | None = None,
-        dgp: SolvedModel | None = None,
-    ) -> "MCPipeline":
-        """Rebuild a runnable :class:`MCPipeline` from ``spec`` + ``resources``.
-
-        Every MC pipeline runs against a reference supplied later at
-        ``pipeline.run(reference=...)`` time, so a reference is assumed here. A
-        ``simulation`` datagen needs the model it simulates: the ``dgp`` by
-        default, or the ``reference`` when the step's ``target="reference"`` --
-        pass whichever it targets (needed only to resolve generated shocks; a
-        step with explicit ``shocks`` builds without it). ``raw_data`` pipelines
-        need nothing.
-        """
-        from ..monte_carlo.builder import build_pipeline, validate_pipeline_spec
-
-        ordered, postprocs = validate_pipeline_spec(
-            self.spec, has_reference=True, has_dgp=dgp is not None
-        )
-        return build_pipeline(
-            ordered,
-            postprocs,
-            dgp=dgp,
-            reference=reference,
-            resources=self.resources,
-        )
 
     def wire(self) -> dict[str, Any] | None:
         """Re-merge document + traces into the UI wire shape, when both exist."""
@@ -286,6 +260,8 @@ def _rebuild_optimization_result(data: dict[str, Any]) -> OptimizationResult:
 
 
 def _load_mc(archive: BundleArchive, manifest: Manifest) -> LoadedMC | None:
+    from ..monte_carlo.builder import build_pipeline, validate_pipeline_spec
+
     pipeline_members = manifest.members_by_kind("mc_pipeline")
     if not pipeline_members:
         return None
@@ -305,8 +281,18 @@ def _load_mc(archive: BundleArchive, manifest: Manifest) -> LoadedMC | None:
     postproc_tables = _load_mc_postproc_tables(archive, manifest)
     resources = _load_mc_resources(archive, manifest, spec)
 
+    # Build the runnable pipeline eagerly. This needs no model: every step
+    # compiles from its parameters alone. A malformed stored spec raises here, so
+    # ``load_bundle`` fails fast on structure. The model-availability gate is a
+    # run concern: both ``reference`` and ``dgp`` are supplied later at
+    # ``pipeline.run(...)``, so both are declared available here (the pipeline is
+    # runnable once the caller passes the models it needs).
+    ordered, postprocs = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
+    pipeline = build_pipeline(ordered, postprocs, resources=resources)
+
     return LoadedMC(
         spec=spec,
+        pipeline=pipeline,
         document=document,
         traces=traces,
         resources=resources,

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -462,17 +462,36 @@ class SolvedModel:
         )
         shock_stds = conf.calibration.shock_std
 
+        # This method is the per-run anchor, so every shock validation lives
+        # here in one pass over the spec. Each entry's variables must be
+        # exogenous, and each exogenous variable may be driven by at most one
+        # entry. A variable shared across two multivar keys (for example "g,z"
+        # and "g,r") is caught here; an exact duplicate key cannot reach this
+        # point because the shocks mapping deduplicates it upstream.
+        exog_names = list(self.compiled.var_names[: self.compiled.n_exog])
+        exog_set = set(exog_names)
+        owner: dict[str, str] = {}
+        for name in shocks:
+            members = [n.strip() for n in name.split(",")] if "," in name else [name]
+            for member in members:
+                if member not in exog_set:
+                    where = f" in entry {name!r}" if "," in name else ""
+                    raise ValueError(
+                        f"Shock variable {member!r}{where} is not an exogenous "
+                        f"model variable. Valid shock variables: {exog_names}."
+                    )
+                if member in owner:
+                    raise ValueError(
+                        f"Shock variable {member!r} is driven by more than one "
+                        f"shock entry ({owner[member]!r} and {name!r}); each "
+                        "exogenous variable may appear in at most one entry."
+                    )
+                owner[member] = name
+
         for name, shock in shocks.items():
             if "," in name:
                 # Multi-Var
                 multi_names = [n.strip() for n in name.split(",")]
-
-                # All names must be exogenous and grouped names must not be re-allocated as univariate shocks
-                assert all(
-                    (n in self.compiled.var_names[: self.compiled.n_exog])
-                    and (n not in shocks)
-                    for n in multi_names
-                )
                 indices = [self.compiled.idx[n] for n in multi_names]
                 perm = np.argsort(indices)
                 multi_names_sorted = [multi_names[i] for i in perm]
@@ -520,11 +539,7 @@ class SolvedModel:
                         f"Shock for {name} must be a callable or ndarray, got {type(shock)}."
                     )
             else:
-                # Uni-Var
-                if name not in self.compiled.var_names[: self.compiled.n_exog]:
-                    raise ValueError(
-                        f"Shock variable {name} not found in exogenous model variables."
-                    )
+                # Uni-Var (target validity already checked in the pass above)
                 idx = self.compiled.idx[name]
                 if callable(shock):
                     sym = reverse_shock_map[name]

--- a/SymbolicDSGE/monte_carlo/builder.py
+++ b/SymbolicDSGE/monte_carlo/builder.py
@@ -270,18 +270,18 @@ def build_pipeline(
     ordered: Sequence[NodeSpec],
     postprocs: Sequence[PostprocSpec] = (),
     *,
-    dgp: SolvedModel | None = None,
-    reference: SolvedModel | None = None,
     resources: Mapping[str, Any] | None = None,
 ) -> MCPipeline:
     """Compile validated, ordered nodes (+ postprocs) into a runnable pipeline.
 
     ``ordered`` are the per-replication nodes in execution order; ``postprocs``
-    are the post-loop ops (a separate terminal phase). ``resources`` reattaches
-    bulk side-channel data the JSON spec only references by key: a ``raw_data``
-    node's arrays (keyed by its ``data_ref``) and a ``custom`` op's callable
-    (keyed by its ``func_ref``). The bundle loader supplies it; for an all-builtin
-    pipeline it can be omitted.
+    are the post-loop ops (a separate terminal phase). No model is needed: every
+    step compiles purely from its parameters (simulation shocks come from the
+    explicit registry, not a model), so a pipeline builds before any model is on
+    hand. ``resources`` reattaches bulk side-channel data the JSON spec only
+    references by key: a ``raw_data`` node's arrays (keyed by its ``data_ref``)
+    and a ``custom`` op's callable (keyed by its ``func_ref``). The bundle loader
+    supplies it; for an all-builtin pipeline it can be omitted.
     """
     resources = resources or {}
     per_rep_steps = []
@@ -294,10 +294,8 @@ def build_pipeline(
             definition = STEP_CATALOG.get(node.step_type)
             if definition is None:
                 raise ValueError(f"Unsupported MC step type: {node.step_type}")
-            # ``dgp`` is only dereferenced by simulation shock generation; other
-            # steps ignore it, so a DGP-free (e.g. raw_data) pipeline still builds.
             per_rep_steps.append(
-                definition.build(node.name, _clean_params(node.params), dgp, reference)
+                definition.build(node.name, _clean_params(node.params))
             )
 
     postproc_steps = []
@@ -308,9 +306,7 @@ def build_pipeline(
             definition = STEP_CATALOG.get(pp.step_type)
             if definition is None:
                 raise ValueError(f"Unsupported MC postproc step type: {pp.step_type}")
-            postproc_steps.append(
-                definition.build(pp.name, _clean_params(pp.params), dgp, reference)
-            )
+            postproc_steps.append(definition.build(pp.name, _clean_params(pp.params)))
     return MCPipeline(per_rep_steps, postproc_steps)
 
 
@@ -388,9 +384,7 @@ def run_pipeline(
         has_dgp=dgp is not None,
     )
     assert reference is not None
-    pipeline = build_pipeline(
-        ordered, postprocs, dgp=dgp, reference=reference, resources=resources
-    )
+    pipeline = build_pipeline(ordered, postprocs, resources=resources)
     return pipeline.run(
         reference=reference,
         dgp=dgp,

--- a/SymbolicDSGE/monte_carlo/catalog.py
+++ b/SymbolicDSGE/monte_carlo/catalog.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import Any, Callable, Literal, cast
 
 import numpy as np
 
@@ -41,9 +41,6 @@ from .operations.transforms import (
 )
 from .mc_constructs import MCStep
 
-if TYPE_CHECKING:
-    from ..core.solved_model import SolvedModel
-
 #: Series a diagnostic/regression step may read from an upstream context.
 INPUT_SOURCES = [
     "states",
@@ -59,9 +56,7 @@ INPUT_SOURCES = [
 FILTER_SOURCES = {"x_pred", "x_filt", "y_pred", "y_filt", "innov", "std_innov"}
 
 StepRole = Literal["datagen", "filter", "transform", "terminal", "postproc"]
-CompileParams = Callable[
-    [dict[str, Any], "SolvedModel | None", "SolvedModel | None"], dict[str, Any]
-]
+CompileParams = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -140,16 +135,13 @@ class StepDefinition:
             "fields": [spec.to_dict() for spec in self.fields],
         }
 
-    def build(
-        self,
-        name: str,
-        params: dict[str, Any],
-        dgp: SolvedModel | None,
-        reference: SolvedModel | None = None,
-    ) -> MCStep:
-        """Compile cleaned ``params`` into an :class:`MCStep` via the factory."""
+    def build(self, name: str, params: dict[str, Any]) -> MCStep:
+        """Compile cleaned ``params`` into an :class:`MCStep` via the factory.
+
+        No model is consulted: every step compiles purely from its parameters
+        (simulation shocks come from the explicit registry, not a model)."""
         if self.compile_params is not None:
-            params = self.compile_params(params, dgp, reference)
+            params = self.compile_params(params)
         return self.factory(name=name, **params)
 
 
@@ -304,15 +296,10 @@ def _coerce_shock_mapping(value: Any) -> dict[str, Shock]:
     return out
 
 
-def _compile_simulation(
-    params: dict[str, Any],
-    dgp: SolvedModel | None,
-    reference: SolvedModel | None = None,
-) -> dict[str, Any]:
+def _compile_simulation(params: dict[str, Any]) -> dict[str, Any]:
     # No model is consulted. Shocks are either explicit (a ``{key: Shock}``
     # mapping from library authoring) or come from the explicit registry the
-    # user authored. ``dgp`` / ``reference`` are unused here and kept only to
-    # satisfy the compile signature (removed in a follow-up, see #263).
+    # user authored.
     params = dict(params)
     params["seed_increment"] = _integer_or_keyword(
         params.get("seed_increment", "auto"),
@@ -329,21 +316,13 @@ def _compile_simulation(
     return params
 
 
-def _compile_filter(
-    params: dict[str, Any],
-    dgp: SolvedModel | None,
-    reference: SolvedModel | None = None,
-) -> dict[str, Any]:
+def _compile_filter(params: dict[str, Any]) -> dict[str, Any]:
     params = dict(params)
     params.pop("filter_key", None)
     return params
 
 
-def _compile_wald(
-    params: dict[str, Any],
-    dgp: SolvedModel | None,
-    reference: SolvedModel | None = None,
-) -> dict[str, Any]:
+def _compile_wald(params: dict[str, Any]) -> dict[str, Any]:
     params = dict(params)
     kind = str(params.get("kind", "mean"))
     target_key = "target_vector" if kind == "mean" else "target_matrix"
@@ -360,11 +339,7 @@ def _compile_wald(
     return params
 
 
-def _compile_regression(
-    params: dict[str, Any],
-    dgp: SolvedModel | None,
-    reference: SolvedModel | None = None,
-) -> dict[str, Any]:
+def _compile_regression(params: dict[str, Any]) -> dict[str, Any]:
     return _regression_params(params)
 
 

--- a/SymbolicDSGE/monte_carlo/catalog.py
+++ b/SymbolicDSGE/monte_carlo/catalog.py
@@ -175,56 +175,70 @@ def _integer_or_keyword(
         ) from exc
 
 
-def _build_generated_shocks(
-    model: SolvedModel | None, params: dict[str, Any]
-) -> dict[str, Shock] | None:
-    if model is None:
+def _shock_for(
+    vars_: list[str], dist: str, loc: float, df: float, seed: int | None, T: int
+) -> Shock:
+    """Build one :class:`Shock` for a shock-registry entry.
+
+    ``multivar`` is derived from the selection: a joint shock when more than one
+    variable is chosen. Uniform is univariate only (no joint uniform is
+    implemented), so a ``uni`` entry must select exactly one variable. No model
+    is consulted; the variables are exactly what the user chose.
+    """
+    n = len(vars_)
+    multivar = n > 1
+    if dist == "uni" and multivar:
         raise ValueError(
-            "A solved model is required to generate simulation shocks; pass "
-            "explicit `shocks` to author a simulation step without one."
+            "A 'uni' shock is univariate; select exactly one variable per "
+            "uniform entry (use separate entries for independent uniform shocks)."
         )
-    T = int(params["T"])
-    distribution_value = str(params.pop("distribution", "norm"))
-    if distribution_value not in {"norm", "t", "uni"}:
-        raise ValueError(f"Unsupported shock distribution: {distribution_value}")
-    distribution = cast(Literal["norm", "t", "uni"], distribution_value)
-    seed_value = params.pop("seed", 0)
-    seed = None if seed_value is None else int(seed_value)
-    loc = float(params.pop("loc", 0.0))
-    df = float(params.pop("df", 5.0))
-    targets = [str(target) for target in model.config.shock_map.values()]
-    if not targets:
-        return None
-
-    if distribution in {"norm", "t"} and len(targets) > 1:
-        kwargs: dict[str, Any] = (
-            {"loc": [loc] * len(targets), "df": df}
-            if distribution == "t"
-            else {"mean": [loc] * len(targets)}
+    if dist == "norm":
+        dist_kwargs: dict[str, Any] = {"mean": [loc] * n} if multivar else {"loc": loc}
+    elif dist == "t":
+        dist_kwargs = (
+            {"loc": [loc] * n, "df": df} if multivar else {"loc": loc, "df": df}
         )
-        return {
-            ",".join(targets): Shock(
-                T=T,
-                dist=distribution,
-                multivar=True,
-                seed=seed,
-                dist_kwargs=kwargs,
-            )
-        }
+    elif dist == "uni":
+        dist_kwargs = {"loc": loc}
+    else:
+        raise ValueError(f"Unsupported shock distribution: {dist!r}")
+    return Shock(
+        T=T,
+        dist=cast(Literal["norm", "t", "uni"], dist),
+        multivar=multivar,
+        seed=seed,
+        dist_kwargs=dist_kwargs,
+    )
 
+
+def _shocks_from_registry(
+    registry: list[dict[str, Any]], T: int
+) -> dict[str, Shock] | None:
+    """Compile an explicit shock registry into a ``{key: Shock}`` mapping.
+
+    Each entry is ``{vars, dist, loc, df, seed}``; the key is the joined variable
+    names. No model is read: the variables are the user's explicit selection.
+    """
     shocks: dict[str, Shock] = {}
-    for index, target in enumerate(targets):
-        kwargs = {"loc": loc}
-        if distribution == "t":
-            kwargs["df"] = df
-        shocks[target] = Shock(
-            T=T,
-            dist=distribution,
-            multivar=False,
-            seed=None if seed is None else seed + index,
-            dist_kwargs=kwargs,
+    for entry in registry:
+        vars_ = [str(v) for v in entry.get("vars", ())]
+        if not vars_:
+            raise ValueError(
+                "Each shock registry entry must select at least one variable."
+            )
+        key = ",".join(vars_)
+        if key in shocks:
+            raise ValueError(f"Duplicate shock entry for {key!r} in the registry.")
+        seed_value = entry.get("seed")
+        shocks[key] = _shock_for(
+            vars_,
+            str(entry.get("dist", "norm")),
+            float(entry.get("loc", 0.0)),
+            float(entry.get("df", 5.0)),
+            None if seed_value is None else int(seed_value),
+            T,
         )
-    return shocks
+    return shocks or None
 
 
 _REGRESSION_ALLOWED_BY_KIND: dict[str, set[str]] = {
@@ -295,30 +309,23 @@ def _compile_simulation(
     dgp: SolvedModel | None,
     reference: SolvedModel | None = None,
 ) -> dict[str, Any]:
+    # No model is consulted. Shocks are either explicit (a ``{key: Shock}``
+    # mapping from library authoring) or come from the explicit registry the
+    # user authored. ``dgp`` / ``reference`` are unused here and kept only to
+    # satisfy the compile signature (removed in a follow-up, see #263).
     params = dict(params)
     params["seed_increment"] = _integer_or_keyword(
         params.get("seed_increment", "auto"),
         keywords={"auto"},
         field_name="seed_increment",
     )
+    registry = params.pop("shock_registry", None)
     if params.get("shocks") is not None:
-        # Explicit (library-authored or bundle-loaded) shocks: pass them through
-        # instead of generating from the GUI shorthand.
         params["shocks"] = _coerce_shock_mapping(params["shocks"])
-        for key in ("distribution", "seed", "loc", "df"):
-            params.pop(key, None)
-    else:
-        # Generated shocks come from the model being simulated: the DGP by
-        # default, or the reference when ``target="reference"``.
-        target = str(params.get("target", "dgp"))
-        model = reference if target == "reference" else dgp
-        if model is None:
-            raise ValueError(
-                f"A solved {target} model is required to generate simulation "
-                "shocks; pass explicit `shocks` to author a simulation step "
-                "without one."
-            )
-        params["shocks"] = _build_generated_shocks(model, params)
+    elif registry:
+        params["shocks"] = _shocks_from_registry(registry, int(params["T"]))
+    # Empty registry and no explicit shocks -> deterministic sim; the op treats
+    # ``shocks=None`` as a zero shock matrix.
     return params
 
 
@@ -387,16 +394,7 @@ _STEP_DEFINITIONS: tuple[StepDefinition, ...] = (
             FieldSpec("observables", "Observables", "boolean", True),
             FieldSpec("shock_scale", "Shock scale", "number", 1.0),
             FieldSpec("seed_increment", "Seed increment", "text", "auto"),
-            FieldSpec(
-                "distribution",
-                "Distribution",
-                "select",
-                "norm",
-                options=("norm", "t", "uni"),
-            ),
-            FieldSpec("seed", "Initial seed", "number", 0),
-            FieldSpec("loc", "Location", "number", 0.0),
-            FieldSpec("df", "Degrees of freedom", "number", 5.0),
+            FieldSpec("shock_registry", "Shocks", "shock_registry", []),
         ),
     ),
     StepDefinition(

--- a/SymbolicDSGE/ui/app.py
+++ b/SymbolicDSGE/ui/app.py
@@ -97,10 +97,10 @@ def create_app(
                 has_reference=ui_session.solved_model("reference") is not None,
                 has_dgp=ui_session.solved_model("dgp") is not None,
             )
-            dgp = ui_session.solved_model("dgp")
-            assert dgp is not None
+            # Compile as part of validation (surfaces bad params). No model is
+            # needed to build; the models are consumed later at run.
             build_pipeline(
-                ordered, postprocs, dgp=dgp, resources=compile_custom_resources(request)
+                ordered, postprocs, resources=compile_custom_resources(request)
             )
             return {
                 "valid": True,

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "8b55608d",
    "metadata": {},
    "outputs": [],
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "fbd00cbe",
    "metadata": {},
    "outputs": [],
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "7868d0e5",
    "metadata": {},
    "outputs": [],
@@ -91,6 +91,7 @@
     "    per_rep_steps=[\n",
     "        simulation_step(\n",
     "            T=T,\n",
+    "            target=\"dgp\",\n",
     "            shocks={\n",
     "                \"g,z\": Shock(T=T, dist=\"norm\", multivar=True, seed=0),\n",
     "                \"r\": Shock(T=T, dist=\"norm\", seed=1),\n",
@@ -130,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "id": "c4a12aa7",
    "metadata": {},
    "outputs": [
@@ -138,19 +139,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MC run concluded successfully in 0.72s with 1388.50 it/s.\n",
+      "MC run concluded successfully in 0.72s with 1396.17 it/s.\n",
       "Per-step Report:\n",
       "\n",
-      "\tdatagen: 0 faliures, 3753.78 it/s (0.27s).\n",
-      "\tfilter: 0 faliures, 3255.05 it/s (0.31s).\n",
-      "\tcustom_std: 0 faliures, 19788.42 it/s (0.05s).\n",
-      "\tbuiltin_std: 0 faliures, 20658.72 it/s (0.05s).\n",
-      "\tstd_innov_mean: 0 faliures, 25211.78 it/s (0.04s).\n",
+      "\tdatagen: 0 faliures, 3773.85 it/s (0.26s).\n",
+      "\tfilter: 0 faliures, 3271.26 it/s (0.31s).\n",
+      "\tcustom_std: 0 faliures, 19969.25 it/s (0.05s).\n",
+      "\tbuiltin_std: 0 faliures, 20685.60 it/s (0.05s).\n",
+      "\tstd_innov_mean: 0 faliures, 25507.93 it/s (0.04s).\n",
       "\n",
       "Post-processing Report:\n",
       "\n",
-      "\tcustom_postproc: Succeeded in 0.0003s.\n",
-      "\tbuiltin_kde: Succeeded in 1.3382s.\n"
+      "\tcustom_postproc: Succeeded in 0.0004s.\n",
+      "\tbuiltin_kde: Succeeded in 1.3464s.\n"
      ]
     }
    ],
@@ -167,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "48110503",
    "metadata": {},
    "outputs": [

--- a/docs/guides/monte_carlo_guide.md
+++ b/docs/guides/monte_carlo_guide.md
@@ -96,6 +96,7 @@ from SymbolicDSGE import Shock
 
 datagen_step = simulation_step(
     T=T,
+    target="dgp",  # (1)!
     shocks={
         "g,z": Shock(T=T, dist="norm", multivar=True, seed=0),
         "r": Shock(T=T, dist="norm", seed=1),
@@ -103,6 +104,8 @@ datagen_step = simulation_step(
     observables=True,
 )
 ```
+
+1. Can be either `"reference"` or `"dgp"` defaulting to `"dgp"`. This determines which model to simulate.
 
 `simulation_step` takes all `kwarg`s that `SolvedModel.sim` accepts.
 Each MC iteration will trigger a simulation with this specification and passthrough the output data.

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -47,6 +47,7 @@ import type {
   MCPipelineSpec,
   MCStepCatalogItem,
   MCStepCategory,
+  Role,
   SessionSummary,
 } from "../types";
 import { StepInspector } from "./StepInspector";
@@ -235,6 +236,18 @@ function MCPipelineBuilder({
   );
   const modelsReady =
     session?.models.reference?.solved === true && session.models.dgp?.solved === true;
+
+  // Exogenous shock variables per model role, sourced from the loaded model
+  // configs (independent of the pipeline), for the simulation shock checklist.
+  const exogByRole: Record<Role, string[]> = useMemo(
+    () => ({
+      reference: (session?.models.reference?.shock_specs ?? []).map(
+        (spec) => spec.target,
+      ),
+      dgp: (session?.models.dgp?.shock_specs ?? []).map((spec) => spec.target),
+    }),
+    [session],
+  );
 
   const markDirty = useCallback(() => {
     setNotice("");
@@ -508,6 +521,7 @@ function MCPipelineBuilder({
           theme={theme}
           payloadProducers={payloadProducers}
           availableTraces={availableTraces}
+          exogByRole={exogByRole}
         />
       ),
     },

--- a/sdsge-ui/frontend/src/mc/StepInspector.tsx
+++ b/sdsge-ui/frontend/src/mc/StepInspector.tsx
@@ -1,10 +1,16 @@
 import Editor from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
-import { Check, TriangleAlert, Trash2 } from "lucide-react";
+import { Check, Plus, TriangleAlert, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { validateCustomOp } from "../api";
 import { registerPythonLsp } from "../lsp/registerPythonLsp";
-import type { MCFieldSpec, MCStepType } from "../types";
+import type {
+  MCFieldSpec,
+  MCStepType,
+  Role,
+  ShockDistribution,
+  ShockRegistryEntry,
+} from "../types";
 import type { MCFlowNode } from "./types";
 
 // Input legs whose value is a dependency source (a "select" with INPUT_SOURCES
@@ -34,6 +40,7 @@ export function StepInspector({
   theme,
   payloadProducers,
   availableTraces,
+  exogByRole,
 }: {
   node: MCFlowNode | null;
   onChange: (node: MCFlowNode) => void;
@@ -41,6 +48,7 @@ export function StepInspector({
   theme: "light" | "dark";
   payloadProducers: string[];
   availableTraces: string[];
+  exogByRole: Record<Role, string[]>;
 }) {
   if (node === null) {
     return (
@@ -58,6 +66,17 @@ export function StepInspector({
         params: { ...node.data.params, [key]: value },
       },
     });
+  };
+
+  // Writing the registry replaces any bundle-serialized `shocks` map so the
+  // backend compiles from the user's explicit entries, not a stale compiled form.
+  const setRegistry = (entries: ShockRegistryEntry[]) => {
+    const params: Record<string, unknown> = {
+      ...node.data.params,
+      shock_registry: entries,
+    };
+    delete params.shocks;
+    onChange({ ...node, data: { ...node.data, params } });
   };
 
   const isCustom =
@@ -106,6 +125,20 @@ export function StepInspector({
             .filter((field) => fieldVisible(field, node.data.params))
             .map((field) => {
               const key = `${node.id}:${field.key}`;
+              if (field.type === "shock_registry") {
+                const targetRole = String(
+                  node.data.params.target ?? "dgp",
+                ) as Role;
+                return (
+                  <ShockRegistryEditor
+                    key={key}
+                    target={targetRole}
+                    exogVars={exogByRole[targetRole] ?? []}
+                    entries={registryFromParams(node.data.params)}
+                    onChange={setRegistry}
+                  />
+                );
+              }
               if (field.type === "select" && SOURCE_LEG_KEYS.has(field.key)) {
                 const payloadKey = LEG_PAYLOAD_KEY[field.key];
                 return (
@@ -134,6 +167,328 @@ export function StepInspector({
       )}
     </div>
   );
+}
+
+const DIST_LABEL: Record<ShockDistribution, string> = {
+  norm: "Normal",
+  t: "Student-t",
+  uni: "Uniform",
+};
+
+// Bespoke shock panel for the simulation step. The checklist is the target
+// model's exogenous variables (offered as options, never assumed); one entry is
+// a free-form shock over the chosen subset. Client-side validation blocks a
+// variable already claimed by another entry and a joint uniform shock.
+function ShockRegistryEditor({
+  target,
+  exogVars,
+  entries,
+  onChange,
+}: {
+  target: Role;
+  exogVars: string[];
+  entries: ShockRegistryEntry[];
+  onChange: (entries: ShockRegistryEntry[]) => void;
+}) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [dist, setDist] = useState<ShockDistribution>("norm");
+  const [loc, setLoc] = useState("0");
+  const [df, setDf] = useState("5");
+  const [seed, setSeed] = useState("");
+  const [error, setError] = useState("");
+  // Index of the entry being edited (null while composing a fresh one). The
+  // entry under edit is excluded from the "used" set so its own variables stay
+  // selectable, and Save replaces it in place instead of appending.
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+
+  const usedVars = new Set(
+    entries.flatMap((entry, index) => (index === editIndex ? [] : entry.vars)),
+  );
+  const multivarUni = dist === "uni" && selected.length > 1;
+  const multivarJoint = dist !== "uni" && selected.length > 1;
+
+  function resetForm() {
+    setEditIndex(null);
+    setSelected([]);
+    setDist("norm");
+    setLoc("0");
+    setDf("5");
+    setSeed("");
+    setError("");
+  }
+
+  function toggleVar(name: string) {
+    setError("");
+    setSelected((current) =>
+      current.includes(name)
+        ? current.filter((item) => item !== name)
+        : [...current, name],
+    );
+  }
+
+  // Load an existing entry back into the form for editing.
+  function startEdit(index: number) {
+    const entry = entries[index];
+    setEditIndex(index);
+    setSelected(entry.vars);
+    setDist(entry.dist);
+    setLoc(String(entry.loc));
+    setDf(String(entry.df));
+    setSeed(entry.seed === null ? "" : String(entry.seed));
+    setError("");
+  }
+
+  function commitEntry() {
+    if (selected.length === 0) {
+      setError("Select at least one exogenous variable.");
+      return;
+    }
+    const clash = selected.find((name) => usedVars.has(name));
+    if (clash !== undefined) {
+      setError(`'${clash}' is already used in another shock entry.`);
+      return;
+    }
+    if (dist === "uni" && selected.length > 1) {
+      setError("A uniform shock is univariate; select exactly one variable.");
+      return;
+    }
+    // Order the key by the model's variable order for a stable identity.
+    const vars = exogVars.filter((name) => selected.includes(name));
+    const entry: ShockRegistryEntry = {
+      vars,
+      dist,
+      loc: Number(loc) || 0,
+      df: Number(df) || 5,
+      seed: seed.trim() === "" ? null : Number(seed),
+    };
+    onChange(
+      editIndex === null
+        ? [...entries, entry]
+        : entries.map((current, index) => (index === editIndex ? entry : current)),
+    );
+    resetForm();
+  }
+
+  function removeEntry(index: number) {
+    onChange(entries.filter((_, position) => position !== index));
+    // Keep the edit target consistent with the shrunk list.
+    if (editIndex === index) resetForm();
+    else if (editIndex !== null && index < editIndex) setEditIndex(editIndex - 1);
+  }
+
+  return (
+    <div className="mc-shock-registry">
+      <div className="mc-shock-registry-head">
+        <span className="mc-shock-registry-label">Shocks</span>
+        <span className="mc-shock-registry-target">from {target}</span>
+      </div>
+      {entries.length > 0 ? (
+        <ul className="mc-shock-list">
+          {entries.map((entry, index) => (
+            <li
+              key={entry.vars.join(",")}
+              className={`mc-shock-entry${editIndex === index ? " editing" : ""}`}
+            >
+              <button
+                className="mc-shock-entry-select"
+                title="Edit shock"
+                disabled={exogVars.length === 0}
+                onClick={() => startEdit(index)}
+              >
+                <div className="mc-shock-entry-body">
+                  <strong>
+                    {entry.vars.join(", ")}
+                    {entry.vars.length > 1 && (
+                      <span className="mc-shock-badge">joint</span>
+                    )}
+                  </strong>
+                  <span>{describeEntry(entry)}</span>
+                </div>
+              </button>
+              <button
+                className="icon-button"
+                title="Remove shock"
+                onClick={() => removeEntry(index)}
+              >
+                <Trash2 size={13} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mc-shock-empty">
+          No shocks configured; this simulation runs deterministically.
+        </p>
+      )}
+      {exogVars.length === 0 ? (
+        <p className="mc-shock-empty">
+          Load and solve the {target} model to choose its exogenous shocks.
+        </p>
+      ) : (
+        <div className="mc-shock-form">
+          <div className="mc-shock-checklist">
+            {exogVars.map((name) => {
+              const used = usedVars.has(name);
+              return (
+                <label
+                  key={name}
+                  className={`mc-shock-check${used ? " used" : ""}`}
+                  title={used ? "Already used in another shock entry." : undefined}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(name)}
+                    disabled={used}
+                    onChange={() => toggleVar(name)}
+                  />
+                  <span>{name}</span>
+                </label>
+              );
+            })}
+          </div>
+          <div className="mc-shock-fields">
+            <label>
+              Distribution
+              <select
+                value={dist}
+                onChange={(event) => {
+                  setDist(event.target.value as ShockDistribution);
+                  setError("");
+                }}
+              >
+                <option value="norm">Normal</option>
+                <option value="t">Student-t</option>
+                <option value="uni">Uniform</option>
+              </select>
+            </label>
+            <label>
+              Location
+              <input
+                type="number"
+                value={loc}
+                onChange={(event) => setLoc(event.target.value)}
+              />
+            </label>
+            {dist === "t" && (
+              <label>
+                Degrees of freedom
+                <input
+                  type="number"
+                  value={df}
+                  onChange={(event) => setDf(event.target.value)}
+                />
+              </label>
+            )}
+            <label>
+              Seed
+              <input
+                type="number"
+                placeholder="none"
+                value={seed}
+                onChange={(event) => setSeed(event.target.value)}
+              />
+            </label>
+          </div>
+          {multivarUni && (
+            <span className="mc-shock-hint">
+              A uniform shock is univariate; select exactly one variable.
+            </span>
+          )}
+          {multivarJoint && (
+            <span className="mc-shock-hint">
+              This is one joint (multivar) shock over {selected.length} variables.
+              Add a separate entry per variable if you want them independent.
+            </span>
+          )}
+          {error !== "" && <span className="status error mc-shock-error">{error}</span>}
+          <div className="mc-shock-actions">
+            <button
+              className="secondary mc-shock-add"
+              onClick={commitEntry}
+              disabled={selected.length === 0}
+            >
+              {editIndex === null ? <Plus size={13} /> : <Check size={13} />}
+              {editIndex === null ? "Add shock" : "Save shock"}
+            </button>
+            {editIndex !== null && (
+              <button className="secondary" onClick={resetForm}>
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function describeEntry(entry: ShockRegistryEntry): string {
+  const parts = [DIST_LABEL[entry.dist], `loc ${entry.loc}`];
+  if (entry.dist === "t") parts.push(`df ${entry.df}`);
+  parts.push(entry.seed === null ? "seed none" : `seed ${entry.seed}`);
+  return parts.join(", ");
+}
+
+// Read the registry the panel renders, literally, from the step params. A
+// GUI-authored step carries `shock_registry`; a bundle-serialized step carries
+// the compiled `shocks` map, which we reconstruct one entry per key with no
+// invented info (the key alone gives the variables and joint/multivar status).
+function registryFromParams(
+  params: Record<string, unknown>,
+): ShockRegistryEntry[] {
+  const registry = params.shock_registry;
+  if (Array.isArray(registry) && registry.length > 0) {
+    return registry.map(normalizeEntry);
+  }
+  const shocks = params.shocks;
+  if (shocks !== null && typeof shocks === "object" && !Array.isArray(shocks)) {
+    return Object.entries(shocks as Record<string, unknown>).map(([key, value]) =>
+      entryFromShock(key, (value ?? {}) as Record<string, unknown>),
+    );
+  }
+  return [];
+}
+
+function normalizeEntry(raw: unknown): ShockRegistryEntry {
+  const entry = (raw ?? {}) as Record<string, unknown>;
+  return {
+    vars: Array.isArray(entry.vars) ? entry.vars.map(String) : [],
+    dist: asDist(entry.dist),
+    loc: Number(entry.loc ?? 0),
+    df: Number(entry.df ?? 5),
+    seed:
+      entry.seed === null || entry.seed === undefined ? null : Number(entry.seed),
+  };
+}
+
+// Invert `_shock_for`: recover the registry entry from a serialized Shock dict.
+// `loc` lives under `mean`/`loc` (scalar or per-variable list) by dist and shape.
+function entryFromShock(
+  key: string,
+  dict: Record<string, unknown>,
+): ShockRegistryEntry {
+  const vars = key
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  const dist = asDist(dict.dist);
+  const multivar = Boolean(dict.multivar) || vars.length > 1;
+  const kwargs = (dict.dist_kwargs ?? {}) as Record<string, unknown>;
+  const first = (value: unknown) =>
+    Array.isArray(value) ? Number(value[0] ?? 0) : Number(value ?? 0);
+  const loc =
+    dist === "norm" && multivar ? first(kwargs.mean) : first(kwargs.loc);
+  return {
+    vars,
+    dist,
+    loc,
+    df: dist === "t" ? Number(kwargs.df ?? 5) : 5,
+    seed: dict.seed === null || dict.seed === undefined ? null : Number(dict.seed),
+  };
+}
+
+function asDist(value: unknown): ShockDistribution {
+  return value === "t" || value === "uni" ? value : "norm";
 }
 
 function SourceLegEditor({

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -1468,6 +1468,168 @@ button.mc-palette-tab.active .mc-palette-tab-count {
   padding-left: 10px;
 }
 
+.mc-shock-registry {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  grid-column: 1 / -1;
+  padding: 10px;
+}
+
+.mc-shock-registry-head {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.mc-shock-registry-label {
+  color: #1e293b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mc-shock-registry-target {
+  color: #64748b;
+  font-size: 11px;
+}
+
+.mc-shock-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mc-shock-entry {
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 6px 8px;
+}
+
+.mc-shock-entry.editing {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 1px #6366f1;
+}
+
+.mc-shock-entry-select {
+  background: none;
+  border: none;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.mc-shock-entry-select:disabled {
+  cursor: default;
+}
+
+.mc-shock-entry-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mc-shock-entry-body strong {
+  align-items: center;
+  color: #1e293b;
+  display: flex;
+  font-size: 12px;
+  gap: 6px;
+}
+
+.mc-shock-entry-body span {
+  color: #64748b;
+  font-size: 10px;
+}
+
+.mc-shock-badge {
+  background: #e0e7ff;
+  border-radius: 4px;
+  color: #4338ca;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 1px 5px;
+  text-transform: uppercase;
+}
+
+.mc-shock-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.mc-shock-empty {
+  color: #64748b;
+  font-size: 11px;
+  margin: 0;
+}
+
+.mc-shock-form {
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+.mc-shock-checklist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mc-shock-check {
+  align-items: center;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  font-size: 11px;
+  gap: 5px;
+  padding: 3px 8px;
+}
+
+.mc-shock-check.used {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.mc-shock-check input {
+  margin: 0;
+}
+
+.mc-shock-fields {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+.mc-shock-hint {
+  color: #b45309;
+  font-size: 10px;
+}
+
+.mc-shock-error {
+  font-size: 10px;
+}
+
+.mc-shock-add {
+  align-self: flex-start;
+}
+
 .mc-edge-legend {
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid #e2e8f0;
@@ -2430,8 +2592,36 @@ button.mc-palette-tab.active .mc-palette-tab-count {
 .theme-dark .mc-summary-tabs,
 .theme-dark .mc-regression-detail,
 .theme-dark .mc-summary-table th,
-.theme-dark .mc-summary-table td {
+.theme-dark .mc-summary-table td,
+.theme-dark .mc-shock-registry,
+.theme-dark .mc-shock-entry,
+.theme-dark .mc-shock-check,
+.theme-dark .mc-shock-form {
   border-color: #334155;
+}
+
+.theme-dark .mc-shock-registry-label,
+.theme-dark .mc-shock-entry-body strong {
+  color: #e2e8f0;
+}
+
+.theme-dark .mc-shock-registry-target,
+.theme-dark .mc-shock-entry-body span,
+.theme-dark .mc-shock-empty {
+  color: #94a3b8;
+}
+
+.theme-dark .mc-shock-entry {
+  background: #1e293b;
+}
+
+.theme-dark .mc-shock-check {
+  background: #1e293b;
+}
+
+.theme-dark .mc-shock-badge {
+  background: #312e81;
+  color: #c7d2fe;
 }
 
 .theme-dark .mc-summary-tabs button {

--- a/sdsge-ui/frontend/src/types.ts
+++ b/sdsge-ui/frontend/src/types.ts
@@ -197,7 +197,19 @@ export type MCFieldType =
   | "trace"
   | "number_list"
   | "number_matrix"
-  | "text_list";
+  | "text_list"
+  | "shock_registry";
+
+// One entry in a simulation step's shock registry: an explicit, free-form shock
+// over a chosen set of the target model's exogenous variables. `vars.length > 1`
+// is a joint (multivar) shock; the joined names form the registry key.
+export interface ShockRegistryEntry {
+  vars: string[];
+  dist: ShockDistribution;
+  loc: number;
+  df: number;
+  seed: number | null;
+}
 
 export interface MCFieldSpec {
   key: string;

--- a/tests/bundle/test_mc_facade.py
+++ b/tests/bundle/test_mc_facade.py
@@ -92,7 +92,7 @@ def test_add_mc_ships_raw_data_member_and_loader_rehydrates(tmp_path) -> None:
     np.testing.assert_allclose(arrays["observables"], expected)
 
     # The loaded spec + resources rebuild an equivalent runnable pipeline.
-    rebuilt = loaded.mc.build_pipeline()
+    rebuilt = loaded.mc.pipeline
     np.testing.assert_allclose(rebuilt.per_rep_steps[0].kwargs["observables"], expected)
     assert [s.step_type for s in rebuilt.per_rep_steps] == ["raw_data", "jarque_bera"]
 
@@ -121,7 +121,7 @@ def test_add_mc_ships_custom_op_member_and_loader_rebuilds(tmp_path) -> None:
     assert isinstance(func, NumpyCustomFunc)  # wrapped + source-carrying
     assert "zscore" in func.source
 
-    rebuilt = loaded.mc.build_pipeline()
+    rebuilt = loaded.mc.pipeline
     z_step = {s.name: s for s in rebuilt.per_rep_steps}["z"]
     assert z_step.step_type == "transform:custom"
     assert callable(z_step.func)
@@ -285,7 +285,7 @@ def test_postproc_custom_op_full_round_trip(tmp_path) -> None:
     )
 
     # Rebuild from spec + resources -> equivalent runnable pipeline.
-    rebuilt = loaded.mc.build_pipeline()
+    rebuilt = loaded.mc.pipeline
     assert [s.step_type for s in (*rebuilt.per_rep_steps, *rebuilt.postproc_steps)] == [
         "raw_data",
         "jarque_bera",

--- a/tests/core/test_solved_model.py
+++ b/tests/core/test_solved_model.py
@@ -269,7 +269,7 @@ def test_solved_model_shock_unpack_univariate_callable_and_errors(solved_test):
     assert out[0][0] == solved_test.compiled.idx["u"]
     assert np.array_equal(out[0][1], np.full((4,), 0.50, dtype=np.float64))
 
-    with pytest.raises(ValueError, match="not found in exogenous"):
+    with pytest.raises(ValueError, match="not an exogenous model variable"):
         solved_test._shock_unpack({"Pi": np.ones((4,), dtype=np.float64)})
 
     with pytest.raises(TypeError, match="must be a callable or ndarray"):
@@ -285,6 +285,23 @@ def test_solved_model_shock_unpack_multivariate_error_paths(solved_test):
 
     with pytest.raises(TypeError, match="must be a callable or ndarray"):
         solved_test._shock_unpack({"u,v": "bad-shock"})
+
+
+def test_solved_model_shock_unpack_names_unknown_multivar_member(solved_test):
+    # An unknown member of a multivar key is named alongside the entry it came
+    # from, so a typo is traceable to the exact grouped spec.
+    arr = np.zeros((4, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match=r"'Pi'.*entry 'u,Pi'"):
+        solved_test._shock_unpack({"u,Pi": arr})
+
+
+def test_solved_model_shock_unpack_rejects_variable_in_two_entries(solved_test):
+    # 'u' is driven by both a multivar and a univariate entry: each exogenous
+    # variable may appear in at most one entry, caught by the single pass.
+    mv = np.zeros((4, 2), dtype=np.float64)
+    uni = np.zeros((4,), dtype=np.float64)
+    with pytest.raises(ValueError, match=r"'u' is driven by more than one"):
+        solved_test._shock_unpack({"u,v": mv, "u": uni})
 
 
 def test_solved_model_kalman_smoke(solved_post82):

--- a/tests/monte_carlo/test_catalog_builder.py
+++ b/tests/monte_carlo/test_catalog_builder.py
@@ -14,6 +14,7 @@ from SymbolicDSGE.monte_carlo import (
     catalog_payload,
     validate_pipeline_spec,
 )
+from SymbolicDSGE.monte_carlo.catalog import _shocks_from_registry
 from SymbolicDSGE.monte_carlo.operations.transforms import transform_step
 from SymbolicDSGE.monte_carlo.spec import (
     STEP_KINDS,
@@ -268,7 +269,16 @@ def test_validate_requires_reference_and_dgp() -> None:
 def test_build_pipeline_compiles_via_catalog_and_filters_regression_kwargs() -> None:
     spec = PipelineSpec(
         nodes=[
-            NodeSpec("sim", "simulation", "datagen", {"T": 8, "observables": True}),
+            NodeSpec(
+                "sim",
+                "simulation",
+                "datagen",
+                {
+                    "T": 8,
+                    "observables": True,
+                    "shock_registry": [{"vars": ["u"], "dist": "norm"}],
+                },
+            ),
             NodeSpec(
                 "reg",
                 "regression",
@@ -290,7 +300,7 @@ def test_build_pipeline_compiles_via_catalog_and_filters_regression_kwargs() -> 
     assert [s.name for s in pipeline.per_rep_steps] == ["datagen", "reg"]
     assert pipeline.per_rep_steps[0].op_type is OpType.DATAGEN
     assert pipeline.per_rep_steps[1].op_type is OpType.REGRESSION
-    # simulation got generated shocks injected
+    # simulation compiled the shock registry into a live shocks mapping
     assert "shocks" in pipeline.per_rep_steps[0].kwargs
     # OLS regression dropped the conditional alpha kwarg
     assert "alpha" not in pipeline.per_rep_steps[1].kwargs
@@ -460,3 +470,69 @@ def test_postproc_custom_trace_refs_not_statically_validated() -> None:
 def test_kde_trace_field_is_typed_trace() -> None:
     trace_field = next(f for f in STEP_CATALOG["kde"].fields if f.key == "trace")
     assert trace_field.type == "trace"
+
+
+# --- shock registry compile -------------------------------------------------
+# The simulation compile hook builds shocks from an explicit registry with no
+# model involved: one entry compiles to one Shock, joint iff it selects more
+# than one variable.
+
+
+def test_registry_norm_univariate_shapes_loc_kwarg() -> None:
+    shocks = _shocks_from_registry([{"vars": ["u"], "dist": "norm", "loc": 0.5}], T=8)
+    assert shocks is not None
+    shock = shocks["u"]
+    assert shock.multivar is False
+    assert shock.dist == "norm"
+    assert shock.dist_kwargs == {"loc": 0.5}
+
+
+def test_registry_norm_multivariate_shapes_mean_kwarg() -> None:
+    shocks = _shocks_from_registry(
+        [{"vars": ["u", "v"], "dist": "norm", "loc": 0.0}], T=8
+    )
+    assert shocks is not None
+    shock = shocks["u,v"]
+    assert shock.multivar is True
+    assert shock.dist_kwargs == {"mean": [0.0, 0.0]}
+
+
+def test_registry_t_carries_df() -> None:
+    shocks = _shocks_from_registry(
+        [{"vars": ["u"], "dist": "t", "loc": 0.0, "df": 7.0}], T=8
+    )
+    assert shocks is not None
+    assert shocks["u"].dist_kwargs == {"loc": 0.0, "df": 7.0}
+
+
+def test_registry_uniform_single_variable_ok() -> None:
+    shocks = _shocks_from_registry([{"vars": ["u"], "dist": "uni"}], T=8)
+    assert shocks is not None
+    assert shocks["u"].multivar is False
+    assert shocks["u"].dist == "uni"
+
+
+def test_registry_uniform_multiple_variables_raises() -> None:
+    with pytest.raises(ValueError, match="univariate"):
+        _shocks_from_registry([{"vars": ["u", "v"], "dist": "uni"}], T=8)
+
+
+def test_registry_empty_compiles_to_none() -> None:
+    assert _shocks_from_registry([], T=8) is None
+
+
+def test_registry_entry_without_variables_raises() -> None:
+    with pytest.raises(ValueError, match="at least one variable"):
+        _shocks_from_registry([{"vars": [], "dist": "norm"}], T=8)
+
+
+def test_registry_duplicate_key_raises() -> None:
+    with pytest.raises(ValueError, match="Duplicate shock entry"):
+        _shocks_from_registry(
+            [{"vars": ["u"], "dist": "norm"}, {"vars": ["u"], "dist": "t"}], T=8
+        )
+
+
+def test_registry_unsupported_distribution_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported shock distribution"):
+        _shocks_from_registry([{"vars": ["u"], "dist": "cauchy"}], T=8)

--- a/tests/monte_carlo/test_catalog_builder.py
+++ b/tests/monte_carlo/test_catalog_builder.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import inspect
-from types import SimpleNamespace
 
 import pytest
-from sympy import Symbol
 
 from SymbolicDSGE.monte_carlo import (
     STEP_CATALOG,
@@ -78,11 +76,6 @@ _FIELD_KEYS = {
     "minimum",
     "when",
 }
-
-
-def _stub_dgp(*targets: str) -> SimpleNamespace:
-    shock_map = {Symbol(f"e_{t}"): Symbol(t) for t in targets}
-    return SimpleNamespace(config=SimpleNamespace(shock_map=shock_map))
 
 
 def test_catalog_payload_shape_and_known_fields() -> None:
@@ -295,7 +288,7 @@ def test_build_pipeline_compiles_via_catalog_and_filters_regression_kwargs() -> 
     )
     ordered, postprocs = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
 
-    pipeline = build_pipeline(ordered, postprocs, dgp=_stub_dgp("u"))
+    pipeline = build_pipeline(ordered, postprocs)
 
     assert [s.name for s in pipeline.per_rep_steps] == ["datagen", "reg"]
     assert pipeline.per_rep_steps[0].op_type is OpType.DATAGEN
@@ -311,7 +304,7 @@ def test_build_pipeline_rejects_unknown_step_type() -> None:
     # bogus kind reaches build_pipeline and must be rejected there.
     node = NodeSpec(id="x", step_type="bogus", name="x", params={})
     with pytest.raises(ValueError, match="Unsupported MC step type"):
-        build_pipeline([node], dgp=_stub_dgp("u"))
+        build_pipeline([node])
 
 
 # --- POSTPROC (post-loop) kind: ordering, edges, compilation -----------------
@@ -376,9 +369,7 @@ def test_build_postproc_custom_from_resources() -> None:
         ],
     )
     ordered, postprocs = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
-    pipeline = build_pipeline(
-        ordered, postprocs, dgp=_stub_dgp("u"), resources={"p": my_summary}
-    )
+    pipeline = build_pipeline(ordered, postprocs, resources={"p": my_summary})
     step = {s.name: s for s in pipeline.postproc_steps}["p"]
     assert step.op_type is OpType.POSTPROC
     assert step.step_type == "postproc:custom"

--- a/tests/monte_carlo/test_to_spec.py
+++ b/tests/monte_carlo/test_to_spec.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
-from typing import cast
 
 import numpy as np
 import pytest
 
 from SymbolicDSGE.core.shock_generators import Shock
-from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.monte_carlo import (
     EdgeSpec,
     MCPipeline,
@@ -89,9 +86,8 @@ def test_to_spec_is_a_fixed_point_under_rebuild() -> None:
     pipe = _simulation_pipeline()
     spec1 = pipe.to_spec()
 
-    stub_dgp = cast(SolvedModel, SimpleNamespace())
     ordered, postprocs = validate_pipeline_spec(spec1, has_reference=True, has_dgp=True)
-    rebuilt = build_pipeline(ordered, postprocs, dgp=stub_dgp)
+    rebuilt = build_pipeline(ordered, postprocs)
 
     spec2 = rebuilt.to_spec()
     assert spec2 == spec1
@@ -116,11 +112,10 @@ def test_to_spec_rejects_shock_generators_with_actionable_message() -> None:
 
 def test_rebuilt_simulation_recovers_live_shocks() -> None:
     pipe = _simulation_pipeline()
-    stub_dgp = cast(SolvedModel, SimpleNamespace())
     ordered, postprocs = validate_pipeline_spec(
         pipe.to_spec(), has_reference=True, has_dgp=True
     )
-    rebuilt = build_pipeline(ordered, postprocs, dgp=stub_dgp)
+    rebuilt = build_pipeline(ordered, postprocs)
 
     shock = rebuilt.per_rep_steps[0].kwargs["shocks"]["u"]
     assert isinstance(shock, Shock)
@@ -223,9 +218,8 @@ def test_to_spec_round_trips_a_postproc_pipeline() -> None:
     # postprocs are a separate list, never nodes or edges.
     assert "kde" not in {n.name for n in spec1.nodes}
 
-    stub_dgp = cast(SolvedModel, SimpleNamespace())
     ordered, postprocs = validate_pipeline_spec(spec1, has_reference=True, has_dgp=True)
     assert [n.id for n in ordered] == ["dgp", "jb"]
     assert [p.name for p in postprocs] == ["kde"]
-    rebuilt = build_pipeline(ordered, postprocs, dgp=stub_dgp)
+    rebuilt = build_pipeline(ordered, postprocs)
     assert rebuilt.to_spec() == spec1  # fixed point

--- a/tests/monte_carlo/test_transforms.py
+++ b/tests/monte_carlo/test_transforms.py
@@ -62,15 +62,6 @@ def _context(observables: np.ndarray) -> MCContext:
     )
 
 
-def _stub_dgp(*_targets: str) -> SimpleNamespace:
-    """A placeholder DGP for build-only tests.
-
-    ``build_pipeline`` no longer reads any model to compile a simulation step
-    (shocks come from the explicit registry, not the model), so this stub only
-    stands in as the ``dgp`` argument. It is never inspected."""
-    return SimpleNamespace()
-
-
 # ---- unit tests for the ops ---------------------------------------------
 
 
@@ -550,7 +541,7 @@ def test_transform_fans_out_to_multiple_downstream_chains() -> None:
     assert wvar.params["payload_key"] == "rvar"
 
     # Catalog-driven compile succeeds with the bound params.
-    pipeline = build_pipeline(ordered, dgp=_stub_dgp("g", "z"))
+    pipeline = build_pipeline(ordered)
     assert [step.name for step in pipeline.per_rep_steps] == names
 
 
@@ -698,7 +689,7 @@ def test_build_pipeline_emits_transform_mcstep_with_bound_params() -> None:
         ],
     )
     ordered, _ = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
-    pipeline = build_pipeline(ordered, dgp=_stub_dgp("g", "z"))
+    pipeline = build_pipeline(ordered)
     names = [step.name for step in pipeline.per_rep_steps]
     assert names == ["datagen", "rmean", "normality"]
     rm_step = pipeline.per_rep_steps[1]

--- a/tests/monte_carlo/test_transforms.py
+++ b/tests/monte_carlo/test_transforms.py
@@ -62,13 +62,13 @@ def _context(observables: np.ndarray) -> MCContext:
     )
 
 
-def _stub_dgp_with_shocks(*targets: str) -> SimpleNamespace:
-    """Mirror catalog tests' fake-DGP shape — `build_pipeline` reads
-    ``dgp.config.shock_map`` for simulation params, nothing else."""
-    from sympy import Symbol
+def _stub_dgp(*_targets: str) -> SimpleNamespace:
+    """A placeholder DGP for build-only tests.
 
-    shock_map = {Symbol(f"e_{t}"): Symbol(t) for t in targets}
-    return SimpleNamespace(config=SimpleNamespace(shock_map=shock_map))
+    ``build_pipeline`` no longer reads any model to compile a simulation step
+    (shocks come from the explicit registry, not the model), so this stub only
+    stands in as the ``dgp`` argument. It is never inspected."""
+    return SimpleNamespace()
 
 
 # ---- unit tests for the ops ---------------------------------------------
@@ -550,7 +550,7 @@ def test_transform_fans_out_to_multiple_downstream_chains() -> None:
     assert wvar.params["payload_key"] == "rvar"
 
     # Catalog-driven compile succeeds with the bound params.
-    pipeline = build_pipeline(ordered, dgp=_stub_dgp_with_shocks("g", "z"))
+    pipeline = build_pipeline(ordered, dgp=_stub_dgp("g", "z"))
     assert [step.name for step in pipeline.per_rep_steps] == names
 
 
@@ -698,7 +698,7 @@ def test_build_pipeline_emits_transform_mcstep_with_bound_params() -> None:
         ],
     )
     ordered, _ = validate_pipeline_spec(spec, has_reference=True, has_dgp=True)
-    pipeline = build_pipeline(ordered, dgp=_stub_dgp_with_shocks("g", "z"))
+    pipeline = build_pipeline(ordered, dgp=_stub_dgp("g", "z"))
     names = [step.name for step in pipeline.per_rep_steps]
     assert names == ["datagen", "rmean", "normality"]
     rm_step = pipeline.per_rep_steps[1]

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -387,8 +387,9 @@ def test_ui_backend_validates_and_runs_monte_carlo_pipeline() -> None:
                 "params": {
                     "T": 8,
                     "observables": True,
-                    "distribution": "norm",
-                    "seed": 10,
+                    "shock_registry": [
+                        {"vars": ["u", "v"], "dist": "norm", "seed": 10}
+                    ],
                 },
             }
         ],
@@ -437,7 +438,11 @@ _POSTPROC_PIPELINE = {
             "id": "sim",
             "step_type": "simulation",
             "name": "datagen",
-            "params": {"T": 8, "observables": True, "distribution": "norm", "seed": 10},
+            "params": {
+                "T": 8,
+                "observables": True,
+                "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 10}],
+            },
         },
         {
             "id": "jb",
@@ -658,7 +663,10 @@ def test_ui_backend_runs_breusch_pagan_monte_carlo_step() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 20},
+                "params": {
+                    "T": 20,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 0}],
+                },
             },
             {
                 "id": "bp",
@@ -717,7 +725,10 @@ def test_ui_backend_runs_breusch_godfrey_monte_carlo_step() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 20},
+                "params": {
+                    "T": 20,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 0}],
+                },
             },
             {
                 "id": "bg",
@@ -776,7 +787,10 @@ def test_ui_backend_runs_cusum_monte_carlo_step() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 30},
+                "params": {
+                    "T": 30,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 0}],
+                },
             },
             {
                 "id": "cs",
@@ -833,7 +847,10 @@ def test_ui_backend_runs_cusumsq_monte_carlo_step() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 30},
+                "params": {
+                    "T": 30,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 0}],
+                },
             },
             {
                 "id": "csq",
@@ -890,7 +907,10 @@ def test_ui_backend_runs_chow_monte_carlo_step() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 30},
+                "params": {
+                    "T": 30,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 0}],
+                },
             },
             {
                 "id": "ch",
@@ -1124,7 +1144,11 @@ def test_ui_backend_runs_custom_op_pipeline() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 8, "observables": True, "seed": 1},
+                "params": {
+                    "T": 8,
+                    "observables": True,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 1}],
+                },
             },
             {
                 "id": "z",
@@ -1175,7 +1199,11 @@ def test_ui_backend_rejects_invalid_custom_op_on_run() -> None:
                 "id": "sim",
                 "step_type": "simulation",
                 "name": "datagen",
-                "params": {"T": 8, "observables": True, "seed": 1},
+                "params": {
+                    "T": 8,
+                    "observables": True,
+                    "shock_registry": [{"vars": ["u", "v"], "dist": "norm", "seed": 1}],
+                },
             },
             {
                 "id": "z",


### PR DESCRIPTION
This pull request refactors the Monte Carlo pipeline and shock handling code to remove all model dependencies from pipeline construction and step compilation. Pipelines are now built eagerly at load time using only the explicit pipeline specification and resources, not the model. Shock generation for simulation steps is now handled exclusively through explicit user-authored registries or direct shock mappings, and all model validation for shocks is deferred to runtime. This simplifies pipeline loading, improves validation, and makes the codebase more modular.

**Monte Carlo Pipeline Refactor**

* Pipelines are now built eagerly at load time (`LoadedMC.pipeline`) from the spec and resources, without requiring a model; the old `build_pipeline` method is removed, and the pipeline is ready to run once models are supplied at execution time. [[1]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR64-L70) [[2]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR81-L113) [[3]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR284-R295)
* The `build_pipeline` and step `build` signatures are simplified: they no longer take `dgp` or `reference` models, and step compilation is now parameter-only. [[1]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL273-R284) [[2]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL297-R298) [[3]](diffhunk://#diff-25788ef4625624c5231c4bcd6211f9e94ff947ea90b499f2f110af78d28873fbL311-R309) [[4]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L44-L46) [[5]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L62-R59) [[6]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L143-R144)

**Shock Handling and Simulation Step Compilation**

* Shock generation for simulation steps is now handled by an explicit registry (`shock_registry`) or direct shock mapping; no model is consulted during pipeline or step compilation. All model validation for shocks happens at runtime, and registry entries are validated for uniqueness and correctness. [[1]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L178-R233) [[2]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L293-R325) [[3]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L390-R372)
* The `_shock_unpack` method in `SolvedModel` now performs all shock variable validation in a single pass at runtime, ensuring each exogenous variable is only driven by one entry and all variables are valid. [[1]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadR465-L475) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL523-R542)

**Codebase Simplification**

* Removes unnecessary model references, `TYPE_CHECKING` imports, and related compile-time code, making the Monte Carlo pipeline code more modular and easier to maintain. [[1]](diffhunk://#diff-1e08e83c6781b93f7c4e96e674cb338b0071499a1b903966b8d296684c93e975L15-R15) [[2]](diffhunk://#diff-d0307cc4d3ee5ac49d3f3d33324608ad4cf3939888860d43c4b654ba46150acdR263-R264)

closes #260 
closes #261 
closes #262 
closes #263 
closes #264 
closes #265 
