### PR TITLE
Guard JB stat for non-finite inputs; improve MC source UI

### DIFF
--- a/SymbolicDSGE/_ckernels/diag/diag.c
+++ b/SymbolicDSGE/_ckernels/diag/diag.c
@@ -503,7 +503,10 @@ int sdsge_jb_stat(const f64 *SDSGE_RESTRICT x, i64 n, f64 *SDSGE_RESTRICT out) {
   m3 /= (f64)n;
   m4 /= (f64)n;
 
-  if (m2 <= 0.0) {
+  /* A non-finite m2 means the input carried NaN/inf (e.g. log of a non-positive
+   * value upstream); `m2 <= 0.0` alone can't catch it since every NaN comparison
+   * is false, so it would otherwise fall through to an OK/NaN statistic. */
+  if (!isfinite(m2) || m2 <= 0.0) {
     *out = NAN;
     return DIAG_UDEF_VARIANCE;
   }

--- a/SymbolicDSGE/_diag_tests/jarque_bera.py
+++ b/SymbolicDSGE/_diag_tests/jarque_bera.py
@@ -50,7 +50,10 @@ def jb_stat(x: NDF) -> tuple[int, float64]:
     m3 /= n
     m4 /= n
 
-    if m2 <= 0.0:
+    # A non-finite m2 means the input carried NaN/inf (e.g. log of a non-positive
+    # value upstream). `m2 <= 0.0` alone can't catch it: every comparison with NaN
+    # is False, so a NaN would otherwise slip through to an OK/NaN statistic.
+    if not np.isfinite(m2) or m2 <= 0.0:
         return UDEF_VARIANCE, float64(np.nan)
 
     skew = m3 / m2**1.5

--- a/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
+++ b/sdsge-ui/frontend/src/mc/MCPipelineView.tsx
@@ -61,7 +61,7 @@ import {
   saveMCWorkspace,
 } from "./persistence";
 import type { MCPersistedWorkspace } from "./persistence";
-import type { MCFlowNode } from "./types";
+import type { MCFlowNode, MCProducer } from "./types";
 
 const nodeTypes = { mcStep: StepNode };
 
@@ -191,11 +191,24 @@ function MCPipelineBuilder({
   }, [setEdges, setNodes]);
 
   const selectedNode = nodes.find((node) => node.id === selectedId) ?? null;
-  // Every transform/custom step produces a payload addressable by its name — the
-  // registry a consumer picks from when a leg reads "payload".
-  const payloadProducers = nodes
-    .filter((node) => node.data.catalog.category === "transforms")
-    .map((node) => node.data.name);
+  // A step may only read from its graph ancestors — producers reachable by
+  // walking edges backward — so the flow arrows actually gate the source
+  // dropdown. Without this, a step wired to one transform could still pick an
+  // unrelated branch. Terminals (tests/regressions/postprocs) can't be sources.
+  const ancestorIds = useMemo(
+    () =>
+      selectedId === null
+        ? new Set<string>()
+        : collectAncestorIds(selectedId, edges),
+    [selectedId, edges],
+  );
+  const producers: MCProducer[] = nodes
+    .filter((node) => ancestorIds.has(node.id))
+    .map((node) => {
+      const kind = sourceProducerKind(node);
+      return kind === null ? null : { name: node.data.name, kind };
+    })
+    .filter((entry): entry is MCProducer => entry !== null);
   const pipeline = useMemo(() => toPipelineSpec(nodes, edges), [nodes, edges]);
 
   // The producible across-rep traces a POSTPROC op can consume. Refreshed from
@@ -519,7 +532,7 @@ function MCPipelineBuilder({
           onChange={updateNode}
           onDelete={deleteNode}
           theme={theme}
-          payloadProducers={payloadProducers}
+          producers={producers}
           availableTraces={availableTraces}
           exogByRole={exogByRole}
         />
@@ -659,6 +672,39 @@ function producerKind(stepType: string | undefined): string {
   if (stepType === "simulation" || stepType === "raw_model_data") return "datagen";
   if (stepType === "filter") return "filter";
   return "transform";
+}
+
+// The source-leg producer kind of a node, or null when it can't be a source
+// (tests/regressions/postprocs). Unlike `producerKind`, this distinguishes
+// non-producers rather than defaulting them to "transform".
+function sourceProducerKind(node: MCFlowNode): MCProducer["kind"] | null {
+  const stepType: string = node.data.stepType;
+  if (stepType === "simulation" || stepType === "raw_model_data") return "datagen";
+  if (stepType === "filter") return "filter";
+  if (node.data.catalog.category === "transforms") return "transform";
+  return null;
+}
+
+// Node ids reachable by walking edges backward from `nodeId` (its ancestors) —
+// the only producers a step may legally read from. The filter's implicit read of
+// the datagen still comes through as an edge on the canvas, so a test wired to
+// the filter sees both the filter and the datagen behind it.
+function collectAncestorIds(nodeId: string, edges: Edge[]): Set<string> {
+  const parentsByTarget = new Map<string, string[]>();
+  for (const edge of edges) {
+    const parents = parentsByTarget.get(edge.target);
+    if (parents) parents.push(edge.source);
+    else parentsByTarget.set(edge.target, [edge.source]);
+  }
+  const ancestors = new Set<string>();
+  const stack = [...(parentsByTarget.get(nodeId) ?? [])];
+  while (stack.length > 0) {
+    const current = stack.pop() as string;
+    if (ancestors.has(current)) continue;
+    ancestors.add(current);
+    for (const parent of parentsByTarget.get(current) ?? []) stack.push(parent);
+  }
+  return ancestors;
 }
 
 function producerColor(stepType: string | undefined): string {

--- a/sdsge-ui/frontend/src/mc/StepInspector.tsx
+++ b/sdsge-ui/frontend/src/mc/StepInspector.tsx
@@ -1,7 +1,7 @@
 import Editor from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { Check, Plus, TriangleAlert, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { validateCustomOp } from "../api";
 import { registerPythonLsp } from "../lsp/registerPythonLsp";
 import type {
@@ -11,34 +11,43 @@ import type {
   ShockDistribution,
   ShockRegistryEntry,
 } from "../types";
-import type { MCFlowNode } from "./types";
+import type { MCFlowNode, MCProducer } from "./types";
 
-// Input legs whose value is a dependency source (a "select" with INPUT_SOURCES
-// options). A leg set to "payload" reads a producer's output by key.
-const SOURCE_LEG_KEYS = new Set([
-  "source",
-  "residual_source",
-  "y_source",
-  "X_source",
-  "x_source",
-]);
+// The two data-step channels; every other catalog source-field option is a
+// filter channel. A transform producer instead exposes a single "payload".
+const DATA_CHANNELS = ["states", "observables"];
 
-// Source leg -> the param naming that leg's payload producer (mirrors the
-// backend's _LEG_TO_PAYLOAD_KEY).
-const LEG_PAYLOAD_KEY: Record<string, string> = {
-  source: "payload_key",
-  residual_source: "residual_payload_key",
-  y_source: "y_payload_key",
-  X_source: "x_payload_key",
-  x_source: "x_payload_key",
-};
+// A binding's source field key: `source` or a `<leg>_source`. Its channel
+// select follows immediately in the catalog (`field` / `<leg>_field`), then an
+// optional columns list.
+function isSourceKey(key: string): boolean {
+  return key === "source" || key.endsWith("_source");
+}
+
+// The channels a consumer may read from a producer of the given kind. Driven by
+// the catalog's own source-field options (INPUT_SOURCES) so the filter channel
+// set can't drift, with "payload" added for transform producers.
+function channelOptionsFor(
+  kind: MCProducer["kind"] | undefined,
+  catalogOptions: string[],
+): string[] {
+  if (kind === "datagen") {
+    return catalogOptions.filter((option) => DATA_CHANNELS.includes(option));
+  }
+  if (kind === "filter") {
+    return catalogOptions.filter((option) => !DATA_CHANNELS.includes(option));
+  }
+  if (kind === "transform") return ["payload"];
+  // No producer selected yet: offer everything so the field stays editable.
+  return [...catalogOptions, "payload"];
+}
 
 export function StepInspector({
   node,
   onChange,
   onDelete,
   theme,
-  payloadProducers,
+  producers,
   availableTraces,
   exogByRole,
 }: {
@@ -46,7 +55,7 @@ export function StepInspector({
   onChange: (node: MCFlowNode) => void;
   onDelete: (id: string) => void;
   theme: "light" | "dark";
-  payloadProducers: string[];
+  producers: MCProducer[];
   availableTraces: string[];
   exogByRole: Record<Role, string[]>;
 }) {
@@ -68,6 +77,18 @@ export function StepInspector({
     });
   };
 
+  // Apply several param changes in one node update (a source-leg change may set
+  // both the producer and its channel together).
+  const updateParams = (patch: Record<string, unknown>) => {
+    onChange({
+      ...node,
+      data: {
+        ...node.data,
+        params: { ...node.data.params, ...patch },
+      },
+    });
+  };
+
   // Writing the registry replaces any bundle-serialized `shocks` map so the
   // backend compiles from the user's explicit entries, not a stale compiled form.
   const setRegistry = (entries: ShockRegistryEntry[]) => {
@@ -82,7 +103,60 @@ export function StepInspector({
   const isCustom =
     node.data.stepType === "transform:custom" ||
     node.data.stepType === "postproc:custom";
-  const producers = payloadProducers.filter((name) => name !== node.data.name);
+
+  // Render the step's fields, folding each source binding (a `<leg>_source`
+  // text field, its `<leg>_field` channel select, and an optional columns list)
+  // into a single source-leg widget. The catalog emits those three
+  // consecutively, so we consume them together and render the rest generically.
+  const step = node;
+  const renderFields = (fields: MCFieldSpec[]): ReactNode[] => {
+    const items: ReactNode[] = [];
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const key = `${step.id}:${field.key}`;
+      if (field.type === "shock_registry") {
+        const targetRole = String(step.data.params.target ?? "dgp") as Role;
+        items.push(
+          <ShockRegistryEditor
+            key={key}
+            target={targetRole}
+            exogVars={exogByRole[targetRole] ?? []}
+            entries={registryFromParams(step.data.params)}
+            onChange={setRegistry}
+          />,
+        );
+        continue;
+      }
+      const channel = fields[i + 1];
+      if (isSourceKey(field.key) && field.type === "text" && channel?.type === "select") {
+        const columns = fields[i + 2];
+        const hasColumns = columns?.type === "number_list";
+        items.push(
+          <SourceLeg
+            key={key}
+            sourceField={field}
+            channelField={channel}
+            columnsField={hasColumns ? columns : undefined}
+            params={step.data.params}
+            producers={producers}
+            onUpdate={updateParams}
+          />,
+        );
+        i += hasColumns ? 2 : 1;
+        continue;
+      }
+      items.push(
+        <FieldEditor
+          key={key}
+          field={field}
+          value={step.data.params[field.key] ?? field.default}
+          availableTraces={availableTraces}
+          onChange={(value) => updateParam(field.key, value)}
+        />,
+      );
+    }
+    return items;
+  };
 
   return (
     <div className="mc-inspector">
@@ -121,48 +195,11 @@ export function StepInspector({
         />
       ) : (
         <div className="mc-inspector-fields">
-          {node.data.catalog.fields
-            .filter((field) => fieldVisible(field, node.data.params))
-            .map((field) => {
-              const key = `${node.id}:${field.key}`;
-              if (field.type === "shock_registry") {
-                const targetRole = String(
-                  node.data.params.target ?? "dgp",
-                ) as Role;
-                return (
-                  <ShockRegistryEditor
-                    key={key}
-                    target={targetRole}
-                    exogVars={exogByRole[targetRole] ?? []}
-                    entries={registryFromParams(node.data.params)}
-                    onChange={setRegistry}
-                  />
-                );
-              }
-              if (field.type === "select" && SOURCE_LEG_KEYS.has(field.key)) {
-                const payloadKey = LEG_PAYLOAD_KEY[field.key];
-                return (
-                  <SourceLegEditor
-                    key={key}
-                    field={field}
-                    channel={String(node.data.params[field.key] ?? field.default ?? "")}
-                    producer={String(node.data.params[payloadKey] ?? "")}
-                    producers={producers}
-                    onChannelChange={(value) => updateParam(field.key, value)}
-                    onProducerChange={(value) => updateParam(payloadKey, value)}
-                  />
-                );
-              }
-              return (
-                <FieldEditor
-                  key={key}
-                  field={field}
-                  value={node.data.params[field.key] ?? field.default}
-                  availableTraces={availableTraces}
-                  onChange={(value) => updateParam(field.key, value)}
-                />
-              );
-            })}
+          {renderFields(
+            node.data.catalog.fields.filter((field) =>
+              fieldVisible(field, node.data.params),
+            ),
+          )}
         </div>
       )}
     </div>
@@ -491,52 +528,86 @@ function asDist(value: unknown): ShockDistribution {
   return value === "t" || value === "uni" ? value : "norm";
 }
 
-function SourceLegEditor({
-  field,
-  channel,
-  producer,
+// One source binding: which producer step to read (a dropdown of the pipeline's
+// producers) and which of its channels (kind-aware: datagen -> states/observables,
+// filter -> filter channels, transform -> payload), plus an optional column list.
+function SourceLeg({
+  sourceField,
+  channelField,
+  columnsField,
+  params,
   producers,
-  onChannelChange,
-  onProducerChange,
+  onUpdate,
 }: {
-  field: MCFieldSpec;
-  channel: string;
-  producer: string;
-  producers: string[];
-  onChannelChange: (value: string) => void;
-  onProducerChange: (value: string) => void;
+  sourceField: MCFieldSpec;
+  channelField: MCFieldSpec;
+  columnsField?: MCFieldSpec;
+  params: Record<string, unknown>;
+  producers: MCProducer[];
+  onUpdate: (patch: Record<string, unknown>) => void;
 }) {
-  // "payload" is always selectable; picking it reveals a producer key dropdown.
-  const options = field.options.includes("payload")
-    ? field.options
-    : [...field.options, "payload"];
+  const sourceValue = String(params[sourceField.key] ?? sourceField.default ?? "");
+  const channelValue = String(params[channelField.key] ?? channelField.default ?? "");
+  const selected = producers.find((producer) => producer.name === sourceValue);
+  const channels = channelOptionsFor(selected?.kind, channelField.options);
+  // Keep a stale/unknown selection visible instead of silently dropping it.
+  const channelOptions =
+    channelValue && !channels.includes(channelValue)
+      ? [channelValue, ...channels]
+      : channels;
+  const producerNames = producers.map((producer) => producer.name);
+  const sourceOptions =
+    sourceValue && !producerNames.includes(sourceValue)
+      ? [sourceValue, ...producerNames]
+      : producerNames;
+
+  const onSourceChange = (value: string) => {
+    const kind = producers.find((producer) => producer.name === value)?.kind;
+    const nextChannels = channelOptionsFor(kind, channelField.options);
+    const patch: Record<string, unknown> = { [sourceField.key]: value };
+    // If the current channel isn't valid for the newly chosen producer's kind,
+    // snap it to the first valid channel so the leg stays consistent.
+    if (nextChannels.length > 0 && !nextChannels.includes(channelValue)) {
+      patch[channelField.key] = nextChannels[0];
+    }
+    onUpdate(patch);
+  };
+
   return (
     <div className="mc-source-leg">
       <label>
-        {field.label}
-        <select value={channel} onChange={(event) => onChannelChange(event.target.value)}>
-          {options.map((option) => (
+        {sourceField.label}
+        <select value={sourceValue} onChange={(event) => onSourceChange(event.target.value)}>
+          <option value="">— select step —</option>
+          {sourceOptions.map((name) => {
+            const kind = producers.find((producer) => producer.name === name)?.kind;
+            return (
+              <option key={name} value={name}>
+                {kind ? `${name} · ${kind}` : name}
+              </option>
+            );
+          })}
+        </select>
+      </label>
+      <label>
+        {channelField.label}
+        <select
+          value={channelValue}
+          onChange={(event) => onUpdate({ [channelField.key]: event.target.value })}
+        >
+          {channelOptions.map((option) => (
             <option key={option} value={option}>
               {option}
             </option>
           ))}
         </select>
       </label>
-      {channel === "payload" && (
-        <label className="mc-payload-producer">
-          Payload from
-          <select
-            value={producer}
-            onChange={(event) => onProducerChange(event.target.value)}
-          >
-            <option value="">— select producer —</option>
-            {producers.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </select>
-        </label>
+      {columnsField && (
+        <DraftListEditor
+          field={columnsField}
+          value={params[columnsField.key] ?? columnsField.default}
+          onChange={(value) => onUpdate({ [columnsField.key]: value })}
+        />
       )}
     </div>
   );

--- a/sdsge-ui/frontend/src/mc/types.ts
+++ b/sdsge-ui/frontend/src/mc/types.ts
@@ -9,3 +9,11 @@ export interface MCNodeData extends Record<string, unknown> {
 }
 
 export type MCFlowNode = Node<MCNodeData, "mcStep">;
+
+// A step a source leg may read from. `kind` picks the channels the consumer can
+// select: datagen -> states/observables, filter -> filter channels, transform ->
+// payload (mirrors the backend's producer op-type / field compatibility).
+export interface MCProducer {
+  name: string;
+  kind: "datagen" | "filter" | "transform";
+}

--- a/sdsge-ui/frontend/src/styles.css
+++ b/sdsge-ui/frontend/src/styles.css
@@ -2624,6 +2624,15 @@ button.mc-palette-tab.active .mc-palette-tab-count {
   color: #c7d2fe;
 }
 
+/* A shock entry is a transparent clickable row, not a CTA. Keep the generic
+   dark `button` background (a light fill) off it so its own entry background
+   shows and the light entry text keeps its contrast. */
+.theme-dark button.mc-shock-entry-select,
+.theme-dark button.mc-shock-entry-select:disabled {
+  background: transparent;
+  color: inherit;
+}
+
 .theme-dark .mc-summary-tabs button {
   background: transparent;
   color: #94a3b8;

--- a/tests/ckernels/test_diag.py
+++ b/tests/ckernels/test_diag.py
@@ -380,3 +380,18 @@ def test_jb_stat_status_paths():
             assert np.isnan(nstat) and np.isnan(rstat)
         else:
             assert np.isclose(nstat, rstat, rtol=RTOL, atol=ATOL)
+
+
+def test_jb_stat_non_finite_input_reports_undefined_variance():
+    """A NaN/inf in the series (e.g. log of a non-positive value upstream) makes
+    the variance non-finite. `m2 <= 0.0` can't catch it, so both backends must
+    guard isfinite and flag UDEF_VARIANCE (-3) rather than return OK with a NaN
+    statistic."""
+    base = np.linspace(-2.0, 2.0, 50, dtype=np.float64)
+    for bad in (np.nan, np.inf, -np.inf):
+        x = np.ascontiguousarray(base.copy())
+        x[3] = bad
+        ns, nstat = diag.jb_stat(x)
+        rs, rstat = jit_jb_stat(x)
+        assert ns == rs == -3
+        assert np.isnan(nstat) and np.isnan(rstat)

--- a/tests/diag_tests/test_jarque_bera.py
+++ b/tests/diag_tests/test_jarque_bera.py
@@ -33,6 +33,30 @@ def test_jb_stat_handles_empty_input() -> None:
     assert np.isnan(statistic)
 
 
+def test_jb_stat_rejects_non_finite_input() -> None:
+    # A NaN/inf in the series (e.g. log of a non-positive value upstream) makes
+    # the variance non-finite. `m2 <= 0.0` alone can't catch it -- every NaN
+    # comparison is False -- so the kernel must guard isfinite rather than fall
+    # through to an OK result carrying a NaN statistic.
+    base = np.linspace(-2.0, 2.0, 50, dtype=np.float64)
+    for bad in (np.nan, np.inf, -np.inf):
+        x = base.copy()
+        x[3] = bad
+        status, statistic = jb_stat(x)
+        assert status == TestStatus.UDEF_VARIANCE
+        assert np.isnan(statistic)
+
+
+def test_jarque_bera_flags_non_finite_series_instead_of_ok() -> None:
+    x = np.linspace(-2.0, 2.0, 100, dtype=np.float64)
+    x[10] = np.nan
+
+    out = jarque_bera(x)
+
+    assert out.status is TestStatus.UDEF_VARIANCE
+    assert np.isnan(out.statistic)
+
+
 def test_jarque_bera_returns_lookup_backed_test_result() -> None:
     x = np.linspace(-2.0, 2.0, 100, dtype=np.float64)
 


### PR DESCRIPTION
Treat a non-finite second moment as undefined variance in the Jarque–Bera kernel and Python reference: check isfinite(m2) before accepting m2 > 0. Added tests to assert NaN/Inf in the series yields UDEF_VARIANCE and NaN statistic (C kernel and Python tests). Frontend: made MC pipeline source selection aware of producer kinds, ancestor-restricted producers, richer source-leg UI (channel options per producer kind, combined source/channel/columns editor), added MCProducer type, and a small dark-theme CSS tweak.

closes #292 