### PR TITLE
Implement Unscented Kalman Filter and refactor Kalman kernel

### DIFF
--- a/SymbolicDSGE/_ckernels/kalman/__init__.py
+++ b/SymbolicDSGE/_ckernels/kalman/__init__.py
@@ -6,3 +6,4 @@ falls back to its numba kernels.
 """
 
 from ._kalman import kalman_hot_loop as kalman_hot_loop
+from ._kalman import ukf_hot_loop as ukf_hot_loop

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
@@ -35,3 +35,32 @@ def kalman_hot_loop(
     tuple[_F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, float64],
 ]:
     """Run the linear Kalman filter; mirrors numba ``_kalman_hot_loop``."""
+
+def ukf_hot_loop(
+    meas_addr: int,
+    hx: _F64,
+    gx: _F64,
+    bx: _F64,
+    hxx: _F64,
+    gxx: _F64,
+    hss: _F64,
+    gss: _F64,
+    steady_state: _F64,
+    params: _F64,
+    Q: _F64,
+    R: _F64,
+    obs: _F64,
+    z0: _F64,
+    P0: _F64,
+    alpha: float,
+    beta: float,
+    kappa: float,
+    jitter: float,
+    symmetrize: bool = ...,
+    store_history: bool = ...,
+) -> tuple[
+    int,
+    tuple[float64, float64, float64],
+    tuple[_F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, float64],
+]:
+    """Run the native second-order UKF hot loop."""

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyi
@@ -61,6 +61,21 @@ def ukf_hot_loop(
 ) -> tuple[
     int,
     tuple[float64, float64, float64],
-    tuple[_F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, _F64, float64],
+    tuple[
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        _F64,
+        float64,
+    ],
 ]:
     """Run the native second-order UKF hot loop."""

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -97,6 +97,9 @@ cdef extern from "kalman.h":
         double *x1_filt
         double *x2_filt
 
+        double *x_pred
+        double *x_filt
+
         double *P_pred
         double *P_filt
 
@@ -303,6 +306,8 @@ def ukf_hot_loop(
     x2_pred = np.zeros((hist_T, n_state), dtype=np.float64)
     x1_filt = np.zeros((hist_T, n_state), dtype=np.float64)
     x2_filt = np.zeros((hist_T, n_state), dtype=np.float64)
+    x_pred = np.zeros((hist_T, n_var), dtype=np.float64)
+    x_filt = np.zeros((hist_T, n_var), dtype=np.float64)
     P_pred = np.zeros((hist_T, nz, nz), dtype=np.float64)
     P_filt = np.zeros((hist_T, nz, nz), dtype=np.float64)
     y_pred = np.zeros((hist_T, n_obs), dtype=np.float64)
@@ -316,6 +321,8 @@ def ukf_hot_loop(
     cdef double[:, ::1] x2_pred_mv = x2_pred
     cdef double[:, ::1] x1_filt_mv = x1_filt
     cdef double[:, ::1] x2_filt_mv = x2_filt
+    cdef double[:, ::1] x_pred_mv = x_pred
+    cdef double[:, ::1] x_filt_mv = x_filt
     cdef double[:, :, ::1] P_pred_mv = P_pred
     cdef double[:, :, ::1] P_filt_mv = P_filt
     cdef double[:, ::1] y_pred_mv = y_pred
@@ -364,6 +371,8 @@ def ukf_hot_loop(
     outp.x2_pred = &x2_pred_mv[0, 0] if hist_T > 0 else NULL
     outp.x1_filt = &x1_filt_mv[0, 0] if hist_T > 0 else NULL
     outp.x2_filt = &x2_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.x_pred = &x_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.x_filt = &x_filt_mv[0, 0] if hist_T > 0 else NULL
     outp.P_pred = &P_pred_mv[0, 0, 0] if hist_T > 0 else NULL
     outp.P_filt = &P_filt_mv[0, 0, 0] if hist_T > 0 else NULL
     outp.y_pred = &y_pred_mv[0, 0] if hist_T > 0 else NULL
@@ -392,6 +401,8 @@ def ukf_hot_loop(
             x2_pred,
             x1_filt,
             x2_filt,
+            x_pred,
+            x_filt,
             P_pred,
             P_filt,
             y_pred,

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -53,6 +53,66 @@ cdef extern from "kalman.h":
 
     int kf_hot_loop(const kf_inputs *inp, kf_outputs *outp) nogil
 
+    ctypedef void (*meas_fn)(
+        const double *x,
+        const double *params,
+        double *out,
+    ) noexcept nogil
+
+    ctypedef struct ukf_inputs:
+        meas_fn meas
+        double *hx
+        double *gx
+        double *bx
+        double *hxx
+        double *gxx
+        double *hss
+        double *gss
+        double *steady_state
+        double *params
+        double *Q
+        double *R
+        double *obs
+        double *z0
+        double *P0
+        int64_t T
+
+        int64_t n_state
+        int64_t n_ctrl
+        int64_t n_exog
+        int64_t n_obs
+        int64_t n_params
+
+        double alpha
+        double beta
+        double kappa
+
+        double jitter
+        int symmetrize
+        int store_history
+
+    ctypedef struct ukf_outputs:
+        double *x1_pred
+        double *x2_pred
+        double *x1_filt
+        double *x2_filt
+
+        double *P_pred
+        double *P_filt
+
+        double *y_pred
+        double *y_filt
+        double *innov
+        double *std_innov
+        double *S
+
+        double *loglik
+
+    int64_t c_ukf_hot_loop "ukf_hot_loop"(
+        const ukf_inputs *inp,
+        ukf_outputs *outp,
+    ) nogil
+
 
 def kalman_hot_loop(
     int64_t T,
@@ -140,7 +200,7 @@ def kalman_hot_loop(
     outp.eps_hat = &eps_hat_mv[0, 0] if shock_T > 0 else NULL
     outp.loglik = &loglik
 
-    cdef int status
+    cdef int64_t status
     with nogil:
         status = kf_hot_loop(&inp, &outp)
 
@@ -163,6 +223,182 @@ def kalman_hot_loop(
             std_innov,
             S,
             eps_hat,
+            loglik,
+        ),
+    )
+
+
+def ukf_hot_loop(
+    size_t meas_addr,
+    double[:, ::1] hx,
+    double[:, ::1] gx,
+    double[:, ::1] bx,
+    double[:, :, ::1] hxx,
+    double[:, :, ::1] gxx,
+    double[::1] hss,
+    double[::1] gss,
+    double[::1] steady_state,
+    double[::1] params,
+    double[:, ::1] Q,
+    double[:, ::1] R,
+    double[:, ::1] obs,
+    double[::1] z0,
+    double[:, ::1] P0,
+    double alpha,
+    double beta,
+    double kappa,
+    double jitter,
+    bint symmetrize=True,
+    bint store_history=True,
+):
+    """Run the native second-order UKF hot loop.
+
+    ``meas_addr`` is a real-valued measurement ``@cfunc`` address with signature
+    ``void(double* vars, double* params, double* out)``.
+    """
+    cdef int64_t n_state = hx.shape[0]
+    cdef int64_t n_ctrl = gx.shape[0]
+    cdef int64_t n_exog = bx.shape[1]
+    cdef int64_t n_obs = obs.shape[1]
+    cdef int64_t n_params = params.shape[0]
+    cdef int64_t T = obs.shape[0]
+    cdef int64_t nz = 2 * n_state
+    cdef int64_t n_var = n_state + n_ctrl
+
+    if meas_addr == 0:
+        raise ValueError("ukf_hot_loop requires a nonzero "
+                         "measurement function address.")
+    if n_state <= 0:
+        raise ValueError("hx must have at least one state.")
+    if n_obs <= 0:
+        raise ValueError("obs must have at least one observable column.")
+    if hx.shape[1] != n_state:
+        raise ValueError("hx must have shape (n_state, n_state).")
+    if bx.shape[0] != n_state:
+        raise ValueError("bx must have shape (n_state, n_exog).")
+    if gx.shape[1] != n_state:
+        raise ValueError("gx must have shape (n_ctrl, n_state).")
+    if hxx.shape[0] != n_state or hxx.shape[1] != n_state or hxx.shape[2] != n_state:
+        raise ValueError("hxx must have shape (n_state, n_state, n_state).")
+    if gxx.shape[0] != n_ctrl or gxx.shape[1] != n_state or gxx.shape[2] != n_state:
+        raise ValueError("gxx must have shape (n_ctrl, n_state, n_state).")
+    if hss.shape[0] != n_state:
+        raise ValueError("hss must have shape (n_state,).")
+    if gss.shape[0] != n_ctrl:
+        raise ValueError("gss must have shape (n_ctrl,).")
+    if steady_state.shape[0] != n_var:
+        raise ValueError("steady_state must have shape (n_state + n_ctrl,).")
+    if Q.shape[0] != n_exog or Q.shape[1] != n_exog:
+        raise ValueError("Q must have shape (n_exog, n_exog).")
+    if R.shape[0] != n_obs or R.shape[1] != n_obs:
+        raise ValueError("R must have shape (n_obs, n_obs).")
+    if z0.shape[0] != nz:
+        raise ValueError("z0 must have shape (2 * n_state,).")
+    if P0.shape[0] != nz or P0.shape[1] != nz:
+        raise ValueError("P0 must have shape (2 * n_state, 2 * n_state).")
+
+    cdef int64_t hist_T = T if store_history else 0
+
+    x1_pred = np.zeros((hist_T, n_state), dtype=np.float64)
+    x2_pred = np.zeros((hist_T, n_state), dtype=np.float64)
+    x1_filt = np.zeros((hist_T, n_state), dtype=np.float64)
+    x2_filt = np.zeros((hist_T, n_state), dtype=np.float64)
+    P_pred = np.zeros((hist_T, nz, nz), dtype=np.float64)
+    P_filt = np.zeros((hist_T, nz, nz), dtype=np.float64)
+    y_pred = np.zeros((hist_T, n_obs), dtype=np.float64)
+    y_filt = np.zeros((hist_T, n_obs), dtype=np.float64)
+    innov = np.zeros((hist_T, n_obs), dtype=np.float64)
+    std_innov = np.zeros((hist_T, n_obs), dtype=np.float64)
+    S = np.zeros((hist_T, n_obs, n_obs), dtype=np.float64)
+    cdef double loglik = 0.0
+
+    cdef double[:, ::1] x1_pred_mv = x1_pred
+    cdef double[:, ::1] x2_pred_mv = x2_pred
+    cdef double[:, ::1] x1_filt_mv = x1_filt
+    cdef double[:, ::1] x2_filt_mv = x2_filt
+    cdef double[:, :, ::1] P_pred_mv = P_pred
+    cdef double[:, :, ::1] P_filt_mv = P_filt
+    cdef double[:, ::1] y_pred_mv = y_pred
+    cdef double[:, ::1] y_filt_mv = y_filt
+    cdef double[:, ::1] innov_mv = innov
+    cdef double[:, ::1] std_innov_mv = std_innov
+    cdef double[:, :, ::1] S_mv = S
+
+    cdef ukf_inputs inp
+    inp.meas = <meas_fn><void*>meas_addr
+    inp.hx = &hx[0, 0]
+    inp.bx = &bx[0, 0] if n_exog > 0 else NULL
+    inp.hxx = &hxx[0, 0, 0]
+    inp.hss = &hss[0]
+    inp.steady_state = &steady_state[0]
+    inp.params = &params[0] if n_params > 0 else NULL
+    inp.Q = &Q[0, 0] if n_exog > 0 else NULL
+    inp.R = &R[0, 0]
+    inp.obs = &obs[0, 0] if T > 0 else NULL
+    inp.z0 = &z0[0]
+    inp.P0 = &P0[0, 0]
+    inp.T = T
+    inp.n_state = n_state
+    inp.n_ctrl = n_ctrl
+    inp.n_exog = n_exog
+    inp.n_obs = n_obs
+    inp.n_params = n_params
+    inp.alpha = alpha
+    inp.beta = beta
+    inp.kappa = kappa
+    inp.jitter = jitter
+    inp.symmetrize = symmetrize
+    inp.store_history = store_history
+
+    if n_ctrl > 0:
+        inp.gx = &gx[0, 0]
+        inp.gxx = &gxx[0, 0, 0]
+        inp.gss = &gss[0]
+    else:
+        inp.gx = NULL
+        inp.gxx = NULL
+        inp.gss = NULL
+
+    cdef ukf_outputs outp
+    outp.x1_pred = &x1_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.x2_pred = &x2_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.x1_filt = &x1_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.x2_filt = &x2_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.P_pred = &P_pred_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.P_filt = &P_filt_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.y_pred = &y_pred_mv[0, 0] if hist_T > 0 else NULL
+    outp.y_filt = &y_filt_mv[0, 0] if hist_T > 0 else NULL
+    outp.innov = &innov_mv[0, 0] if hist_T > 0 else NULL
+    outp.std_innov = &std_innov_mv[0, 0] if hist_T > 0 else NULL
+    outp.S = &S_mv[0, 0, 0] if hist_T > 0 else NULL
+    outp.loglik = &loglik
+
+    cdef int64_t status
+    with nogil:
+        status = c_ukf_hot_loop(&inp, &outp)
+
+    if status == KF_ERR_MATRIX_CONDITION:
+        raise LinAlgError("UKF covariance is not positive definite.")
+    if status == KF_ERR_ALLOC:
+        raise MemoryError("ukf_hot_loop: scratch allocation failed.")
+    if status != KF_OK:
+        raise ValueError(f"ukf_hot_loop failed with status {status}.")
+
+    return (
+        KF_OK,
+        (0.0, 0.0, 0.0),
+        (
+            x1_pred,
+            x2_pred,
+            x1_filt,
+            x2_filt,
+            P_pred,
+            P_filt,
+            y_pred,
+            y_filt,
+            innov,
+            std_innov,
+            S,
             loglik,
         ),
     )

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -431,11 +431,42 @@ static void ukf_cov_update(const f64 *SDSGE_RESTRICT P_pred,
   }
 }
 
-static void ukf_store_state_blocks(const f64 *SDSGE_RESTRICT z,
-                                   f64 *SDSGE_RESTRICT x1,
-                                   f64 *SDSGE_RESTRICT x2, i64 t, i64 ns) {
-  memcpy(x1 + t * ns, z, (size_t)ns * sizeof(f64));
-  memcpy(x2 + t * ns, z + ns, (size_t)ns * sizeof(f64));
+static void ukf_store_history(const ukf_inputs *in,
+                              const f64 *SDSGE_RESTRICT z,
+                              const f64 *SDSGE_RESTRICT P,
+                              f64 *SDSGE_RESTRICT x1,
+                              f64 *SDSGE_RESTRICT x2,
+                              f64 *SDSGE_RESTRICT x, i64 t) {
+  const i64 ns = in->n_state;
+  const i64 nc = in->n_ctrl;
+  const i64 nz = 2 * ns;
+  const i64 nv = ns + nc;
+  const f64 *z1 = z;
+  const f64 *z2 = z + ns;
+  f64 *x1_row = x1 + t * ns;
+  f64 *x2_row = x2 + t * ns;
+  f64 *x_row = x + t * nv;
+
+  memcpy(x1_row, z1, (size_t)ns * sizeof(f64));
+  memcpy(x2_row, z2, (size_t)ns * sizeof(f64));
+
+  for (i64 i = 0; i < ns; ++i)
+    x_row[i] = in->steady_state[i] + z1[i] + z2[i];
+
+  for (i64 i = 0; i < nc; ++i) {
+    f64 s = 0.5 * in->gss[i];
+    const f64 *gx_i = in->gx + i * ns;
+    for (i64 j = 0; j < ns; ++j)
+      s += gx_i[j] * (z1[j] + z2[j]);
+    const f64 *gxx_i = in->gxx + i * ns * ns;
+    for (i64 j = 0; j < ns; ++j) {
+      for (i64 k = 0; k < ns; ++k) {
+        const f64 m2 = P[j * nz + k] + z1[j] * z1[k];
+        s += 0.5 * gxx_i[j * ns + k] * m2;
+      }
+    }
+    x_row[ns + i] = in->steady_state[ns + i] + s;
+  }
 }
 
 i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
@@ -571,15 +602,16 @@ i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
                       sdsge_dot(innov, S_inv_v, no));
 
     if (in->store_history) {
-      ukf_store_state_blocks(z_pred, out->x1_pred, out->x2_pred, t, ns);
-      ukf_store_state_blocks(z_filt, out->x1_filt, out->x2_filt, t, ns);
+      ukf_store_history(in, z_pred, P_pred, out->x1_pred, out->x2_pred,
+                        out->x_pred, t);
+      ukf_store_history(in, z_filt, P_filt, out->x1_filt, out->x2_filt,
+                        out->x_filt, t);
       memcpy(out->P_pred + t * nz * nz, P_pred,
              (size_t)(nz * nz) * sizeof(f64));
       memcpy(out->P_filt + t * nz * nz, P_filt,
              (size_t)(nz * nz) * sizeof(f64));
       memcpy(out->y_pred + t * no, y_pred, (size_t)no * sizeof(f64));
-      ukf_project_vars(in, z_filt, vars_buf);
-      in->meas(vars_buf, in->params, out->y_filt + t * no);
+      in->meas(out->x_filt + t * nv, in->params, out->y_filt + t * no);
       memcpy(out->innov + t * no, innov, (size_t)no * sizeof(f64));
       memcpy(out->std_innov + t * no, std_innov, (size_t)no * sizeof(f64));
       memcpy(out->S + t * no * no, S, (size_t)(no * no) * sizeof(f64));

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -4,241 +4,596 @@
 #include <string.h>
 
 void kf_row_minus_vec(const f64 *SDSGE_RESTRICT A, i64 row,
-                      const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT out, i64 m) {
-    const f64 *Arow = A + row * m;
-    for (i64 j = 0; j < m; ++j)
-        out[j] = Arow[j] - x[j];
+                      const f64 *SDSGE_RESTRICT x, f64 *SDSGE_RESTRICT out,
+                      i64 m) {
+  const f64 *Arow = A + row * m;
+  for (i64 j = 0; j < m; ++j)
+    out[j] = Arow[j] - x[j];
 }
 
 void kf_chol_solve_row(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT B,
-                       i64 row, f64 *SDSGE_RESTRICT fbuf, f64 *SDSGE_RESTRICT bbuf,
-                       f64 *SDSGE_RESTRICT out, i64 n) {
-    const f64 *Brow = B + row * n;
-    for (i64 i = 0; i < n; ++i) {
-        f64 s = 0.0;
-        for (i64 j = 0; j < i; ++j)
-            s += L[i * n + j] * fbuf[j];
-        fbuf[i] = (Brow[i] - s) / L[i * n + i];
-    }
-    for (i64 i = n - 1; i >= 0; --i) {
-        f64 s = 0.0;
-        for (i64 j = i + 1; j < n; ++j)
-            s += L[j * n + i] * bbuf[j];
-        bbuf[i] = (fbuf[i] - s) / L[i * n + i];
-    }
-    f64 *outrow = out + row * n;
-    for (i64 i = 0; i < n; ++i)
-        outrow[i] = bbuf[i];
+                       i64 row, f64 *SDSGE_RESTRICT fbuf,
+                       f64 *SDSGE_RESTRICT bbuf, f64 *SDSGE_RESTRICT out,
+                       i64 n) {
+  const f64 *Brow = B + row * n;
+  for (i64 i = 0; i < n; ++i) {
+    f64 s = 0.0;
+    for (i64 j = 0; j < i; ++j)
+      s += L[i * n + j] * fbuf[j];
+    fbuf[i] = (Brow[i] - s) / L[i * n + i];
+  }
+  for (i64 i = n - 1; i >= 0; --i) {
+    f64 s = 0.0;
+    for (i64 j = i + 1; j < n; ++j)
+      s += L[j * n + i] * bbuf[j];
+    bbuf[i] = (fbuf[i] - s) / L[i * n + i];
+  }
+  f64 *outrow = out + row * n;
+  for (i64 i = 0; i < n; ++i)
+    outrow[i] = bbuf[i];
 }
 
-void kf_predict_cov(const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT P_prev,
+void kf_predict_cov(const f64 *SDSGE_RESTRICT A,
+                    const f64 *SDSGE_RESTRICT P_prev,
                     const f64 *SDSGE_RESTRICT BQBT, f64 *SDSGE_RESTRICT temp_nn,
                     f64 *SDSGE_RESTRICT out, i64 n) {
-    sdsge_matmul(A, P_prev, temp_nn, n, n, n);
-    sdsge_matmul_abt_plus_c(temp_nn, A, BQBT, out, n, n, n);
+  sdsge_matmul(A, P_prev, temp_nn, n, n, n);
+  sdsge_matmul_abt_plus_c(temp_nn, A, BQBT, out, n, n, n);
 }
 
-void kf_measurement_cov(const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT P_pred,
-                        const f64 *SDSGE_RESTRICT R, f64 *SDSGE_RESTRICT temp_mn,
-                        f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    sdsge_matmul(C, P_pred, temp_mn, m, n, n);
-    sdsge_matmul_abt_plus_c(temp_mn, C, R, out, m, n, m);
+void kf_measurement_cov(const f64 *SDSGE_RESTRICT C,
+                        const f64 *SDSGE_RESTRICT P_pred,
+                        const f64 *SDSGE_RESTRICT R,
+                        f64 *SDSGE_RESTRICT temp_mn, f64 *SDSGE_RESTRICT out,
+                        i64 n, i64 m) {
+  sdsge_matmul(C, P_pred, temp_mn, m, n, n);
+  sdsge_matmul_abt_plus_c(temp_mn, C, R, out, m, n, m);
 }
 
 void kf_pc_t(const f64 *SDSGE_RESTRICT P_pred, const f64 *SDSGE_RESTRICT C,
              f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < m; ++j) {
-            f64 s = 0.0;
-            for (i64 k = 0; k < n; ++k)
-                s += P_pred[i * n + k] * C[j * n + k];
-            out[i * m + j] = s;
-        }
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < m; ++j) {
+      f64 s = 0.0;
+      for (i64 k = 0; k < n; ++k)
+        s += P_pred[i * n + k] * C[j * n + k];
+      out[i * m + j] = s;
     }
+  }
 }
 
-void kf_gain_from_pc_t(const f64 *SDSGE_RESTRICT L, const f64 *SDSGE_RESTRICT PCt,
-                       f64 *SDSGE_RESTRICT fbuf, f64 *SDSGE_RESTRICT bbuf,
-                       f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    for (i64 row = 0; row < n; ++row)
-        kf_chol_solve_row(L, PCt, row, fbuf, bbuf, out, m);
+void kf_gain_from_pc_t(const f64 *SDSGE_RESTRICT L,
+                       const f64 *SDSGE_RESTRICT PCt, f64 *SDSGE_RESTRICT fbuf,
+                       f64 *SDSGE_RESTRICT bbuf, f64 *SDSGE_RESTRICT out, i64 n,
+                       i64 m) {
+  for (i64 row = 0; row < n; ++row)
+    kf_chol_solve_row(L, PCt, row, fbuf, bbuf, out, m);
 }
 
-void kf_state_update(const f64 *SDSGE_RESTRICT x_pred, const f64 *SDSGE_RESTRICT K,
-                     const f64 *SDSGE_RESTRICT v, f64 *SDSGE_RESTRICT out,
-                     i64 n, i64 m) {
-    for (i64 i = 0; i < n; ++i) {
-        f64 s = x_pred[i];
-        for (i64 j = 0; j < m; ++j)
-            s += K[i * m + j] * v[j];
-        out[i] = s;
-    }
+void kf_state_update(const f64 *SDSGE_RESTRICT x_pred,
+                     const f64 *SDSGE_RESTRICT K, const f64 *SDSGE_RESTRICT v,
+                     f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
+  for (i64 i = 0; i < n; ++i) {
+    f64 s = x_pred[i];
+    for (i64 j = 0; j < m; ++j)
+      s += K[i * m + j] * v[j];
+    out[i] = s;
+  }
 }
 
-void kf_identity_minus(const f64 *SDSGE_RESTRICT A, f64 *SDSGE_RESTRICT out, i64 n) {
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < n; ++j)
-            out[i * n + j] = -A[i * n + j];
-        out[i * n + i] += 1.0;
-    }
+void kf_identity_minus(const f64 *SDSGE_RESTRICT A, f64 *SDSGE_RESTRICT out,
+                       i64 n) {
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < n; ++j)
+      out[i * n + j] = -A[i * n + j];
+    out[i * n + i] += 1.0;
+  }
 }
 
 void kf_joseph_cov(const f64 *SDSGE_RESTRICT K, const f64 *SDSGE_RESTRICT C,
-                   const f64 *SDSGE_RESTRICT P_pred, const f64 *SDSGE_RESTRICT R,
-                   f64 *SDSGE_RESTRICT KC, f64 *SDSGE_RESTRICT I_minus_KC,
-                   f64 *SDSGE_RESTRICT temp_nn, f64 *SDSGE_RESTRICT temp_nm,
-                   f64 *SDSGE_RESTRICT out, i64 n, i64 m) {
-    sdsge_matmul(K, C, KC, n, m, n);
-    kf_identity_minus(KC, I_minus_KC, n);
-    sdsge_matmul(I_minus_KC, P_pred, temp_nn, n, n, n);
-    sdsge_matmul_abt(temp_nn, I_minus_KC, out, n, n, n);
-    sdsge_matmul(K, R, temp_nm, n, m, m);
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < n; ++j) {
-            f64 s = 0.0;
-            for (i64 k = 0; k < m; ++k)
-                s += temp_nm[i * m + k] * K[j * m + k];
-            out[i * n + j] += s;
-        }
+                   const f64 *SDSGE_RESTRICT P_pred,
+                   const f64 *SDSGE_RESTRICT R, f64 *SDSGE_RESTRICT KC,
+                   f64 *SDSGE_RESTRICT I_minus_KC, f64 *SDSGE_RESTRICT temp_nn,
+                   f64 *SDSGE_RESTRICT temp_nm, f64 *SDSGE_RESTRICT out, i64 n,
+                   i64 m) {
+  sdsge_matmul(K, C, KC, n, m, n);
+  kf_identity_minus(KC, I_minus_KC, n);
+  sdsge_matmul(I_minus_KC, P_pred, temp_nn, n, n, n);
+  sdsge_matmul_abt(temp_nn, I_minus_KC, out, n, n, n);
+  sdsge_matmul(K, R, temp_nm, n, m, m);
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < n; ++j) {
+      f64 s = 0.0;
+      for (i64 k = 0; k < m; ++k)
+        s += temp_nm[i * m + k] * K[j * m + k];
+      out[i * n + j] += s;
     }
+  }
 }
 
 void kf_build_bqbt(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT Q,
-                   f64 *SDSGE_RESTRICT temp_nk, f64 *SDSGE_RESTRICT out,
-                   i64 n, i64 k) {
-    sdsge_matmul(B, Q, temp_nk, n, k, k);
-    for (i64 i = 0; i < n; ++i) {
-        for (i64 j = 0; j < n; ++j) {
-            f64 s = 0.0;
-            for (i64 l = 0; l < k; ++l)
-                s += temp_nk[i * k + l] * B[j * k + l];
-            out[i * n + j] = s;
-        }
+                   f64 *SDSGE_RESTRICT temp_nk, f64 *SDSGE_RESTRICT out, i64 n,
+                   i64 k) {
+  sdsge_matmul(B, Q, temp_nk, n, k, k);
+  for (i64 i = 0; i < n; ++i) {
+    for (i64 j = 0; j < n; ++j) {
+      f64 s = 0.0;
+      for (i64 l = 0; l < k; ++l)
+        s += temp_nk[i * k + l] * B[j * k + l];
+      out[i * n + j] = s;
     }
-    sdsge_sym_inplace(out, n);
+  }
+  sdsge_sym_inplace(out, n);
 }
 
-void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B, const f64 *SDSGE_RESTRICT C,
-                               const f64 *SDSGE_RESTRICT Q, f64 *SDSGE_RESTRICT temp_km,
+void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B,
+                               const f64 *SDSGE_RESTRICT C,
+                               const f64 *SDSGE_RESTRICT Q,
+                               f64 *SDSGE_RESTRICT temp_km,
                                f64 *SDSGE_RESTRICT out, i64 n, i64 k, i64 m) {
-    for (i64 i = 0; i < k; ++i) {
-        for (i64 j = 0; j < m; ++j) {
-            f64 s = 0.0;
-            for (i64 l = 0; l < n; ++l)
-                s += B[l * k + i] * C[j * n + l];
-            temp_km[i * m + j] = s;
-        }
+  for (i64 i = 0; i < k; ++i) {
+    for (i64 j = 0; j < m; ++j) {
+      f64 s = 0.0;
+      for (i64 l = 0; l < n; ++l)
+        s += B[l * k + i] * C[j * n + l];
+      temp_km[i * m + j] = s;
     }
-    sdsge_matmul(Q, temp_km, out, k, k, m);
+  }
+  sdsge_matmul(Q, temp_km, out, k, k, m);
 }
 
 int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
-    const i64 n = in->n, m = in->m, k = in->k, T = in->T;
+  const i64 n = in->n, m = in->m, k = in->k, T = in->T;
 
-    /* One scratch arena carved into every per-step buffer (allocated once). */
-    const i64 total = 2 * n + 7 * m   /* vectors + triangular-solve scratch */
-                      + 6 * n * n     /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
-                      + 2 * m * m     /* S_buf, L */
-                      + 3 * n * m     /* PCt, K, temp_nm */
-                      + m * n         /* temp_mn */
-                      + n * k         /* temp_nk */
-                      + 2 * k * m;    /* M, temp_km */
-    f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-    if (arena == NULL)
-        return KF_ERR_ALLOC;
+  /* One scratch arena carved into every per-step buffer (allocated once). */
+  const i64 total =
+      2 * n + 7 * m /* vectors + triangular-solve scratch */
+      + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+      + 2 * m * m   /* S_buf, L */
+      + 3 * n * m   /* PCt, K, temp_nm */
+      + m * n       /* temp_mn */
+      + n * k       /* temp_nk */
+      + 2 * k * m;  /* M, temp_km */
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return KF_ERR_ALLOC;
 
-    f64 *p = arena;
-    f64 *x_pred_buf = p; p += n;
-    f64 *x_filt_buf = p; p += n;
-    f64 *y_pred_buf = p; p += m;
-    f64 *y_filt_buf = p; p += m;
-    f64 *v_buf = p; p += m;
-    f64 *u_buf = p; p += m;
-    f64 *S_inv_v = p; p += m;
-    f64 *solve_f = p; p += m;
-    f64 *solve_b = p; p += m;
-    f64 *P_pred_buf = p; p += n * n;
-    f64 *P_filt_buf = p; p += n * n;
-    f64 *KC = p; p += n * n;
-    f64 *I_minus_KC = p; p += n * n;
-    f64 *temp_nn = p; p += n * n;
-    f64 *BQBT = p; p += n * n;
-    f64 *S_buf = p; p += m * m;
-    f64 *L = p; p += m * m;
-    f64 *PCt = p; p += n * m;
-    f64 *K = p; p += n * m;
-    f64 *temp_nm = p; p += n * m;
-    f64 *temp_mn = p; p += m * n;
-    f64 *temp_nk = p; p += n * k;
-    f64 *M = p; p += k * m;
-    f64 *temp_km = p; p += k * m;
+  f64 *p = arena;
+  f64 *x_pred_buf = p;
+  p += n;
+  f64 *x_filt_buf = p;
+  p += n;
+  f64 *y_pred_buf = p;
+  p += m;
+  f64 *y_filt_buf = p;
+  p += m;
+  f64 *v_buf = p;
+  p += m;
+  f64 *u_buf = p;
+  p += m;
+  f64 *S_inv_v = p;
+  p += m;
+  f64 *solve_f = p;
+  p += m;
+  f64 *solve_b = p;
+  p += m;
+  f64 *P_pred_buf = p;
+  p += n * n;
+  f64 *P_filt_buf = p;
+  p += n * n;
+  f64 *KC = p;
+  p += n * n;
+  f64 *I_minus_KC = p;
+  p += n * n;
+  f64 *temp_nn = p;
+  p += n * n;
+  f64 *BQBT = p;
+  p += n * n;
+  f64 *S_buf = p;
+  p += m * m;
+  f64 *L = p;
+  p += m * m;
+  f64 *PCt = p;
+  p += n * m;
+  f64 *K = p;
+  p += n * m;
+  f64 *temp_nm = p;
+  p += n * m;
+  f64 *temp_mn = p;
+  p += m * n;
+  f64 *temp_nk = p;
+  p += n * k;
+  f64 *M = p;
+  p += k * m;
+  f64 *temp_km = p;
+  p += k * m;
 
-    kf_build_bqbt(in->B, in->Q, temp_nk, BQBT, n, k);
-    if (in->return_shocks && in->store_history)
-        kf_build_shock_projection(in->B, in->C, in->Q, temp_km, M, n, k, m);
+  kf_build_bqbt(in->B, in->Q, temp_nk, BQBT, n, k);
+  if (in->return_shocks && in->store_history)
+    kf_build_shock_projection(in->B, in->C, in->Q, temp_km, M, n, k, m);
 
-    const f64 const_term = (f64)m * log(TWO_PI); /* m * log(2*pi) */
-    f64 loglik = 0.0;
+  const f64 const_term = (f64)m * log(TWO_PI); /* m * log(2*pi) */
+  f64 loglik = 0.0;
 
-    /* x_prev/P_prev start at the inputs, then alias the filtered scratch; each
-     * is read (into x_pred_buf / P_pred_buf) before being overwritten. */
-    const f64 *x_prev = in->x0;
-    const f64 *P_prev = in->P0;
-    int status = KF_OK;
+  /* x_prev/P_prev start at the inputs, then alias the filtered scratch; each
+   * is read (into x_pred_buf / P_pred_buf) before being overwritten. */
+  const f64 *x_prev = in->x0;
+  const f64 *P_prev = in->P0;
+  int status = KF_OK;
 
-    for (i64 t = 0; t < T; ++t) {
-        sdsge_matvec(in->A, x_prev, x_pred_buf, n, n);
-        kf_predict_cov(in->A, P_prev, BQBT, temp_nn, P_pred_buf, n);
-        if (in->symmetrize)
-            sdsge_sym_inplace(P_pred_buf, n);
+  for (i64 t = 0; t < T; ++t) {
+    sdsge_matvec(in->A, x_prev, x_pred_buf, n, n);
+    kf_predict_cov(in->A, P_prev, BQBT, temp_nn, P_pred_buf, n);
+    if (in->symmetrize)
+      sdsge_sym_inplace(P_pred_buf, n);
 
-        sdsge_matvec_plus_vec(in->C, x_pred_buf, in->d, y_pred_buf, m, n);
-        kf_row_minus_vec(in->y, t, y_pred_buf, v_buf, m);
-        kf_measurement_cov(in->C, P_pred_buf, in->R, temp_mn, S_buf, n, m);
-        if (in->symmetrize)
-            sdsge_sym_inplace(S_buf, m);
+    sdsge_matvec_plus_vec(in->C, x_pred_buf, in->d, y_pred_buf, m, n);
+    kf_row_minus_vec(in->y, t, y_pred_buf, v_buf, m);
+    kf_measurement_cov(in->C, P_pred_buf, in->R, temp_mn, S_buf, n, m);
+    if (in->symmetrize)
+      sdsge_sym_inplace(S_buf, m);
 
-        if (sdsge_chol(S_buf, in->jitter, L, m) != SDSGE_OK) {
-            status = KF_ERR_MATRIX_CONDITION;
-            break;
-        }
-
-        sdsge_forward_subst(L, v_buf, u_buf, m);
-        sdsge_backward_subst_chol_t(L, u_buf, S_inv_v, m);
-
-        kf_pc_t(P_pred_buf, in->C, PCt, n, m);
-        kf_gain_from_pc_t(L, PCt, solve_f, solve_b, K, n, m);
-
-        kf_state_update(x_pred_buf, K, v_buf, x_filt_buf, n, m);
-        kf_joseph_cov(K, in->C, P_pred_buf, in->R, KC, I_minus_KC, temp_nn,
-                      temp_nm, P_filt_buf, n, m);
-        if (in->symmetrize)
-            sdsge_sym_inplace(P_filt_buf, n);
-
-        loglik += -0.5 * (const_term + sdsge_logdet_from_chol(L, m)
-                          + sdsge_dot(v_buf, S_inv_v, m));
-
-        if (in->return_shocks && in->store_history)
-            sdsge_matvec(M, S_inv_v, out->eps_hat + t * k, k, m);
-
-        if (in->store_history) {
-            sdsge_matvec_plus_vec(in->C, x_filt_buf, in->d, y_filt_buf, m, n);
-            memcpy(out->x_pred + t * n, x_pred_buf, (size_t)n * sizeof(f64));
-            memcpy(out->x_filt + t * n, x_filt_buf, (size_t)n * sizeof(f64));
-            memcpy(out->P_pred + t * n * n, P_pred_buf, (size_t)(n * n) * sizeof(f64));
-            memcpy(out->P_filt + t * n * n, P_filt_buf, (size_t)(n * n) * sizeof(f64));
-            memcpy(out->y_pred + t * m, y_pred_buf, (size_t)m * sizeof(f64));
-            memcpy(out->y_filt + t * m, y_filt_buf, (size_t)m * sizeof(f64));
-            memcpy(out->innov + t * m, v_buf, (size_t)m * sizeof(f64));
-            memcpy(out->std_innov + t * m, u_buf, (size_t)m * sizeof(f64));
-            memcpy(out->S + t * m * m, S_buf, (size_t)(m * m) * sizeof(f64));
-        }
-
-        x_prev = x_filt_buf;
-        P_prev = P_filt_buf;
+    if (sdsge_chol(S_buf, in->jitter, L, m) != SDSGE_OK) {
+      status = KF_ERR_MATRIX_CONDITION;
+      break;
     }
 
-    *out->loglik = loglik;
-    free(arena);
-    return status;
+    sdsge_forward_subst(L, v_buf, u_buf, m);
+    sdsge_backward_subst_chol_t(L, u_buf, S_inv_v, m);
+
+    kf_pc_t(P_pred_buf, in->C, PCt, n, m);
+    kf_gain_from_pc_t(L, PCt, solve_f, solve_b, K, n, m);
+
+    kf_state_update(x_pred_buf, K, v_buf, x_filt_buf, n, m);
+    kf_joseph_cov(K, in->C, P_pred_buf, in->R, KC, I_minus_KC, temp_nn, temp_nm,
+                  P_filt_buf, n, m);
+    if (in->symmetrize)
+      sdsge_sym_inplace(P_filt_buf, n);
+
+    loglik += -0.5 * (const_term + sdsge_logdet_from_chol(L, m) +
+                      sdsge_dot(v_buf, S_inv_v, m));
+
+    if (in->return_shocks && in->store_history)
+      sdsge_matvec(M, S_inv_v, out->eps_hat + t * k, k, m);
+
+    if (in->store_history) {
+      sdsge_matvec_plus_vec(in->C, x_filt_buf, in->d, y_filt_buf, m, n);
+      memcpy(out->x_pred + t * n, x_pred_buf, (size_t)n * sizeof(f64));
+      memcpy(out->x_filt + t * n, x_filt_buf, (size_t)n * sizeof(f64));
+      memcpy(out->P_pred + t * n * n, P_pred_buf,
+             (size_t)(n * n) * sizeof(f64));
+      memcpy(out->P_filt + t * n * n, P_filt_buf,
+             (size_t)(n * n) * sizeof(f64));
+      memcpy(out->y_pred + t * m, y_pred_buf, (size_t)m * sizeof(f64));
+      memcpy(out->y_filt + t * m, y_filt_buf, (size_t)m * sizeof(f64));
+      memcpy(out->innov + t * m, v_buf, (size_t)m * sizeof(f64));
+      memcpy(out->std_innov + t * m, u_buf, (size_t)m * sizeof(f64));
+      memcpy(out->S + t * m * m, S_buf, (size_t)(m * m) * sizeof(f64));
+    }
+
+    x_prev = x_filt_buf;
+    P_prev = P_filt_buf;
+  }
+
+  *out->loglik = loglik;
+  free(arena);
+  return status;
+}
+
+static void ukf_build_sigma_points(const f64 *SDSGE_RESTRICT mean,
+                                   const f64 *SDSGE_RESTRICT chol,
+                                   f64 gamma, f64 *SDSGE_RESTRICT sigma,
+                                   i64 n) {
+  memcpy(sigma, mean, (size_t)n * sizeof(f64));
+  for (i64 col = 0; col < n; ++col) {
+    f64 *plus = sigma + (1 + col) * n;
+    f64 *minus = sigma + (1 + n + col) * n;
+    for (i64 row = 0; row < n; ++row) {
+      f64 delta = gamma * chol[row * n + col];
+      plus[row] = mean[row] + delta;
+      minus[row] = mean[row] - delta;
+    }
+  }
+}
+
+static void ukf_weighted_mean(const f64 *SDSGE_RESTRICT sigma, f64 w0, f64 wi,
+                              i64 n_sig, i64 n, f64 *SDSGE_RESTRICT out) {
+  for (i64 j = 0; j < n; ++j)
+    out[j] = w0 * sigma[j];
+  for (i64 r = 1; r < n_sig; ++r) {
+    const f64 *row = sigma + r * n;
+    for (i64 j = 0; j < n; ++j)
+      out[j] += wi * row[j];
+  }
+}
+
+static void ukf_weighted_cov(const f64 *SDSGE_RESTRICT sigma,
+                             const f64 *SDSGE_RESTRICT mean, f64 w0, f64 wi,
+                             i64 n_sig, i64 n, f64 *SDSGE_RESTRICT out) {
+  sdsge_zero_mat(out, n, n);
+  for (i64 r = 0; r < n_sig; ++r) {
+    const f64 *row = sigma + r * n;
+    const f64 w = (r == 0) ? w0 : wi;
+    for (i64 i = 0; i < n; ++i) {
+      const f64 di = row[i] - mean[i];
+      for (i64 j = 0; j < n; ++j)
+        out[i * n + j] += w * di * (row[j] - mean[j]);
+    }
+  }
+}
+
+static void ukf_pruned_transition(const ukf_inputs *in,
+                                  const f64 *SDSGE_RESTRICT z,
+                                  f64 *SDSGE_RESTRICT out) {
+  const i64 ns = in->n_state;
+  const f64 *x1 = z;
+  const f64 *x2 = z + ns;
+  f64 *x1_next = out;
+  f64 *x2_next = out + ns;
+
+  for (i64 i = 0; i < ns; ++i) {
+    f64 s1 = 0.0;
+    f64 s2 = 0.5 * in->hss[i];
+    for (i64 j = 0; j < ns; ++j) {
+      const f64 hxij = in->hx[i * ns + j];
+      s1 += hxij * x1[j];
+      s2 += hxij * x2[j];
+    }
+    const f64 *hxx_i = in->hxx + i * ns * ns;
+    for (i64 j = 0; j < ns; ++j)
+      for (i64 k = 0; k < ns; ++k)
+        s2 += 0.5 * hxx_i[j * ns + k] * x1[j] * x1[k];
+    x1_next[i] = s1;
+    x2_next[i] = s2;
+  }
+}
+
+static void ukf_project_vars(const ukf_inputs *in,
+                             const f64 *SDSGE_RESTRICT z,
+                             f64 *SDSGE_RESTRICT vars) {
+  const i64 ns = in->n_state;
+  const i64 nc = in->n_ctrl;
+  const f64 *x1 = z;
+  const f64 *x2 = z + ns;
+
+  for (i64 i = 0; i < ns; ++i)
+    vars[i] = in->steady_state[i] + x1[i] + x2[i];
+
+  for (i64 i = 0; i < nc; ++i) {
+    f64 s = 0.5 * in->gss[i];
+    const f64 *gx_i = in->gx + i * ns;
+    for (i64 j = 0; j < ns; ++j)
+      s += gx_i[j] * (x1[j] + x2[j]);
+    const f64 *gxx_i = in->gxx + i * ns * ns;
+    for (i64 j = 0; j < ns; ++j)
+      for (i64 k = 0; k < ns; ++k)
+        s += 0.5 * gxx_i[j * ns + k] * x1[j] * x1[k];
+    vars[ns + i] = in->steady_state[ns + i] + s;
+  }
+}
+
+static void ukf_eval_measurement_sigma(const ukf_inputs *in,
+                                       const f64 *SDSGE_RESTRICT sigma_z,
+                                       i64 n_sig,
+                                       f64 *SDSGE_RESTRICT vars_buf,
+                                       f64 *SDSGE_RESTRICT sigma_y) {
+  const i64 nz = 2 * in->n_state;
+  const i64 no = in->n_obs;
+  for (i64 r = 0; r < n_sig; ++r) {
+    ukf_project_vars(in, sigma_z + r * nz, vars_buf);
+    in->meas(vars_buf, in->params, sigma_y + r * no);
+  }
+}
+
+static void ukf_weighted_meas_cov_cross(
+    const f64 *SDSGE_RESTRICT sigma_z, const f64 *SDSGE_RESTRICT z_mean,
+    const f64 *SDSGE_RESTRICT sigma_y, const f64 *SDSGE_RESTRICT y_mean, f64 w0,
+    f64 wi, i64 n_sig, i64 nz, i64 no, f64 *SDSGE_RESTRICT S,
+    f64 *SDSGE_RESTRICT Pzy) {
+  sdsge_zero_mat(S, no, no);
+  sdsge_zero_mat(Pzy, nz, no);
+
+  for (i64 r = 0; r < n_sig; ++r) {
+    const f64 *zr = sigma_z + r * nz;
+    const f64 *yr = sigma_y + r * no;
+    const f64 w = (r == 0) ? w0 : wi;
+    for (i64 i = 0; i < no; ++i) {
+      const f64 dyi = yr[i] - y_mean[i];
+      for (i64 j = 0; j < no; ++j)
+        S[i * no + j] += w * dyi * (yr[j] - y_mean[j]);
+    }
+    for (i64 i = 0; i < nz; ++i) {
+      const f64 dzi = zr[i] - z_mean[i];
+      for (i64 j = 0; j < no; ++j)
+        Pzy[i * no + j] += w * dzi * (yr[j] - y_mean[j]);
+    }
+  }
+}
+
+static void ukf_add_process_cov(const f64 *SDSGE_RESTRICT BQBT,
+                                f64 *SDSGE_RESTRICT P, i64 ns, i64 nz) {
+  for (i64 i = 0; i < ns; ++i)
+    for (i64 j = 0; j < ns; ++j)
+      P[i * nz + j] += BQBT[i * ns + j];
+}
+
+static void ukf_cov_update(const f64 *SDSGE_RESTRICT P_pred,
+                           const f64 *SDSGE_RESTRICT K,
+                           const f64 *SDSGE_RESTRICT Pzy,
+                           f64 *SDSGE_RESTRICT P_filt, i64 nz, i64 no) {
+  for (i64 i = 0; i < nz; ++i) {
+    for (i64 j = 0; j < nz; ++j) {
+      f64 s = P_pred[i * nz + j];
+      for (i64 l = 0; l < no; ++l)
+        s -= K[i * no + l] * Pzy[j * no + l];
+      P_filt[i * nz + j] = s;
+    }
+  }
+}
+
+static void ukf_store_state_blocks(const f64 *SDSGE_RESTRICT z,
+                                   f64 *SDSGE_RESTRICT x1,
+                                   f64 *SDSGE_RESTRICT x2, i64 t, i64 ns) {
+  memcpy(x1 + t * ns, z, (size_t)ns * sizeof(f64));
+  memcpy(x2 + t * ns, z + ns, (size_t)ns * sizeof(f64));
+}
+
+i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
+  const i64 ns = in->n_state;
+  const i64 nc = in->n_ctrl;
+  const i64 ne = in->n_exog;
+  const i64 no = in->n_obs;
+  const i64 T = in->T;
+  const i64 nz = 2 * ns;
+  const i64 n_sig = 2 * nz + 1;
+  const i64 nv = ns + nc;
+
+  if (in->meas == NULL || ns <= 0 || no <= 0 || nz <= 0)
+    return KF_ERR_SHAPE_MISMATCH;
+
+  const f64 lambda = in->alpha * in->alpha * ((f64)nz + in->kappa) - (f64)nz;
+  const f64 scale = (f64)nz + lambda;
+  if (!(scale > 0.0) || !isfinite(scale))
+    return KF_ERR_MATRIX_CONDITION;
+  const f64 gamma = sqrt(scale);
+  const f64 w0_m = lambda / scale;
+  const f64 w0_c = w0_m + (1.0 - in->alpha * in->alpha + in->beta);
+  const f64 wi = 1.0 / (2.0 * scale);
+
+  const i64 total =
+      3 * nz + 4 * nz * nz + 2 * n_sig * nz + n_sig * no + ns * ns +
+      ns * ne + 6 * no + 2 * no * no + 2 * nz * no + nv;
+
+  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
+  if (arena == NULL)
+    return KF_ERR_ALLOC;
+
+  f64 *p = arena;
+  f64 *z_prev = p;
+  p += nz;
+  f64 *z_pred = p;
+  p += nz;
+  f64 *z_filt = p;
+  p += nz;
+  f64 *P_prev = p;
+  p += nz * nz;
+  f64 *P_pred = p;
+  p += nz * nz;
+  f64 *P_filt = p;
+  p += nz * nz;
+  f64 *P_chol = p;
+  p += nz * nz;
+  f64 *sigma_z = p;
+  p += n_sig * nz;
+  f64 *sigma_z_next = p;
+  p += n_sig * nz;
+  f64 *sigma_y = p;
+  p += n_sig * no;
+  f64 *BQBT = p;
+  p += ns * ns;
+  f64 *temp_nk = p;
+  p += ns * ne;
+  f64 *y_pred = p;
+  p += no;
+  f64 *innov = p;
+  p += no;
+  f64 *std_innov = p;
+  p += no;
+  f64 *S_inv_v = p;
+  p += no;
+  f64 *solve_f = p;
+  p += no;
+  f64 *solve_b = p;
+  p += no;
+  f64 *S = p;
+  p += no * no;
+  f64 *L = p;
+  p += no * no;
+  f64 *Pzy = p;
+  p += nz * no;
+  f64 *K = p;
+  p += nz * no;
+  f64 *vars_buf = p;
+
+  memcpy(z_prev, in->z0, (size_t)nz * sizeof(f64));
+  memcpy(P_prev, in->P0, (size_t)(nz * nz) * sizeof(f64));
+  kf_build_bqbt(in->bx, in->Q, temp_nk, BQBT, ns, ne);
+
+  const f64 const_term = (f64)no * log(TWO_PI);
+  f64 loglik = 0.0;
+  i64 status = KF_OK;
+
+  for (i64 t = 0; t < T; ++t) {
+    if (sdsge_chol(P_prev, in->jitter, P_chol, nz) != SDSGE_OK) {
+      status = KF_ERR_MATRIX_CONDITION;
+      break;
+    }
+    ukf_build_sigma_points(z_prev, P_chol, gamma, sigma_z, nz);
+
+    for (i64 r = 0; r < n_sig; ++r)
+      ukf_pruned_transition(in, sigma_z + r * nz, sigma_z_next + r * nz);
+
+    ukf_weighted_mean(sigma_z_next, w0_m, wi, n_sig, nz, z_pred);
+    ukf_weighted_cov(sigma_z_next, z_pred, w0_c, wi, n_sig, nz, P_pred);
+    ukf_add_process_cov(BQBT, P_pred, ns, nz);
+    if (in->symmetrize)
+      sdsge_sym_inplace(P_pred, nz);
+
+    if (sdsge_chol(P_pred, in->jitter, P_chol, nz) != SDSGE_OK) {
+      status = KF_ERR_MATRIX_CONDITION;
+      break;
+    }
+    ukf_build_sigma_points(z_pred, P_chol, gamma, sigma_z, nz);
+    ukf_eval_measurement_sigma(in, sigma_z, n_sig, vars_buf, sigma_y);
+    ukf_weighted_mean(sigma_y, w0_m, wi, n_sig, no, y_pred);
+    ukf_weighted_meas_cov_cross(sigma_z, z_pred, sigma_y, y_pred, w0_c, wi,
+                                n_sig, nz, no, S, Pzy);
+    for (i64 i = 0; i < no * no; ++i)
+      S[i] += in->R[i];
+    if (in->symmetrize)
+      sdsge_sym_inplace(S, no);
+
+    kf_row_minus_vec(in->obs, t, y_pred, innov, no);
+    if (sdsge_chol(S, in->jitter, L, no) != SDSGE_OK) {
+      status = KF_ERR_MATRIX_CONDITION;
+      break;
+    }
+    sdsge_forward_subst(L, innov, std_innov, no);
+    sdsge_backward_subst_chol_t(L, std_innov, S_inv_v, no);
+
+    kf_gain_from_pc_t(L, Pzy, solve_f, solve_b, K, nz, no);
+    kf_state_update(z_pred, K, innov, z_filt, nz, no);
+    ukf_cov_update(P_pred, K, Pzy, P_filt, nz, no);
+    if (in->symmetrize)
+      sdsge_sym_inplace(P_filt, nz);
+
+    loglik += -0.5 * (const_term + sdsge_logdet_from_chol(L, no) +
+                      sdsge_dot(innov, S_inv_v, no));
+
+    if (in->store_history) {
+      ukf_store_state_blocks(z_pred, out->x1_pred, out->x2_pred, t, ns);
+      ukf_store_state_blocks(z_filt, out->x1_filt, out->x2_filt, t, ns);
+      memcpy(out->P_pred + t * nz * nz, P_pred,
+             (size_t)(nz * nz) * sizeof(f64));
+      memcpy(out->P_filt + t * nz * nz, P_filt,
+             (size_t)(nz * nz) * sizeof(f64));
+      memcpy(out->y_pred + t * no, y_pred, (size_t)no * sizeof(f64));
+      ukf_project_vars(in, z_filt, vars_buf);
+      in->meas(vars_buf, in->params, out->y_filt + t * no);
+      memcpy(out->innov + t * no, innov, (size_t)no * sizeof(f64));
+      memcpy(out->std_innov + t * no, std_innov, (size_t)no * sizeof(f64));
+      memcpy(out->S + t * no * no, S, (size_t)(no * no) * sizeof(f64));
+    }
+
+    f64 *z_tmp = z_prev;
+    z_prev = z_filt;
+    z_filt = z_tmp;
+    f64 *P_tmp = P_prev;
+    P_prev = P_filt;
+    P_filt = P_tmp;
+  }
+
+  *out->loglik = loglik;
+  free(arena);
+  return status;
 }

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -159,6 +159,9 @@ typedef struct {
   f64 *x1_filt; /* (T, n_state) */
   f64 *x2_filt; /* (T, n_state) */
 
+  f64 *x_pred; /* (T, n_state + n_ctrl) */
+  f64 *x_filt; /* (T, n_state + n_ctrl) */
+
   f64 *P_pred; /* (T, 2*n_state, 2*n_state) */
   f64 *P_filt; /* (T, 2*n_state, 2*n_state) */
 

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -136,13 +136,13 @@ typedef struct {
   const f64 *obs;
   const f64 *z0;
   const f64 *P0;
-  const i64 T;
+  i64 T;
 
-  const i64 n_state;
-  const i64 n_ctrl;
-  const i64 n_exog;
-  const i64 n_obs;
-  const i64 n_params;
+  i64 n_state;
+  i64 n_ctrl;
+  i64 n_exog;
+  i64 n_obs;
+  i64 n_params;
 
   f64 alpha;
   f64 beta;

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -4,6 +4,8 @@
 #include "../_common/sdsge_common.h"
 #include "../_common/sdsge_linalg.h"
 
+/* ERROR CODES */
+
 #define KF_OK 0
 #define KF_ERR_COMPLEX_MATRIX -1
 #define KF_ERR_SHAPE_MISMATCH -2
@@ -18,7 +20,7 @@
  * (sdsge_matmul, sdsge_chol, sdsge_*subst, sdsge_dot, ...) now live in
  * _common/sdsge_linalg so the regression / diagnostic kernels share them. */
 
-/* ---- Kalman-specific dense helpers (not general enough for sdsge_linalg) ---- */
+/* -- Kalman-specific dense helpers (not general enough for sdsge_linalg) -- */
 
 /* out(m) := A[row, :] - x(m), where A has m columns */
 void kf_row_minus_vec(const f64 *A, i64 row, const f64 *x, f64 *out, i64 m);
@@ -26,8 +28,8 @@ void kf_row_minus_vec(const f64 *A, i64 row, const f64 *x, f64 *out, i64 m);
 /* Solve (L L^T) x = B[row, :] for the single row; writes x into out[row, :].
  * `n` is the Cholesky dimension (= column count of B and out); fbuf/bbuf are
  * scratch of length n. */
-void kf_chol_solve_row(const f64 *L, const f64 *B, i64 row, f64 *fbuf, f64 *bbuf,
-                       f64 *out, i64 n);
+void kf_chol_solve_row(const f64 *L, const f64 *B, i64 row, f64 *fbuf,
+                       f64 *bbuf, f64 *out, i64 n);
 
 /* ---- Kalman-specific composition helpers ---- */
 
@@ -62,8 +64,8 @@ void kf_joseph_cov(const f64 *K, const f64 *C, const f64 *P_pred, const f64 *R,
                    f64 *out, i64 n, i64 m);
 
 /* out(n,n) := sym(B(n,k) Q(k,k) B^T), via temp_nk(n,k) */
-void kf_build_bqbt(const f64 *B, const f64 *Q, f64 *temp_nk, f64 *out,
-                   i64 n, i64 k);
+void kf_build_bqbt(const f64 *B, const f64 *Q, f64 *temp_nk, f64 *out, i64 n,
+                   i64 k);
 
 /* out(k,m) := Q(k,k) @ (B^T C^T)(k,m), via temp_km(k,m) */
 void kf_build_shock_projection(const f64 *B, const f64 *C, const f64 *Q,
@@ -73,44 +75,102 @@ void kf_build_shock_projection(const f64 *B, const f64 *C, const f64 *Q,
 
 /* Model + data inputs. All matrices C-contiguous, row-major, f64. */
 typedef struct {
-    i64 n;              /* state dimension */
-    i64 m;              /* observation dimension */
-    i64 k;              /* shock dimension */
-    i64 T;              /* number of time steps */
-    const f64 *A;       /* (n, n) state transition */
-    const f64 *B;       /* (n, k) shock loading */
-    const f64 *C;       /* (m, n) observation */
-    const f64 *d;       /* (m,)   observation intercept */
-    const f64 *Q;       /* (k, k) shock covariance */
-    const f64 *R;       /* (m, m) measurement covariance */
-    const f64 *y;       /* (T, m) observations */
-    const f64 *x0;      /* (n,)   initial state mean */
-    const f64 *P0;      /* (n, n) initial state covariance (pre-symmetrized) */
-    int symmetrize;     /* symmetrize P/S each step (0/1) */
-    f64 jitter;         /* diagonal jitter for the Cholesky */
-    int return_shocks;  /* compute eps_hat (0/1) */
-    int store_history;  /* fill the per-step history arrays (0/1) */
+  i64 n;             /* state dimension */
+  i64 m;             /* observation dimension */
+  i64 k;             /* shock dimension */
+  i64 T;             /* number of time steps */
+  const f64 *A;      /* (n, n) state transition */
+  const f64 *B;      /* (n, k) shock loading */
+  const f64 *C;      /* (m, n) observation */
+  const f64 *d;      /* (m,)   observation intercept */
+  const f64 *Q;      /* (k, k) shock covariance */
+  const f64 *R;      /* (m, m) measurement covariance */
+  const f64 *y;      /* (T, m) observations */
+  const f64 *x0;     /* (n,)   initial state mean */
+  const f64 *P0;     /* (n, n) initial state covariance (pre-symmetrized) */
+  int symmetrize;    /* symmetrize P/S each step (0/1) */
+  f64 jitter;        /* diagonal jitter for the Cholesky */
+  int return_shocks; /* compute eps_hat (0/1) */
+  int store_history; /* fill the per-step history arrays (0/1) */
 } kf_inputs;
 
 /* Caller-allocated outputs. When store_history is 0 the history arrays may be
  * NULL / zero-length; eps_hat is written only when return_shocks &&
  * store_history. loglik is always written. */
 typedef struct {
-    f64 *x_pred;     /* (T, n) */
-    f64 *x_filt;     /* (T, n) */
-    f64 *P_pred;     /* (T, n, n) */
-    f64 *P_filt;     /* (T, n, n) */
-    f64 *y_pred;     /* (T, m) */
-    f64 *y_filt;     /* (T, m) */
-    f64 *innov;      /* (T, m)  innovations v */
-    f64 *std_innov;  /* (T, m)  L^-1 v */
-    f64 *S;          /* (T, m, m) innovation covariances */
-    f64 *eps_hat;    /* (T, k) or NULL */
-    f64 *loglik;     /* scalar out */
+  f64 *x_pred;    /* (T, n) */
+  f64 *x_filt;    /* (T, n) */
+  f64 *P_pred;    /* (T, n, n) */
+  f64 *P_filt;    /* (T, n, n) */
+  f64 *y_pred;    /* (T, m) */
+  f64 *y_filt;    /* (T, m) */
+  f64 *innov;     /* (T, m)  innovations v */
+  f64 *std_innov; /* (T, m)  L^-1 v */
+  f64 *S;         /* (T, m, m) innovation covariances */
+  f64 *eps_hat;   /* (T, k) or NULL */
+  f64 *loglik;    /* scalar out */
 } kf_outputs;
 
 /* Run the linear Kalman filter. Returns KF_OK, KF_ERR_MATRIX_CONDITION (non-PD
  * innovation covariance), or KF_ERR_ALLOC (scratch allocation failed). */
 int kf_hot_loop(const kf_inputs *in, kf_outputs *out);
+
+/* Unscented Kalman Filter */
+
+typedef void (*meas_fn)(const f64 *SDSGE_RESTRICT x,
+                        const f64 *SDSGE_RESTRICT params, f64 *out);
+
+typedef struct {
+  meas_fn meas;
+  const f64 *hx;
+  const f64 *gx;
+  const f64 *bx;
+  const f64 *hxx;
+  const f64 *gxx;
+  const f64 *hss;
+  const f64 *gss;
+  const f64 *steady_state;
+  const f64 *params;
+  const f64 *Q;
+  const f64 *R;
+  const f64 *obs;
+  const f64 *z0;
+  const f64 *P0;
+  const i64 T;
+
+  const i64 n_state;
+  const i64 n_ctrl;
+  const i64 n_exog;
+  const i64 n_obs;
+  const i64 n_params;
+
+  f64 alpha;
+  f64 beta;
+  f64 kappa;
+
+  f64 jitter;
+  int symmetrize;
+  int store_history;
+} ukf_inputs;
+
+typedef struct {
+  f64 *x1_pred; /* (T, n_state) */
+  f64 *x2_pred; /* (T, n_state) */
+  f64 *x1_filt; /* (T, n_state) */
+  f64 *x2_filt; /* (T, n_state) */
+
+  f64 *P_pred; /* (T, 2*n_state, 2*n_state) */
+  f64 *P_filt; /* (T, 2*n_state, 2*n_state) */
+
+  f64 *y_pred;    /* (T, n_obs) */
+  f64 *y_filt;    /* (T, n_obs) */
+  f64 *innov;     /* (T, n_obs) */
+  f64 *std_innov; /* (T, n_obs) */
+  f64 *S;         /* (T, n_obs, n_obs) */
+
+  f64 *loglik;
+} ukf_outputs;
+
+i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out);
 
 #endif /* SDSGE_KALMAN_H */

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -37,7 +37,7 @@ from .simulation import (
 )
 from ..kalman.config import KalmanConfig
 from ..kalman.interface import KalmanInterface, _KFMatrices
-from ..kalman.filter import FilterResult
+from ..kalman.filter import FilterResult, UnscentedFilterResult
 
 if TYPE_CHECKING:
     from ..regression.sr.config import TemplateConfig
@@ -755,7 +755,7 @@ class SolvedModel:
     def kalman(
         self,
         y: NDF | pd.DataFrame,
-        filter_mode: Literal["linear", "extended"] = "linear",
+        filter_mode: Literal["linear", "extended", "unscented"] = "linear",
         *,
         observables: list[str] | None = None,
         x0: NDF | None = None,
@@ -768,7 +768,7 @@ class SolvedModel:
         estimate_R_diag: bool = False,
         R_scale: float = 1.0,
         _debug: bool = False,
-    ) -> FilterResult:
+    ) -> FilterResult | UnscentedFilterResult:
 
         params = asarray(
             [self.config.calibration.parameters[p] for p in self.compiled.calib_params],
@@ -777,8 +777,9 @@ class SolvedModel:
 
         h_func: Callable[..., NDF] | None = None
         H_jac: Callable[..., NDF] | None = None
+        meas_addr: int | None = None
 
-        if filter_mode == "extended":
+        if filter_mode in {"extended", "unscented"}:
             obs_idx = {name: i for i, name in enumerate(self.compiled.observable_names)}
             if observables is None:
                 selected_obs = list(self.compiled.observable_names)
@@ -786,8 +787,19 @@ class SolvedModel:
                 selected_obs = list(observables)
             selected_obs = sorted(selected_obs, key=lambda name: obs_idx[name])
 
+        if filter_mode == "extended":
             h_func = self.compiled.construct_measurement_array_func(selected_obs)
             H_jac = self.compiled.construct_observable_jacobian_array_func(selected_obs)
+        elif filter_mode == "unscented":
+            if return_shocks:
+                raise ValueError(
+                    "return_shocks is not supported for unscented filtering."
+                )
+            if self.policy.order != 2:
+                raise ValueError(
+                    "Unscented Kalman Filter requires a second order solution."
+                )
+            meas_addr = self.compiled.construct_measurement_cfunc(selected_obs).address
 
         ki = KalmanInterface(
             model=self,
@@ -797,6 +809,7 @@ class SolvedModel:
             R=R,
             h_func=h_func,
             H_jac=H_jac,
+            meas_addr=meas_addr,
             calib_params=params,
             p0_mode=p0_mode,
             p0_scale=p0_scale,

--- a/SymbolicDSGE/kalman/filter.py
+++ b/SymbolicDSGE/kalman/filter.py
@@ -42,7 +42,22 @@ _kalman_hot_loop_native: Callable[..., _KalmanReturn] | None
 _UKFReturn = Tuple[
     int,
     Tuple[float64, float64, float64],
-    Tuple[NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, float64],
+    Tuple[
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        NDF,
+        float64,
+    ],
 ]
 _ukf_hot_loop_native: Callable[..., _UKFReturn] | None
 
@@ -85,6 +100,9 @@ class FilterResult:
 
 @dataclass(frozen=True)
 class UnscentedFilterResult:
+    x_pred: NDF
+    x_filt: NDF
+
     x1_pred: NDF
     x2_pred: NDF
     x1_filt: NDF
@@ -1241,6 +1259,8 @@ class KalmanFilter:
             x2_pred,
             x1_filt,
             x2_filt,
+            x_pred,
+            x_filt,
             P_pred,
             P_filt,
             y_pred,
@@ -1252,6 +1272,8 @@ class KalmanFilter:
         ) = out
 
         return UnscentedFilterResult(
+            x_pred=x_pred,
+            x_filt=x_filt,
             x1_pred=x1_pred,
             x2_pred=x2_pred,
             x1_filt=x1_filt,

--- a/SymbolicDSGE/kalman/filter.py
+++ b/SymbolicDSGE/kalman/filter.py
@@ -39,9 +39,16 @@ _KalmanReturn = Tuple[
     Tuple[NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, float64],
 ]
 _kalman_hot_loop_native: Callable[..., _KalmanReturn] | None
+_UKFReturn = Tuple[
+    int,
+    Tuple[float64, float64, float64],
+    Tuple[NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, NDF, float64],
+]
+_ukf_hot_loop_native: Callable[..., _UKFReturn] | None
 
 if FORCE_NUMBA:
     _kalman_hot_loop_native = None
+    _ukf_hot_loop_native = None
 else:
     try:
         from .._ckernels.kalman import kalman_hot_loop as _kalman_hot_loop_native
@@ -49,6 +56,12 @@ else:
         if REQUIRE_NATIVE:
             raise
         _kalman_hot_loop_native = None
+    try:
+        from .._ckernels.kalman import ukf_hot_loop as _ukf_hot_loop_native
+    except ImportError:  # pragma: no cover - exercised only without the extension
+        if REQUIRE_NATIVE:
+            raise
+        _ukf_hot_loop_native = None
 
 
 @dataclass(frozen=True)
@@ -70,12 +83,34 @@ class FilterResult:
     eps_hat: NDF | None = None
 
 
+@dataclass(frozen=True)
+class UnscentedFilterResult:
+    x1_pred: NDF
+    x2_pred: NDF
+    x1_filt: NDF
+    x2_filt: NDF
+
+    P_pred: NDF
+    P_filt: NDF
+
+    y_pred: NDF
+    y_filt: NDF
+
+    innov: NDF
+    std_innov: NDF
+    S: NDF
+
+    loglik: float64
+
+
 def _get_real(mat: NDC | NDF, name: str, tol: float = 1e8) -> NDF:
     """
     Convert a complex matrix to a real matrix if the imaginary parts are negligible.
     """
     res = real_if_close(mat, tol=tol)
     if np.iscomplexobj(res):
+        if res.size == 0:
+            return np.ascontiguousarray(res.real, dtype=float64)
         max_i = np.max(np.abs(res.imag))  # pyright: ignore
         raise ComplexMatrixError(name, max_i)
     return np.ascontiguousarray(res, dtype=float64)
@@ -1072,6 +1107,162 @@ class KalmanFilter:
             std_innov=u,
             S=S,
             eps_hat=eps_hat if (return_shocks and _store_history) else None,
+            loglik=loglik,
+        )
+
+    @staticmethod
+    def run_unscented(
+        meas_addr: int,
+        hx: NDF | NDC,
+        gx: NDF | NDC,
+        bx: NDF | NDC,
+        hxx: NDF | NDC,
+        gxx: NDF | NDC,
+        hss: NDF | NDC,
+        gss: NDF | NDC,
+        steady_state: NDF | NDC,
+        calib_params: NDF | NDC,
+        Q: NDF | NDC,
+        R: NDF | NDC,
+        y: NDF | NDC,
+        z0: NDF | NDC,
+        P0: NDF | NDC,
+        alpha: float = 1.0,
+        beta: float = 2.0,
+        kappa: float = 1.0,
+        symmetrize: bool = True,
+        jitter: float = 0.0,
+        _store_history: bool = True,
+    ) -> UnscentedFilterResult:
+        if _ukf_hot_loop_native is None:
+            raise RuntimeError("Native unscented Kalman filter is not available.")
+        if meas_addr == 0:
+            raise ValueError("meas_addr must be a nonzero measurement cfunc address.")
+
+        hx = _get_real(hx, "hx")
+        bx = _get_real(bx, "bx")
+        hxx = _get_real(hxx, "hxx")
+        hss = _get_real(hss, "hss").reshape(-1)
+        steady_state = _get_real(steady_state, "steady_state").reshape(-1)
+        calib_params = _get_real(calib_params, "calib_params").reshape(-1)
+        Q = _get_real(Q, "Q")
+        R = _get_real(R, "R")
+        y = _get_real(y, "y")
+        z0 = _get_real(z0, "z0").reshape(-1)
+        P0 = _get_real(P0, "P0")
+
+        gx = _get_real(gx, "gx")
+        gxx = _get_real(gxx, "gxx")
+        gss = _get_real(gss, "gss").reshape(-1)
+
+        if hx.ndim != 2 or hx.shape[0] != hx.shape[1]:
+            raise ShapeMismatchError("hx", "(n_state, n_state)", str(hx.shape))
+        n_state = hx.shape[0]
+        n_z = 2 * n_state
+
+        if bx.ndim != 2 or bx.shape[0] != n_state:
+            raise ShapeMismatchError("bx", f"({n_state}, n_exog)", str(bx.shape))
+        n_exog = bx.shape[1]
+
+        if gx.ndim != 2 or gx.shape[1] != n_state:
+            raise ShapeMismatchError("gx", f"(n_ctrl, {n_state})", str(gx.shape))
+        n_ctrl = gx.shape[0]
+        n_var = n_state + n_ctrl
+
+        if hxx.shape != (n_state, n_state, n_state):
+            raise ShapeMismatchError(
+                "hxx",
+                f"({n_state}, {n_state}, {n_state})",
+                str(hxx.shape),
+            )
+        if gxx.shape != (n_ctrl, n_state, n_state):
+            raise ShapeMismatchError(
+                "gxx",
+                f"({n_ctrl}, {n_state}, {n_state})",
+                str(gxx.shape),
+            )
+        if hss.shape != (n_state,):
+            raise ShapeMismatchError("hss", f"({n_state},)", str(hss.shape))
+        if gss.shape != (n_ctrl,):
+            raise ShapeMismatchError("gss", f"({n_ctrl},)", str(gss.shape))
+        if steady_state.shape != (n_var,):
+            raise ShapeMismatchError(
+                "steady_state", f"({n_var},)", str(steady_state.shape)
+            )
+        if Q.shape != (n_exog, n_exog):
+            raise ShapeMismatchError("Q", f"({n_exog}, {n_exog})", str(Q.shape))
+        if y.ndim != 2:
+            raise ShapeMismatchError("y", "(T, n_obs)", str(y.shape))
+        n_obs = y.shape[1]
+        if R.shape != (n_obs, n_obs):
+            raise ShapeMismatchError("R", f"({n_obs}, {n_obs})", str(R.shape))
+        if z0.shape != (n_z,):
+            raise ShapeMismatchError("z0", f"({n_z},)", str(z0.shape))
+        if P0.shape != (n_z, n_z):
+            raise ShapeMismatchError("P0", f"({n_z}, {n_z})", str(P0.shape))
+
+        if symmetrize:
+            Q = _sym(Q)
+            R = _sym(R)
+            P0 = _sym(P0)
+
+        try:
+            err, err_info, out = _ukf_hot_loop_native(
+                meas_addr,
+                hx,
+                gx,
+                bx,
+                hxx,
+                gxx,
+                hss,
+                gss,
+                steady_state,
+                calib_params,
+                Q,
+                R,
+                y,
+                z0,
+                P0,
+                alpha,
+                beta,
+                kappa,
+                jitter,
+                symmetrize,
+                _store_history,
+            )
+        except linalg.LinAlgError as exc:
+            raise MatrixConditionError(float("inf")) from exc
+        if err != 0:
+            ErrorConstructor = get_error_constructor(ErrorCode(err))
+            raise ErrorConstructor(*err_info)
+
+        (
+            x1_pred,
+            x2_pred,
+            x1_filt,
+            x2_filt,
+            P_pred,
+            P_filt,
+            y_pred,
+            y_filt,
+            v,
+            u,
+            S,
+            loglik,
+        ) = out
+
+        return UnscentedFilterResult(
+            x1_pred=x1_pred,
+            x2_pred=x2_pred,
+            x1_filt=x1_filt,
+            x2_filt=x2_filt,
+            P_pred=P_pred,
+            P_filt=P_filt,
+            y_pred=y_pred,
+            y_filt=y_filt,
+            innov=v,
+            std_innov=u,
+            S=S,
             loglik=loglik,
         )
 

--- a/SymbolicDSGE/kalman/interface.py
+++ b/SymbolicDSGE/kalman/interface.py
@@ -1,4 +1,4 @@
-from .filter import KalmanFilter, FilterResult
+from .filter import KalmanFilter, FilterResult, UnscentedFilterResult
 from .config import KalmanConfig
 from .validator import validate_kf_inputs, _KalmanDebugInfo, FilterMode
 from typing import TYPE_CHECKING, Any, Tuple, Literal, Callable
@@ -24,6 +24,7 @@ import pandas as pd
 
 NDF = NDArray[float64]
 Float64Like = float | float64 | int | int64
+FilterOutput = FilterResult | UnscentedFilterResult
 
 
 @dataclass
@@ -53,10 +54,11 @@ class KalmanInterface(KalmanFilter):
         model: "SolvedModel",
         observables: list[str] | None,
         y: NDF | pd.DataFrame,
-        filter_mode: Literal["linear", "extended"] = "linear",
+        filter_mode: Literal["linear", "extended", "unscented"] = "linear",
         *,
         h_func: Callable[..., NDF] | None = None,
         H_jac: Callable[..., NDF] | None = None,
+        meas_addr: int | None = None,
         calib_params: NDF | None = None,
         R: NDF | None = None,
         p0_mode: Literal["diag", "eye"] | None = None,
@@ -125,7 +127,11 @@ class KalmanInterface(KalmanFilter):
 
         self.h_func = h_func
         self.H_jac = H_jac
+        self.meas_addr = meas_addr
         self.calib_params = calib_params
+        self.ukf_alpha = 1.0
+        self.ukf_beta = 2.0
+        self.ukf_kappa = 1.0
 
         self._validate_mode_and_inputs()
 
@@ -140,76 +146,177 @@ class KalmanInterface(KalmanFilter):
         x0: NDF | None = None,
         _debug: bool = False,
         _arg_overrides: dict[str, Any] | None = None,
-    ) -> FilterResult:
+    ) -> FilterOutput:
         if _arg_overrides is None:
             _arg_overrides = {}
 
+        if self.mode == FilterMode.LINEAR:
+            return self.filter_linear(
+                x0=x0,
+                _debug=_debug,
+                _arg_overrides=_arg_overrides,
+            )
+        if self.mode == FilterMode.EXTENDED:
+            return self.filter_extended(
+                x0=x0,
+                _debug=_debug,
+                _arg_overrides=_arg_overrides,
+            )
+        if self.mode == FilterMode.UNSCENTED:
+            return self.filter_unscented(
+                x0=x0,
+                _debug=_debug,
+                _arg_overrides=_arg_overrides,
+            )
+        raise ValueError(f"Unrecognized filter mode: {self.mode}")
+
+    def filter_linear(
+        self,
+        x0: NDF | None = None,
+        _debug: bool = False,
+        _arg_overrides: dict[str, Any] | None = None,
+    ) -> FilterResult:
+        if _arg_overrides is None:
+            _arg_overrides = {}
         if x0 is None:
             x0 = np.zeros((self.A.shape[0],), dtype=float64)
+        base_args = self._linear_validated_args
+        run_args = base_args | _arg_overrides
+        self._validate_linear_extended_run(
+            run_args,
+            x0=x0,
+            probe_measurement=False,
+            arg_overrides=_arg_overrides,
+        )
 
-        if self.mode == FilterMode.LINEAR:
-            base_args = self._linear_validated_args
-        elif self.mode == FilterMode.EXTENDED:
-            base_args = self._extended_validated_args
-        else:
-            raise ValueError(f"Unrecognized filter mode: {self.mode}")
+        run = self.run(
+            **run_args,
+            x0=x0,
+            jitter=self.jitter,
+            symmetrize=self.symmetrize,
+            return_shocks=self.return_shocks,
+        )
+        if _debug:
+            self._set_debug_info(x0=x0, run_args=run_args)
+        return run
 
-        validated_args = base_args | _arg_overrides
+    def filter_extended(
+        self,
+        x0: NDF | None = None,
+        _debug: bool = False,
+        _arg_overrides: dict[str, Any] | None = None,
+    ) -> FilterResult:
+        if _arg_overrides is None:
+            _arg_overrides = {}
+        if x0 is None:
+            x0 = np.zeros((self.A.shape[0],), dtype=float64)
+        base_args = self._extended_validated_args
+        run_args = base_args | _arg_overrides
+        self._validate_linear_extended_run(
+            run_args,
+            x0=x0,
+            probe_measurement=True,
+            arg_overrides=_arg_overrides,
+        )
 
-        # The covariance-sanity checks (symmetry + non-negative diagonals) run on
-        # the model-constant Q/P0/R and dominate per-call validation. Skip them
-        # once they've passed for cached constant matrices; y/x0 and every shape
-        # check still run on each call. A user-supplied or estimated R (and any
-        # explicit override) is not cache-validated and keeps the full checks.
+        run = self.run_extended(
+            **run_args,
+            x0=x0,
+            jitter=self.jitter,
+            symmetrize=self.symmetrize,
+            return_shocks=self.return_shocks,
+        )
+        if _debug:
+            self._set_debug_info(x0=x0, run_args=run_args)
+        return run
+
+    def _validate_linear_extended_run(
+        self,
+        run_args: dict[str, Any],
+        *,
+        x0: NDF,
+        probe_measurement: bool,
+        arg_overrides: dict[str, Any],
+    ) -> None:
         const_validated = (
-            self._cache_record.validated and self._uses_const_R and not _arg_overrides
+            self._cache_record.validated and self._uses_const_R and not arg_overrides
         )
         run_const_checks = not const_validated
         validate_kf_inputs(
-            **validated_args,
+            **run_args,
             x0=x0,
             filter_mode=self.mode,
             check_nonneg_diag=run_const_checks,
             check_symmetry=run_const_checks,
-            probe_measurement=(self.mode == FilterMode.EXTENDED),
-            probe_state=("x0" if x0 is not None else "zeros"),
+            probe_measurement=probe_measurement,
+            probe_state="x0",
         )
-        if run_const_checks and self._uses_const_R and not _arg_overrides:
+        if run_const_checks and self._uses_const_R and not arg_overrides:
             self._cache_record.validated = True
 
-        if self.mode == FilterMode.LINEAR:
+    def filter_unscented(
+        self,
+        x0: NDF | None = None,
+        _debug: bool = False,
+        _arg_overrides: dict[str, Any] | None = None,
+    ) -> UnscentedFilterResult:
+        if _arg_overrides is None:
+            _arg_overrides = {}
+        if self.return_shocks:
+            raise ValueError("return_shocks is not supported for unscented filtering.")
 
-            run = self.run(
-                **base_args | _arg_overrides,
-                # Options
-                jitter=self.jitter,
-                symmetrize=self.symmetrize,
-                return_shocks=self.return_shocks,
-            )
-        elif self.mode == FilterMode.EXTENDED:
-            run = self.run_extended(
-                **base_args | _arg_overrides,
-                # Options
-                jitter=self.jitter,
-                symmetrize=self.symmetrize,
-                return_shocks=self.return_shocks,
-            )
+        z0 = self._build_unscented_z0(x0)
+        base_args = self._unscented_validated_args
+        run_args = base_args | _arg_overrides
+        self._validate_unscented_covariances(run_args, arg_overrides=_arg_overrides)
 
+        run = self.run_unscented(
+            **run_args,
+            z0=z0,
+            alpha=self.ukf_alpha,
+            beta=self.ukf_beta,
+            kappa=self.ukf_kappa,
+            jitter=float(self.jitter),
+            symmetrize=self.symmetrize,
+        )
         if _debug:
-            self._debug_info = _KalmanDebugInfo(
-                A=self.A,
-                B=self.B,
-                C=self.C,
-                d=self.d,
-                h_func=self.h_func,
-                H_jac=self.H_jac,
-                Q=self.Q,
-                R=self.R,
-                y=self.y,
-                x0=x0,
-                P0=self.P0,
-            )
+            self._set_debug_info(x0=x0, z0=z0, run_args=run_args)
         return run
+
+    def _set_debug_info(
+        self,
+        *,
+        x0: NDF | None,
+        run_args: dict[str, Any],
+        z0: NDF | None = None,
+    ) -> None:
+        self._debug_info = _KalmanDebugInfo(
+            A=run_args.get("A", self.A),
+            B=run_args.get("B", self.B),
+            C=run_args.get("C", self.C),
+            d=run_args.get("d", self.d),
+            h_func=run_args.get("h", self.h_func),
+            H_jac=run_args.get("H_jac", self.H_jac),
+            Q=run_args.get("Q", self.Q),
+            R=run_args.get("R", self.R),
+            y=run_args.get("y", self.y),
+            x0=x0,
+            P0=run_args.get("P0", self.P0),
+            meas_addr=run_args.get("meas_addr", self.meas_addr),
+            hx=run_args.get("hx"),
+            gx=run_args.get("gx"),
+            bx=run_args.get("bx"),
+            hxx=run_args.get("hxx"),
+            gxx=run_args.get("gxx"),
+            hss=run_args.get("hss"),
+            gss=run_args.get("gss"),
+            steady_state=run_args.get("steady_state"),
+            calib_params=run_args.get("calib_params", self.calib_params),
+            z0=z0,
+            alpha=self.ukf_alpha if self.mode == FilterMode.UNSCENTED else None,
+            beta=self.ukf_beta if self.mode == FilterMode.UNSCENTED else None,
+            kappa=self.ukf_kappa if self.mode == FilterMode.UNSCENTED else None,
+        )
 
     def _get_symmetrize(self, symmetrize_arg: bool | None) -> bool:
         return bool(symmetrize_arg) if symmetrize_arg is not None else False
@@ -297,7 +404,7 @@ class KalmanInterface(KalmanFilter):
         def obj(eta: NDF) -> float64:
             R_diag = np.exp(eta)
             R = np.diag(R_diag)
-            result: FilterResult = self.filter(
+            result: FilterResult | UnscentedFilterResult = self.filter(
                 x0=np.zeros((self.A.shape[0],), dtype=float64),
                 _debug=False,
                 _arg_overrides={"R": R},
@@ -548,6 +655,80 @@ class KalmanInterface(KalmanFilter):
             #         UserWarning,
             #     )
 
+        elif self.mode == FilterMode.UNSCENTED:
+            if self.meas_addr is None or self.meas_addr == 0:
+                raise ValueError("meas_addr is required for unscented Kalman Filter.")
+            if self.calib_params is None:
+                raise ValueError(
+                    "calib_params is required for unscented Kalman Filter."
+                )
+            if getattr(getattr(self.model, "policy", None), "order", None) != 2:
+                raise ValueError(
+                    "Unscented Kalman Filter requires a second order solution."
+                )
+
+        else:
+            raise ValueError(f"Unrecognized filter mode: {self.mode}")
+
+    @staticmethod
+    def _check_covariance_matrix(name: str, value: NDF) -> None:
+        if not isinstance(value, np.ndarray):
+            raise TypeError(f"{name} must be a numpy ndarray.")
+        if value.ndim != 2 or value.shape[0] != value.shape[1]:
+            raise ValueError(f"{name} must be a square 2D matrix.")
+        if not np.isfinite(value).all():
+            raise ValueError(f"{name} contains non-finite values.")
+        if not np.allclose(value, value.T):
+            raise ValueError(f"{name} must be symmetric.")
+        if np.any(np.diag(value) < 0.0):
+            raise ValueError(f"{name} must have non-negative diagonal entries.")
+
+    def _validate_unscented_covariances(
+        self,
+        run_args: dict[str, Any],
+        *,
+        arg_overrides: dict[str, Any],
+    ) -> None:
+        const_validated = (
+            self._cache_record.validated and self._uses_const_R and not arg_overrides
+        )
+        if const_validated:
+            return
+
+        self._check_covariance_matrix("Q", run_args["Q"])
+        self._check_covariance_matrix("R", run_args["R"])
+        self._check_covariance_matrix("P0", run_args["P0"])
+        if self._uses_const_R and not arg_overrides:
+            self._cache_record.validated = True
+
+    def _build_unscented_z0(self, x0: NDF | None) -> NDF:
+        n_state = self.model.compiled.n_state
+        n_var = len(self.model.compiled.var_names)
+        if x0 is None:
+            x0_state = np.zeros((n_state,), dtype=float64)
+        else:
+            raw = asarray(x0, dtype=float64)
+            if raw.ndim != 1:
+                raise ValueError("x0 must be a 1D array.")
+            if raw.shape[0] == n_state:
+                x0_state = raw.copy()
+            elif raw.shape[0] == n_var:
+                x0_state = raw[:n_state].copy()
+            else:
+                raise ValueError(
+                    f"x0 must have length {n_state} or {n_var}, got {raw.shape[0]}."
+                )
+
+        z0 = np.zeros((2 * n_state,), dtype=float64)
+        z0[:n_state] = x0_state
+        return z0
+
+    def _policy_array(self, name: str) -> NDF:
+        value = getattr(self.model.policy, name, None)
+        if value is None:
+            raise ValueError(f"Unscented filtering requires policy.{name}.")
+        return asarray(np.real_if_close(value), dtype=float64)
+
     @cached_property
     def _obs_idx(self) -> dict[str, int]:
         return {name: i for i, name in enumerate(self.model.compiled.observable_names)}
@@ -598,4 +779,24 @@ class KalmanInterface(KalmanFilter):
             # "x0": x0,  # provided at filter() call time
             # Data
             "y": self.y,
+        }
+
+    @property
+    def _unscented_validated_args(self) -> dict:
+        n_state = self.model.compiled.n_state
+        return {
+            "meas_addr": self.meas_addr,
+            "hx": self._policy_array("p"),
+            "gx": self._policy_array("f"),
+            "bx": asarray(self.B[:n_state, :], dtype=float64),
+            "hxx": self._policy_array("hxx"),
+            "gxx": self._policy_array("gxx"),
+            "hss": self._policy_array("hss"),
+            "gss": self._policy_array("gss"),
+            "steady_state": self._policy_array("steady_state"),
+            "calib_params": self.calib_params,
+            "Q": self.Q,
+            "R": self.R,
+            "y": self.y,
+            "P0": self.P0,
         }

--- a/SymbolicDSGE/kalman/interface.py
+++ b/SymbolicDSGE/kalman/interface.py
@@ -331,11 +331,52 @@ class KalmanInterface(KalmanFilter):
         p0_mode: Literal["diag", "eye"] | None = None,
         p0_scale: Float64Like | None = None,
     ) -> NDF:
+        mode = getattr(self, "mode", FilterMode.LINEAR)
+        if mode == FilterMode.UNSCENTED:
+            return self._build_unscented_P0(p0_mode=p0_mode, p0_scale=p0_scale)
+        return self._build_full_P0(p0_mode=p0_mode, p0_scale=p0_scale)
+
+    def _build_full_P0(
+        self,
+        p0_mode: Literal["diag", "eye"] | None = None,
+        p0_scale: Float64Like | None = None,
+    ) -> NDF:
+        return self._build_named_P0(
+            self.model.compiled.var_names,
+            p0_mode=p0_mode,
+            p0_scale=p0_scale,
+            required_scope="model variables",
+        )
+
+    def _build_unscented_P0(
+        self,
+        p0_mode: Literal["diag", "eye"] | None = None,
+        p0_scale: Float64Like | None = None,
+    ) -> NDF:
+        n_state = self.model.compiled.n_state
+        state_vars = self.model.compiled.var_names[:n_state]
+        state_P0 = self._build_named_P0(
+            state_vars,
+            p0_mode=p0_mode,
+            p0_scale=p0_scale,
+            required_scope="state variables",
+        )
+
+        out = np.zeros((2 * n_state, 2 * n_state), dtype=float64)
+        out[:n_state, :n_state] = state_P0
+        out[n_state:, n_state:] = np.eye(n_state, dtype=float64)
+        return out
+
+    def _build_named_P0(
+        self,
+        vars_ordered: list[str],
+        p0_mode: Literal["diag", "eye"] | None = None,
+        p0_scale: Float64Like | None = None,
+        required_scope: str = "model variables",
+    ) -> NDF:
         conf = self.kalman_config
-        vars_ordered = self.model.compiled.var_names
         n = len(vars_ordered)
 
-        # Branch 0: Has P0 Config
         if (P0 := getattr(conf, "P0", None)) is not None:
             mode = p0_mode if p0_mode is not None else P0.mode
             scale = (
@@ -345,10 +386,9 @@ class KalmanInterface(KalmanFilter):
             )
             if mode == "diag":
                 if (diag_dict := getattr(P0, "diag", None)) is not None:
-                    # Check all variables have value
                     if not all(var in diag_dict for var in vars_ordered):
                         raise ValueError(
-                            "P0 diagonal specification must include all model variables."
+                            f"P0 diagonal specification must include all {required_scope}."
                         )
 
                     mat = np.zeros((n, n), dtype=float64)
@@ -366,7 +406,6 @@ class KalmanInterface(KalmanFilter):
                     f"Unrecognized P0 mode: {mode}. Expected 'diag' or 'eye'."
                 )
 
-        # Branch 1: No P0 Config, Check for overrides
         else:
             if p0_mode is None or p0_scale is None:
                 raise ValueError(

--- a/SymbolicDSGE/kalman/validator.py
+++ b/SymbolicDSGE/kalman/validator.py
@@ -26,6 +26,20 @@ class _KalmanDebugInfo:
     y: NDF | None
     x0: Optional[NDF]
     P0: Optional[NDF]
+    meas_addr: int | None = None
+    hx: NDF | None = None
+    gx: NDF | None = None
+    bx: NDF | None = None
+    hxx: NDF | None = None
+    gxx: NDF | None = None
+    hss: NDF | None = None
+    gss: NDF | None = None
+    steady_state: NDF | None = None
+    calib_params: NDF | None = None
+    z0: NDF | None = None
+    alpha: float | None = None
+    beta: float | None = None
+    kappa: float | None = None
 
 
 @dataclass(frozen=True)

--- a/SymbolicDSGE/kalman/validator.py
+++ b/SymbolicDSGE/kalman/validator.py
@@ -10,6 +10,7 @@ NDF = NDArray[np.float64]
 class FilterMode(StrEnum):
     LINEAR = "linear"
     EXTENDED = "extended"
+    UNSCENTED = "unscented"
 
 
 @dataclass(frozen=True)

--- a/SymbolicDSGE/monte_carlo/operations/core/ops.py
+++ b/SymbolicDSGE/monte_carlo/operations/core/ops.py
@@ -7,7 +7,7 @@ from numpy import float64, ndarray
 
 
 from ....core.solved_model import SolvedModel
-from ....kalman.filter import FilterResult
+from ....kalman.filter import FilterResult, UnscentedFilterResult
 from ...mc_constructs import MCContext, MCData, NDF, SeedIncrement, ShockMapping
 from ..utils import _clone_or_pass_shocks, _select_raw_rep_array
 
@@ -130,7 +130,7 @@ def run_reference_filter(
     reference: SolvedModel,
     dgp: SolvedModel | None,
     rep_idx: int,
-    filter_mode: Literal["linear", "extended"] = "linear",
+    filter_mode: Literal["linear", "extended", "unscented"] = "linear",
     observables: list[str] | None = None,
     x0: NDF | None = None,
     p0_mode: Literal["diag", "eye"] | None = None,
@@ -141,7 +141,16 @@ def run_reference_filter(
     R: NDF | None = None,
     estimate_R_diag: bool = False,
     R_scale: float = 1.0,
-) -> FilterResult:
+) -> FilterResult | UnscentedFilterResult:
+
+    # TODO: Figure out MC payloads to be generated from UKF:
+    # - map to model variables or carry {x1, x2} form?
+    # - Fit to current KF payload setup or split/extend the payload return of filters?
+    if filter_mode == "unscented":
+        raise NotImplementedError(
+            "MC Filtration for Unscented Kalman Filter is not yet implemented."
+        )
+
     del dgp, rep_idx
     data = context.require_data()
     if data.observables is None:

--- a/SymbolicDSGE/regression/sr/sr_interface.py
+++ b/SymbolicDSGE/regression/sr/sr_interface.py
@@ -3,7 +3,7 @@ from .symbolic_regression import SymbolicRegressor
 from .model_parametrizer import ModelParametrizer
 from .fit_result import FitResult
 
-from ...kalman.filter import FilterResult
+from ...kalman.filter import FilterResult, UnscentedFilterResult
 
 from numpy.typing import NDArray
 from numpy import float64
@@ -40,7 +40,7 @@ class SRInterface:
         eq_subbed = eq_raw.subs(subs_map)
         return eq_subbed
 
-    def get_kf(self, y: NDF | DataFrame) -> FilterResult:
+    def get_kf(self, y: NDF | DataFrame) -> FilterResult | UnscentedFilterResult:
         affine = all(self._model.config.equations.obs_is_affine.values())
         mode = "linear" if affine else "extended"
         kf = self._model.kalman(
@@ -54,7 +54,8 @@ class SRInterface:
         return kf
 
     def fit_to_kf(self, y: NDF | DataFrame) -> FitResult:
-        kf: FilterResult = self.get_kf(y)
+
+        kf: FilterResult | UnscentedFilterResult = self.get_kf(y)
 
         var_idx = self._model.compiled.idx
         var_idx_ls = sorted([var_idx[var] for var in self.selected_var_names])

--- a/tests/ckernels/test_kalman.py
+++ b/tests/ckernels/test_kalman.py
@@ -5,6 +5,7 @@ Skips when the ``_ckernels.kalman`` extension is not built.
 
 import numpy as np
 import pytest
+from numba import cfunc, types
 
 from SymbolicDSGE.kalman.filter import _kalman_hot_loop
 
@@ -49,6 +50,18 @@ def _make_system(n: int, m: int, k: int, T: int, seed: int):
     y = rng.standard_normal((T, m))
     x0 = rng.standard_normal(n)
     return tuple(_c(z) for z in (A, B, C, d, Q, R, y, x0, P0))
+
+
+_MEAS_SIG = types.void(
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+)
+
+
+@cfunc(_MEAS_SIG)
+def _ukf_measure_first_var(model_vars, _params, out):
+    out[0] = model_vars[0]
 
 
 @pytest.mark.parametrize(
@@ -130,3 +143,94 @@ def test_kalman_non_pd_raises() -> None:
         kf.kalman_hot_loop(*args)
     with pytest.raises(np.linalg.LinAlgError):
         _kalman_hot_loop(*args)
+
+
+def test_ukf_returns_projected_model_variable_history() -> None:
+    T = 4
+    hx = _c([[0.55]])
+    gx = _c([[2.0]])
+    bx = _c([[1.0]])
+    hxx = _c([[[0.1]]])
+    gxx = _c([[[0.4]]])
+    hss = _c([0.03])
+    gss = _c([0.2])
+    steady_state = _c([10.0, 20.0])
+    params = _c([])
+    Q = _c([[0.05]])
+    R = _c([[0.25]])
+    obs = _c(np.zeros((T, 1)))
+    z0 = _c([0.1, 0.0])
+    P0 = _c(np.diag([0.2, 0.3]))
+
+    _, _, out = kf.ukf_hot_loop(
+        _ukf_measure_first_var.address,
+        hx,
+        gx,
+        bx,
+        hxx,
+        gxx,
+        hss,
+        gss,
+        steady_state,
+        params,
+        Q,
+        R,
+        obs,
+        z0,
+        P0,
+        1.0,
+        2.0,
+        1.0,
+        1e-12,
+        True,
+        True,
+    )
+    (
+        x1_pred,
+        x2_pred,
+        x1_filt,
+        x2_filt,
+        x_pred,
+        x_filt,
+        P_pred,
+        P_filt,
+        _y_pred,
+        _y_filt,
+        _innov,
+        _std_innov,
+        _S,
+        _loglik,
+    ) = out
+
+    assert x_pred.shape == (T, 2)
+    assert x_filt.shape == (T, 2)
+    np.testing.assert_allclose(
+        x_pred[:, 0],
+        steady_state[0] + x1_pred[:, 0] + x2_pred[:, 0],
+        rtol=_RTOL,
+        atol=_ATOL,
+    )
+    np.testing.assert_allclose(
+        x_filt[:, 0],
+        steady_state[0] + x1_filt[:, 0] + x2_filt[:, 0],
+        rtol=_RTOL,
+        atol=_ATOL,
+    )
+    np.testing.assert_allclose(
+        x_pred[:, 1],
+        steady_state[1]
+        + 0.5 * gss[0]
+        + gx[0, 0] * (x1_pred[:, 0] + x2_pred[:, 0])
+        + 0.5 * gxx[0, 0, 0] * (P_pred[:, 0, 0] + x1_pred[:, 0] ** 2),
+        rtol=_RTOL,
+        atol=_ATOL,
+    )
+    np.testing.assert_allclose(
+        x_filt[:, 1],
+        steady_state[1]
+        + 0.5 * gss[0]
+        + gx[0, 0] * (x1_filt[:, 0] + x2_filt[:, 0])
+        + 0.5 * gxx[0, 0, 0] * (P_filt[:, 0, 0] + x1_filt[:, 0] ** 2),
+        rtol=_RTOL,
+        atol=_ATOL,
+    )

--- a/tests/core/test_solved_model.py
+++ b/tests/core/test_solved_model.py
@@ -505,6 +505,78 @@ def test_solved_model_kalman_extended_uses_default_obs_and_debug(monkeypatch):
     assert printed == [({"debug": True},)]
 
 
+def test_solved_model_kalman_unscented_uses_measurement_cfunc(monkeypatch):
+    alpha = Symbol("alpha")
+    captured = {}
+
+    class _FakeKalmanInterface:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self._debug_info = None
+
+        def filter(self, x0=None, _debug=False):
+            captured["filter"] = {"x0": x0, "_debug": _debug}
+            return "ukf-result"
+
+    compiled = SimpleNamespace(
+        calib_params=[alpha],
+        observable_names=["ObsA", "ObsB"],
+        construct_measurement_cfunc=lambda obs: SimpleNamespace(
+            address=456,
+            obs=tuple(obs),
+        ),
+        config=SimpleNamespace(calibration=SimpleNamespace(parameters={alpha: 1.5})),
+        kalman=SimpleNamespace(y_names=["ObsB", "ObsA"]),
+    )
+    solved = solved_model_module.SolvedModel(
+        compiled=compiled,
+        policy=SimpleNamespace(order=2),
+        A=np.eye(1, dtype=np.float64),
+        B=np.eye(1, dtype=np.float64),
+    )
+
+    monkeypatch.setattr(solved_model_module, "KalmanInterface", _FakeKalmanInterface)
+
+    out = solved.kalman(
+        y=np.zeros((3, 2), dtype=np.float64),
+        filter_mode="unscented",
+        observables=None,
+        x0=np.array([0.1], dtype=np.float64),
+    )
+
+    assert out == "ukf-result"
+    assert captured["init"]["filter_mode"] == "unscented"
+    assert captured["init"]["meas_addr"] == 456
+    assert captured["init"]["h_func"] is None
+    assert captured["init"]["H_jac"] is None
+    assert np.array_equal(captured["init"]["calib_params"], np.array([1.5]))
+    assert np.array_equal(captured["filter"]["x0"], np.array([0.1]))
+
+
+def test_solved_model_kalman_unscented_rejects_return_shocks(monkeypatch):
+    alpha = Symbol("alpha")
+    compiled = SimpleNamespace(
+        calib_params=[alpha],
+        observable_names=["ObsA"],
+        construct_measurement_cfunc=lambda obs: SimpleNamespace(address=456),
+        config=SimpleNamespace(calibration=SimpleNamespace(parameters={alpha: 1.5})),
+        kalman=SimpleNamespace(y_names=["ObsA"]),
+    )
+    solved = solved_model_module.SolvedModel(
+        compiled=compiled,
+        policy=SimpleNamespace(order=2),
+        A=np.eye(1, dtype=np.float64),
+        B=np.eye(1, dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match="return_shocks is not supported"):
+        solved.kalman(
+            y=np.zeros((3, 1), dtype=np.float64),
+            filter_mode="unscented",
+            return_shocks=True,
+        )
+
+
 def test_kalman_interface_rebuilds_symbolic_R_from_current_calibration(
     post82_test_model_path,
 ):

--- a/tests/kalman/test_filter.py
+++ b/tests/kalman/test_filter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from numba import cfunc, types
 from numpy import float64
 from sympy import Symbol
 
@@ -24,6 +25,43 @@ def _linear_system_1d():
     Q = np.array([[0.04]], dtype=float64)
     R = np.array([[0.01]], dtype=float64)
     return A, B, C, d, Q, R
+
+
+_UKF_MEAS_SIG = types.void(
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+)
+
+
+@cfunc(_UKF_MEAS_SIG)
+def _ukf_measurement(model_vars, params, out):
+    out[0] = model_vars[0] + params[0] * model_vars[1]
+
+
+def _ukf_system_1d():
+    return {
+        "meas_addr": _ukf_measurement.address,
+        "hx": np.array([[0.65]], dtype=float64),
+        "gx": np.array([[1.5]], dtype=float64),
+        "bx": np.array([[1.0]], dtype=float64),
+        "hxx": np.array([[[0.05]]], dtype=float64),
+        "gxx": np.array([[[0.1]]], dtype=float64),
+        "hss": np.array([0.02], dtype=float64),
+        "gss": np.array([0.04], dtype=float64),
+        "steady_state": np.array([2.0, 3.0], dtype=float64),
+        "calib_params": np.array([0.25], dtype=float64),
+        "Q": np.array([[0.03]], dtype=float64),
+        "R": np.array([[0.2]], dtype=float64),
+        "y": np.array([[2.8], [2.7], [2.65], [2.6]], dtype=float64),
+        "z0": np.array([0.1, 0.0], dtype=float64),
+        "P0": np.diag(np.array([0.4, 0.2], dtype=float64)),
+        "alpha": 1.0,
+        "beta": 2.0,
+        "kappa": 1.0,
+        "jitter": 1e-12,
+        "symmetrize": True,
+    }
 
 
 def test_make_r_builds_covariance_from_std_and_corr_maps():
@@ -166,6 +204,97 @@ def test_run_linear_raises_on_singular_innovation_covariance():
 
     with pytest.raises(MatrixConditionError):
         KalmanFilter.run(A, B, C, d, Q, R, y, P0=np.zeros((1, 1), dtype=float64))
+
+
+def test_run_unscented_outputs_shapes_and_projected_fields():
+    pytest.importorskip("SymbolicDSGE._ckernels.kalman")
+    kwargs = _ukf_system_1d()
+
+    out = KalmanFilter.run_unscented(**kwargs)
+
+    T = kwargs["y"].shape[0]
+    n_state = kwargs["hx"].shape[0]
+    n_var = kwargs["steady_state"].shape[0]
+    n_obs = kwargs["y"].shape[1]
+    nz = 2 * n_state
+    assert out.x_pred.shape == (T, n_var)
+    assert out.x_filt.shape == (T, n_var)
+    assert out.x1_pred.shape == (T, n_state)
+    assert out.x2_pred.shape == (T, n_state)
+    assert out.x1_filt.shape == (T, n_state)
+    assert out.x2_filt.shape == (T, n_state)
+    assert out.P_pred.shape == (T, nz, nz)
+    assert out.P_filt.shape == (T, nz, nz)
+    assert out.y_pred.shape == (T, n_obs)
+    assert out.y_filt.shape == (T, n_obs)
+    assert out.innov.shape == (T, n_obs)
+    assert out.std_innov.shape == (T, n_obs)
+    assert out.S.shape == (T, n_obs, n_obs)
+    assert np.isfinite(out.loglik)
+
+    steady_state = kwargs["steady_state"]
+    params = kwargs["calib_params"]
+    np.testing.assert_allclose(
+        out.x_pred[:, 0],
+        steady_state[0] + out.x1_pred[:, 0] + out.x2_pred[:, 0],
+    )
+    np.testing.assert_allclose(
+        out.x_filt[:, 0],
+        steady_state[0] + out.x1_filt[:, 0] + out.x2_filt[:, 0],
+    )
+    np.testing.assert_allclose(
+        out.y_filt[:, 0],
+        out.x_filt[:, 0] + params[0] * out.x_filt[:, 1],
+    )
+    np.testing.assert_allclose(out.P_filt, np.transpose(out.P_filt, (0, 2, 1)))
+
+
+def test_run_unscented_can_skip_history_storage_for_loglik_only_path():
+    pytest.importorskip("SymbolicDSGE._ckernels.kalman")
+    kwargs = _ukf_system_1d()
+
+    full = KalmanFilter.run_unscented(**kwargs)
+    minimal = KalmanFilter.run_unscented(**kwargs, _store_history=False)
+
+    assert np.allclose(minimal.loglik, full.loglik)
+    assert minimal.x_pred.shape == (0, 2)
+    assert minimal.x_filt.shape == (0, 2)
+    assert minimal.x1_pred.shape == (0, 1)
+    assert minimal.x2_pred.shape == (0, 1)
+    assert minimal.x1_filt.shape == (0, 1)
+    assert minimal.x2_filt.shape == (0, 1)
+    assert minimal.P_pred.shape == (0, 2, 2)
+    assert minimal.P_filt.shape == (0, 2, 2)
+    assert minimal.y_pred.shape == (0, 1)
+    assert minimal.y_filt.shape == (0, 1)
+    assert minimal.innov.shape == (0, 1)
+    assert minimal.std_innov.shape == (0, 1)
+    assert minimal.S.shape == (0, 1, 1)
+
+
+def test_run_unscented_rejects_degenerate_inputs():
+    pytest.importorskip("SymbolicDSGE._ckernels.kalman")
+    kwargs = _ukf_system_1d()
+
+    with pytest.raises(ValueError, match="meas_addr"):
+        KalmanFilter.run_unscented(**(kwargs | {"meas_addr": 0}))
+
+    with pytest.raises(ShapeMismatchError, match="hxx"):
+        KalmanFilter.run_unscented(
+            **(kwargs | {"hxx": np.zeros((1, 1), dtype=float64)})
+        )
+
+    with pytest.raises(MatrixConditionError):
+        KalmanFilter.run_unscented(
+            **(
+                kwargs
+                | {
+                    "P0": np.zeros((2, 2), dtype=float64),
+                    "Q": np.zeros((1, 1), dtype=float64),
+                    "jitter": 0.0,
+                }
+            )
+        )
 
 
 def test_run_extended_matches_linear_when_measurement_is_linear():

--- a/tests/kalman/test_interface.py
+++ b/tests/kalman/test_interface.py
@@ -53,6 +53,7 @@ def _make_stub_model(
     compiled = SimpleNamespace(
         observable_names=observable_names,
         var_names=var_names,
+        n_state=2,
         n_exog=2,
     )
 
@@ -109,6 +110,7 @@ def _make_shell(model=None, observables=None):
     ki = KalmanInterface.__new__(KalmanInterface)
     ki.model = _make_stub_model() if model is None else model
     ki.observables = ["ObsA", "ObsB"] if observables is None else observables
+    ki.mode = FilterMode.LINEAR
     return ki
 
 
@@ -408,6 +410,75 @@ def test_build_p0_supports_diag_and_eye_and_reports_invalid_configs():
     assert np.array_equal(no_p0._build_P0(p0_mode="eye", p0_scale=3.0), np.eye(3) * 3.0)
     with pytest.raises(ValueError, match="Unrecognized p0_mode"):
         no_p0._build_P0(p0_mode="triangle", p0_scale=2.0)
+
+
+def test_build_unscented_p0_uses_state_block_and_identity_second_block():
+    ki = _make_shell()
+    ki.mode = FilterMode.UNSCENTED
+
+    expected = np.diag([2.0, 6.0, 1.0, 1.0]).astype(FLOAT)
+    assert np.array_equal(ki._build_P0(), expected)
+
+    expected_eye = np.diag([1.5, 1.5, 1.0, 1.0]).astype(FLOAT)
+    assert np.array_equal(
+        ki._build_P0(p0_mode="eye", p0_scale=1.5),
+        expected_eye,
+    )
+
+    state_only_diag = _make_shell(
+        _make_stub_model(
+            kalman_config=SimpleNamespace(
+                y_names=["ObsA"],
+                R=np.array([[1.0]], dtype=FLOAT),
+                jitter=0.0,
+                symmetrize=False,
+                P0=SimpleNamespace(mode="diag", scale=2.0, diag={"u": 1.0, "v": 2.0}),
+                R_builder=None,
+                R_param_names=None,
+            )
+        )
+    )
+    state_only_diag.mode = FilterMode.UNSCENTED
+    assert np.array_equal(
+        state_only_diag._build_P0(),
+        np.diag([2.0, 4.0, 1.0, 1.0]).astype(FLOAT),
+    )
+
+    missing_state_diag = _make_shell(
+        _make_stub_model(
+            kalman_config=SimpleNamespace(
+                y_names=["ObsA"],
+                R=np.array([[1.0]], dtype=FLOAT),
+                jitter=0.0,
+                symmetrize=False,
+                P0=SimpleNamespace(mode="diag", scale=1.0, diag={"u": 1.0, "x": 5.0}),
+                R_builder=None,
+                R_param_names=None,
+            )
+        )
+    )
+    missing_state_diag.mode = FilterMode.UNSCENTED
+    with pytest.raises(ValueError, match="must include all state variables"):
+        missing_state_diag._build_P0()
+
+    no_p0 = _make_shell(
+        _make_stub_model(
+            kalman_config=SimpleNamespace(
+                y_names=["ObsA"],
+                R=np.array([[1.0]], dtype=FLOAT),
+                jitter=0.0,
+                symmetrize=False,
+                P0=None,
+                R_builder=None,
+                R_param_names=None,
+            )
+        )
+    )
+    no_p0.mode = FilterMode.UNSCENTED
+    assert np.array_equal(
+        no_p0._build_P0(p0_mode="eye", p0_scale=3.0),
+        np.diag([3.0, 3.0, 1.0, 1.0]).astype(FLOAT),
+    )
 
 
 def test_reorder_obs_uses_defaults_and_aligns_dataframe_and_ndarray_inputs():

--- a/tests/kalman/test_interface.py
+++ b/tests/kalman/test_interface.py
@@ -89,6 +89,16 @@ def _make_stub_model(
         compiled=compiled,
         config=config,
         kalman_config=kalman_config,
+        policy=SimpleNamespace(
+            order=2,
+            p=np.array([[0.8, 0.1], [0.0, 0.7]], dtype=FLOAT),
+            f=np.array([[0.2, 0.3]], dtype=FLOAT),
+            hxx=np.zeros((2, 2, 2), dtype=FLOAT),
+            gxx=np.zeros((1, 2, 2), dtype=FLOAT),
+            hss=np.array([0.01, 0.02], dtype=FLOAT),
+            gss=np.array([0.03], dtype=FLOAT),
+            steady_state=np.array([1.0, 2.0, 3.0], dtype=FLOAT),
+        ),
     )
     model._build_C_d_from_obs = build_measurement
 
@@ -662,6 +672,67 @@ def test_filter_dispatches_extended_and_rejects_unknown_runtime_mode(monkeypatch
     ki.mode = "mystery"
     with pytest.raises(ValueError, match="Unrecognized filter mode"):
         ki.filter()
+
+
+def test_filter_dispatches_unscented_and_populates_debug_info(monkeypatch):
+    ki = KalmanInterface(
+        model=_make_stub_model(),
+        observables=["ObsA"],
+        y=np.array([[1.0], [2.0]], dtype=FLOAT),
+        filter_mode="unscented",
+        meas_addr=123,
+        calib_params=np.array([0.5], dtype=FLOAT),
+        jitter=0.25,
+        symmetrize=False,
+    )
+    captured = {}
+
+    def fake_run_unscented(**kwargs):
+        captured["run_unscented"] = kwargs
+        return "ukf-run"
+
+    monkeypatch.setattr(
+        KalmanInterface, "run_unscented", staticmethod(fake_run_unscented)
+    )
+
+    x0 = np.array([0.2, 0.3, 99.0], dtype=FLOAT)
+    out = ki.filter(x0=x0, _debug=True)
+
+    assert out == "ukf-run"
+    run_args = captured["run_unscented"]
+    assert run_args["meas_addr"] == 123
+    assert np.array_equal(run_args["z0"], np.array([0.2, 0.3, 0.0, 0.0]))
+    assert np.array_equal(run_args["bx"], np.eye(2, dtype=FLOAT))
+    assert np.array_equal(run_args["steady_state"], np.array([1.0, 2.0, 3.0]))
+    assert run_args["alpha"] == pytest.approx(1.0)
+    assert run_args["beta"] == pytest.approx(2.0)
+    assert run_args["kappa"] == pytest.approx(1.0)
+    assert run_args["jitter"] == pytest.approx(0.25)
+    assert run_args["symmetrize"] is False
+    assert ki._debug_info is not None
+    assert ki._debug_info.meas_addr == 123
+    assert np.array_equal(ki._debug_info.z0, np.array([0.2, 0.3, 0.0, 0.0]))
+    assert np.array_equal(ki._debug_info.hx, ki.model.policy.p)
+    assert np.array_equal(ki._debug_info.gx, ki.model.policy.f)
+    assert ki._debug_info.alpha == pytest.approx(1.0)
+
+
+def test_filter_unscented_rejects_return_shocks_and_bad_x0():
+    ki = KalmanInterface(
+        model=_make_stub_model(),
+        observables=["ObsA"],
+        y=np.array([[1.0], [2.0]], dtype=FLOAT),
+        filter_mode="unscented",
+        meas_addr=123,
+        calib_params=np.array([0.5], dtype=FLOAT),
+        return_shocks=True,
+    )
+    with pytest.raises(ValueError, match="return_shocks is not supported"):
+        ki.filter()
+
+    ki.return_shocks = False
+    with pytest.raises(ValueError, match="x0 must have length"):
+        ki.filter(x0=np.array([1.0], dtype=FLOAT))
 
 
 def test_ml_estimate_r_diag_success_path(monkeypatch):


### PR DESCRIPTION
This pull request adds support for the Unscented Kalman Filter (UKF) to the codebase, including both the native C extension and Python interfaces. It introduces a new `ukf_hot_loop` implementation, updates the API to allow selecting the UKF, and adds a corresponding result data class. The changes are grouped below by theme.

**Native UKF implementation:**

* Added `ukf_hot_loop` C function and corresponding structs (`ukf_inputs`, `ukf_outputs`) to `kalman.h`, and exposed these in the Cython wrapper (`_kalman.pyx` and `_kalman.pyi`). This enables running a second-order UKF natively. [[1]](diffhunk://#diff-39f52ac5c48b83d9f956a00ff1e79b1d6fd779aacd15f1e11de06d187471fbc7R118-R178) [[2]](diffhunk://#diff-52b2ef7eb2292f88b0925a738af711fc83686e0ed611dd81008d7256a88b54e5R56-R118) [[3]](diffhunk://#diff-52b2ef7eb2292f88b0925a738af711fc83686e0ed611dd81008d7256a88b54e5R232-R415) [[4]](diffhunk://#diff-9a3a98cb82b544e3c52b216705074953dc39393bb9a20818aab220b2bce55682R38-R81)
* Registered the new `ukf_hot_loop` in the Python package init file for import.

**Python interface and API:**

* Updated the `solved_model.py` Kalman interface to support a new `filter_mode="unscented"` option, which triggers the UKF path and disables unsupported options. [[1]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL758-R758) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL771-R771) [[3]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadR780-R802) [[4]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadR812)
* Added the `UnscentedFilterResult` dataclass to encapsulate UKF outputs, and updated the filter module to import and expose the new native function. [[1]](diffhunk://#diff-2183be9b4e88fbfb07eaafef8b9d1953d6764902954b2ad7b5bebfbbf26698dfR101-R131) [[2]](diffhunk://#diff-4ac494e8a6b5ac8b433896a1c6df329142512a54414629d8189f27459e7e6dadL40-R40) [[3]](diffhunk://#diff-2183be9b4e88fbfb07eaafef8b9d1953d6764902954b2ad7b5bebfbbf26698dfR42-R79)

**Miscellaneous improvements:**

* Improved error checking, shape validation, and result handling in the new UKF code path.

These changes collectively enable efficient, native Unscented Kalman Filtering for second-order models.

closes #277 