### PR TITLE
Document TANH prior transform and Q/R estimation

### DIFF
--- a/docs/documentation/prior_spec/Prior.md
+++ b/docs/documentation/prior_spec/Prior.md
@@ -77,6 +77,7 @@ Dispatched `transform` values accepted by `make_prior(...)`:
 | `AFFINE_PROBIT` | `"affine_probit"` | `low`, `high` |
 | `LOWER_BOUNDED` | `"lower_bounded"` | `low` |
 | `UPPER_BOUNDED` | `"upper_bounded"` | `high` |
+| `TANH` | `"tanh"` | none |
 
 Additional `TransformMethod` enum members currently not dispatched by `make_prior(...)`:
 

--- a/docs/documentation/prior_spec/transforms/tanh.md
+++ b/docs/documentation/prior_spec/transforms/tanh.md
@@ -1,0 +1,19 @@
+---
+tags:
+    - doc
+---
+# Tanh
+
+Correlation-space transform mapping the open interval $(-1, 1)$ to unconstrained space. Used for standalone correlation parameters, such as an isolated off-diagonal entry of a `Q` or `R` matrix.
+
+### Parameters
+This transform has no parameters.
+
+### Transformation
+$$
+x \in (-1,1) \mapsto y = \tanh^{-1}(x) \in \mathbb{R}
+$$
+
+$$
+y \in \mathbb{R} \mapsto x = \tanh(y) \in (-1,1)
+$$

--- a/docs/guides/estimation_guide.md
+++ b/docs/guides/estimation_guide.md
@@ -266,6 +266,9 @@ res.logpost_trace_plot() # (1)!
     - `MAP`: MAP is similar to MLE in the sense that it returns a single set of parameters maximizing a given objective. However, MAP has prior beliefs in the objective function. Therefore, the maximization yields a result both respecting the plain likelihood and our beliefs regarding parameters.
     - `MCMC`: MCMC is a sampling method aimed to generate a posterior distribution using our prior beliefs and the likelihood. Effectively, MCMC samples multiple parameter sets sampled with respect to priors and computes their likelihood. In this case, we no longer have a maximization problem; we create a sampled distribution and use a point in said distribution as the parameters. This approach often yields more stable parameter compositions and allows more freedom regarding exactly which "point" to select as the parameters.
 
+???+ warning "Estimating Components of Symmetric Positice Definite Matrices"
+    The model and kalman config provides two covariance matrices specified with parameters for standard deviations and the correlation coefficients. These are `Q` and `R` explaining the covariance of shocks and measurement noise respectively. To ensure estimation of any component in these matrices yields a valid covariance matrix, there's logic implemented around estimation to transform these variables. It is recommended to estimate the correlation block of these marices together using the reserved estimation keys: `<R/Q>_corr`. Standard deviations are estimated as scalars and in cases where they lack a prior, the estimation defaults to a log transform ensuring positivity.
+
 ## Further Steps
 
 More detailed information regarding estimation can be found via the references. Alternatively you can refer to [this](../assets/guide_notebook.ipynb) example notebook to see parameter estimation workflow used when generating the outputs for this guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,7 @@ nav:
               - AffineProbit: documentation/prior_spec/transforms/affine_probit.md
               - LowerBounded: documentation/prior_spec/transforms/lower_bounded.md
               - UpperBounded: documentation/prior_spec/transforms/upper_bounded.md
+              - Tanh: documentation/prior_spec/transforms/tanh.md
       - Utilities:
           - FRED: documentation/utilities/FRED.md
           - KalmanFilter: documentation/utilities/KalmanFilter.md


### PR DESCRIPTION
Adds documentation for the `TANH` transform used for correlation-space parameters, including a dedicated transform page, inclusion in the prior transform list, and navigation wiring in `mkdocs.yml`. Also expands the estimation guide with a warning about estimating covariance-matrix components (`Q`/`R`), recommending grouped correlation estimation via `<R/Q>_corr` and noting positivity handling for standard deviations.

closes #324 