### PR TITLE
Add native Nelder-Mead optimizer driver

### DIFF
--- a/SymbolicDSGE/_ckernels/optim/_optim.pyi
+++ b/SymbolicDSGE/_ckernels/optim/_optim.pyi
@@ -1,0 +1,45 @@
+from numpy import float64
+from numpy.typing import NDArray
+
+from typing import Sequence, TypedDict
+
+_F64 = NDArray[float64]
+_Bound = tuple[float | None, float | None]
+
+class OptimResult(TypedDict):
+    x: _F64
+    fun: float
+    nfev: int
+    nit: int
+    success: bool
+    status: int
+    message: str
+
+# Native optimizer drivers over the synthetic benchmark objectives
+# ("rosenbrock", "quad", "double_well", "rosen_halfplane"). ``bounds`` is None
+# (unbounded) or a length-n sequence of (lo, hi) with None for a missing side;
+# ``params`` feeds the parametrized objectives (e.g. "quad").
+
+def run_lbfgsb(
+    objective: str,
+    x0: _F64,
+    bounds: Sequence[_Bound] | None = ...,
+    params: _F64 | None = ...,
+    m: int = ...,
+    maxiter: int = ...,
+    maxfun: int = ...,
+    maxls: int = ...,
+    factr: float = ...,
+    pgtol: float = ...,
+    fd_step: float = ...,
+) -> OptimResult: ...
+def run_neldermead(
+    objective: str,
+    x0: _F64,
+    bounds: Sequence[_Bound] | None = ...,
+    params: _F64 | None = ...,
+    maxiter: int = ...,
+    maxfun: int = ...,
+    xatol: float = ...,
+    fatol: float = ...,
+) -> OptimResult: ...

--- a/SymbolicDSGE/_ckernels/optim/_optim.pyx
+++ b/SymbolicDSGE/_ckernels/optim/_optim.pyx
@@ -8,6 +8,7 @@ point for the scipy parity tests; the estimation objective wires in separately
 (issue #330).
 """
 
+from libc.math cimport INFINITY
 from libc.stdint cimport int64_t
 
 import numpy as np
@@ -37,6 +38,28 @@ cdef extern from "optim.h":
                          double *x, const double *lo, const double *hi,
                          const int64_t *nbd, const sdsge_lbfgsb_options *opt,
                          sdsge_lbfgsb_result *out) nogil
+
+
+cdef extern from "nelder_mead.h":
+    ctypedef struct sdsge_neldermead_options:
+        int64_t maxiter
+        int64_t maxfun
+        double xatol
+        double fatol
+
+    ctypedef struct sdsge_neldermead_result:
+        int64_t status
+        int64_t nfev
+        int64_t nit
+        double fun
+        int success
+        const char *message
+
+    int64_t sdsge_neldermead(sdsge_objective_fn obj, void *obj_ctx, int64_t n,
+                             double *x, const double *lo, const double *hi,
+                             const int64_t *nbd,
+                             const sdsge_neldermead_options *opt,
+                             sdsge_neldermead_result *out) nogil
 
 
 # --- Benchmark objectives (match sdsge_objective_fn) --------------------------
@@ -80,6 +103,16 @@ cdef double _obj_double_well(const double *x, void *ctx) noexcept nogil:
     return s
 
 
+cdef double _obj_rosen_halfplane(const double *x, void *ctx) noexcept nogil:
+    # Rosenbrock restricted to the feasible half-plane x[0] >= 0; +inf outside.
+    # Models a BK-violation boundary: the optimizer must tolerate +inf returns
+    # and keep searching from the feasible vertices. The minimum (all-ones) is
+    # feasible.
+    if x[0] < 0.0:
+        return INFINITY
+    return _obj_rosenbrock(x, ctx)
+
+
 cdef sdsge_objective_fn _objective(str name) except NULL:
     if name == "rosenbrock":
         return _obj_rosenbrock
@@ -87,6 +120,8 @@ cdef sdsge_objective_fn _objective(str name) except NULL:
         return _obj_quad
     if name == "double_well":
         return _obj_double_well
+    if name == "rosen_halfplane":
+        return _obj_rosen_halfplane
     raise ValueError(f"unknown objective {name!r}")
 
 
@@ -153,6 +188,76 @@ def run_lbfgsb(
     with nogil:
         sdsge_lbfgsb(obj, <void *>&ctx, n, &xv[0], &lo[0], &hi[0], nbd_ptr,
                      &opt, &res)
+
+    return {
+        "x": x,
+        "fun": res.fun,
+        "nfev": int(res.nfev),
+        "nit": int(res.nit),
+        "success": bool(res.success),
+        "status": int(res.status),
+        "message": (<bytes>res.message).decode() if res.message != NULL else "",
+    }
+
+
+def run_neldermead(
+    str objective,
+    double[::1] x0,
+    bounds=None,
+    object params=None,
+    int maxiter=0,
+    int maxfun=0,
+    double xatol=1e-4,
+    double fatol=1e-4,
+):
+    """Minimize a benchmark objective with native Nelder-Mead. ``bounds`` is None
+    (unbounded) or a length-n list of (lo, hi) with None for a missing side.
+    ``params`` feeds the parametrized objectives (``quad``). ``maxiter``/``maxfun``
+    of 0 default to ``N*200`` (scipy's rule). Returns a result dict mirroring the
+    lean native struct."""
+    cdef int64_t n = x0.shape[0]
+    x = np.array(x0, dtype=np.float64, copy=True)
+    cdef double[::1] xv = x
+
+    cdef double[::1] pv
+    cdef ObjCtx ctx
+    ctx.n = n
+    ctx.p = NULL
+    if params is not None:
+        pv = np.ascontiguousarray(params, dtype=np.float64)
+        ctx.p = &pv[0]
+
+    # Bounds -> lo/hi/nbd (scipy map: none=0, lower=1, both=2, upper=3).
+    cdef double[::1] lo = np.zeros(n, dtype=np.float64)
+    cdef double[::1] hi = np.zeros(n, dtype=np.float64)
+    cdef int64_t[::1] nbd = np.zeros(n, dtype=np.int64)
+    cdef int has_bounds = bounds is not None
+    cdef int i
+    if has_bounds:
+        for i in range(n):
+            lb, ub = bounds[i]
+            has_lo = lb is not None
+            has_hi = ub is not None
+            if has_lo:
+                lo[i] = lb
+            if has_hi:
+                hi[i] = ub
+            nbd[i] = (2 if has_hi else 1) if has_lo else (3 if has_hi else 0)
+
+    cdef sdsge_objective_fn obj = _objective(objective)
+
+    cdef sdsge_neldermead_options opt
+    opt.maxiter = maxiter
+    opt.maxfun = maxfun
+    opt.xatol = xatol
+    opt.fatol = fatol
+
+    cdef sdsge_neldermead_result res
+    cdef const int64_t *nbd_ptr = &nbd[0] if has_bounds else NULL
+
+    with nogil:
+        sdsge_neldermead(obj, <void *>&ctx, n, &xv[0], &lo[0], &hi[0], nbd_ptr,
+                         &opt, &res)
 
     return {
         "x": x,

--- a/SymbolicDSGE/_ckernels/optim/nelder_mead.c
+++ b/SymbolicDSGE/_ckernels/optim/nelder_mead.c
@@ -1,0 +1,333 @@
+#include "nelder_mead.h"
+
+#include <math.h>   /* fabs, isfinite, INFINITY, NAN */
+#include <stdlib.h> /* malloc, free */
+#include <string.h> /* memcpy */
+
+/* scipy `_status_message` equivalents (scipy/optimize/_optimize.py). */
+static const char *const MSG_SUCCESS = "Optimization terminated successfully.";
+static const char *const MSG_MAXFEV =
+    "Maximum number of function evaluations has been exceeded.";
+static const char *const MSG_MAXITER =
+    "Maximum number of iterations has been exceeded.";
+
+/* np.clip(v, lb, ub) elementwise, matching scipy's per-trial-point clip. Only
+ * called when bounds are active; lb/ub carry -/+INFINITY on absent sides, so an
+ * unbounded coordinate is a no-op. */
+static inline void nm_clip(f64 *SDSGE_RESTRICT v, const f64 *lb, const f64 *ub,
+                           i64 n) {
+  for (i64 i = 0; i < n; ++i) {
+    if (v[i] < lb[i]) {
+      v[i] = lb[i];
+    } else if (v[i] > ub[i]) {
+      v[i] = ub[i];
+    }
+  }
+}
+
+/* Stable insertion sort of the simplex rows + fsim by ascending fsim. scipy
+ * re-sorts with np.argsort (introsort, not stable) every iteration, so tie
+ * order is not reproducible across implementations; this uses a stable sort and
+ * parity is asserted within tolerance, never on the trajectory. +inf entries
+ * (infeasible / not-yet-evaluated vertices) compare greatest and rank last,
+ * which is exactly scipy's ordering for them. Only inversions are moved, so a
+ * near-sorted simplex (one replaced worst vertex) costs O(N). */
+static void nm_sort(f64 *sim, f64 *fsim, i64 np1, i64 n, f64 *tmprow) {
+  for (i64 i = 1; i < np1; ++i) {
+    const f64 key = fsim[i];
+    memcpy(tmprow, sim + i * n, (size_t)n * sizeof(f64));
+    i64 j = i - 1;
+    while (j >= 0 && fsim[j] > key) {
+      fsim[j + 1] = fsim[j];
+      memcpy(sim + (j + 1) * n, sim + j * n, (size_t)n * sizeof(f64));
+      --j;
+    }
+    fsim[j + 1] = key;
+    memcpy(sim + (j + 1) * n, tmprow, (size_t)n * sizeof(f64));
+  }
+}
+
+static void nm_fill_error(sdsge_neldermead_result *out, i64 status,
+                          const char *message) {
+  if (out) {
+    out->status = status;
+    out->nfev = 0;
+    out->nit = 0;
+    out->fun = NAN;
+    out->success = 0;
+    out->message = message;
+  }
+}
+
+i64 sdsge_neldermead(sdsge_objective_fn obj, void *obj_ctx, i64 n,
+                     f64 *SDSGE_RESTRICT x, const f64 *lo, const f64 *hi,
+                     const i64 *nbd, const sdsge_neldermead_options *opt,
+                     sdsge_neldermead_result *out) {
+  if (n < 1) {
+    nm_fill_error(out, SDSGE_OPTIM_EINVAL, "ERROR: n must be >= 1");
+    return SDSGE_OPTIM_EINVAL;
+  }
+
+  const i64 N = n;
+  const i64 np1 = N + 1;
+  const int has_bounds = (nbd != NULL);
+
+  /* scipy defaults maxiter = maxfun = N*200 when unset. */
+  const i64 maxiter = opt->maxiter > 0 ? opt->maxiter : N * 200;
+  const i64 maxfun = opt->maxfun > 0 ? opt->maxfun : N * 200;
+  const f64 xatol = opt->xatol;
+  const f64 fatol = opt->fatol;
+
+  /* Standard Nelder-Mead coefficients (non-adaptive branch of scipy). */
+  const f64 rho = 1.0, chi = 2.0, psi = 0.5, sigma = 0.5;
+  const f64 nonzdelt = 0.05, zdelt = 0.00025;
+
+  /* One workspace allocation; the eval loop allocates nothing. Layout:
+   * sim[(N+1)*N] | fsim[N+1] | xbar[N] | xr[N] | xt[N] | lb[N] | ub[N] |
+   * tmprow[N]. */
+  const size_t nd = (size_t)N;
+  const size_t total = (size_t)np1 * nd + (size_t)np1 + nd * 6;
+  f64 *buf = (f64 *)malloc(total * sizeof(f64));
+  if (!buf) {
+    nm_fill_error(out, SDSGE_OPTIM_EALLOC,
+                  "ERROR: workspace allocation failed");
+    return SDSGE_OPTIM_EALLOC;
+  }
+
+  f64 *sim = buf;
+  f64 *fsim = sim + (size_t)np1 * nd;
+  f64 *xbar = fsim + (size_t)np1;
+  f64 *xr = xbar + nd;
+  f64 *xt = xr + nd;
+  f64 *lb = xt + nd;
+  f64 *ub = lb + nd;
+  f64 *tmprow = ub + nd;
+
+  if (has_bounds) {
+    for (i64 i = 0; i < N; ++i) {
+      const i64 b = nbd[i];
+      lb[i] = (b == 1 || b == 2) ? lo[i] : -INFINITY;
+      ub[i] = (b == 2 || b == 3) ? hi[i] : INFINITY;
+    }
+  }
+
+  /* Initial simplex: sim[0] = clip(x0); each sim[k+1] perturbs coordinate k of
+   * the (clipped) x0 by nonzdelt (relative) or zdelt (when the coordinate is
+   * exactly zero). */
+  memcpy(sim, x, nd * sizeof(f64));
+  if (has_bounds) {
+    nm_clip(sim, lb, ub, N);
+  }
+  for (i64 k = 0; k < N; ++k) {
+    f64 *row = sim + (size_t)(k + 1) * nd;
+    memcpy(row, sim, nd * sizeof(f64));
+    const f64 yk = row[k];
+    row[k] = (yk != 0.0) ? (1.0 + nonzdelt) * yk : zdelt;
+  }
+  /* Reflect-then-clip the whole simplex into the box: if x0 sits near an upper
+   * bound the step can push every vertex past it, so reflect those back before
+   * clipping to avoid a degenerate (all-clamped) simplex. Unbounded sides carry
+   * +/-INFINITY, so the reflect/clip is a no-op there. */
+  if (has_bounds) {
+    for (i64 r = 0; r < np1; ++r) {
+      f64 *row = sim + (size_t)r * nd;
+      for (i64 j = 0; j < N; ++j) {
+        f64 s = row[j];
+        if (s > ub[j]) {
+          s = 2.0 * ub[j] - s;
+        }
+        if (s < lb[j]) {
+          s = lb[j];
+        } else if (s > ub[j]) {
+          s = ub[j];
+        }
+        row[j] = s;
+      }
+    }
+  }
+
+  i64 nfev = 0;
+  for (i64 k = 0; k < np1; ++k) {
+    fsim[k] = INFINITY;
+  }
+  for (i64 k = 0; k < np1; ++k) {
+    if (nfev >= maxfun) {
+      break;
+    }
+    fsim[k] = obj(sim + (size_t)k * nd, obj_ctx);
+    ++nfev;
+  }
+  nm_sort(sim, fsim, np1, N, tmprow);
+
+  i64 nit = 1;
+
+  while (nfev < maxfun && nit < maxiter) {
+    /* Convergence: simplex spread and objective spread both within tol. A +inf
+     * fsim entry keeps max_df at +inf, so an infeasible vertex never lets the
+     * search terminate early. The `> || isnan` form is a NaN-propagating max
+     * matching numpy's np.max: when the best vertex is itself infeasible,
+     * fsim[0]-fsim[r] is inf-inf == NaN, and a NaN spread must fail the test
+     * (scipy: `nan <= fatol` is False) rather than read as zero. */
+    f64 max_dx = 0.0, max_df = 0.0;
+    for (i64 r = 1; r < np1; ++r) {
+      const f64 *row = sim + (size_t)r * nd;
+      for (i64 j = 0; j < N; ++j) {
+        const f64 d = fabs(row[j] - sim[j]);
+        if (d > max_dx || isnan(d)) {
+          max_dx = d;
+        }
+      }
+      const f64 df = fabs(fsim[0] - fsim[r]);
+      if (df > max_df || isnan(df)) {
+        max_df = df;
+      }
+    }
+    if (max_dx <= xatol && max_df <= fatol) {
+      break;
+    }
+
+    /* Centroid of the best N vertices (excludes the worst, sim[-1]). Summed in
+     * row order to mirror numpy's add.reduce accumulation. */
+    f64 *worst = sim + (size_t)N * nd;
+    for (i64 j = 0; j < N; ++j) {
+      f64 acc = 0.0;
+      for (i64 r = 0; r < N; ++r) {
+        acc += sim[(size_t)r * nd + j];
+      }
+      xbar[j] = acc / (f64)N;
+    }
+
+    /* Reflection. */
+    for (i64 j = 0; j < N; ++j) {
+      xr[j] = (1.0 + rho) * xbar[j] - rho * worst[j];
+    }
+    if (has_bounds) {
+      nm_clip(xr, lb, ub, N);
+    }
+
+    f64 fxr = 0.0;
+    int doshrink = 0;
+    if (nfev >= maxfun) {
+      goto resort;
+    }
+    fxr = obj(xr, obj_ctx);
+    ++nfev;
+
+    if (fxr < fsim[0]) {
+      /* Expansion. */
+      for (i64 j = 0; j < N; ++j) {
+        xt[j] = (1.0 + rho * chi) * xbar[j] - rho * chi * worst[j];
+      }
+      if (has_bounds) {
+        nm_clip(xt, lb, ub, N);
+      }
+      if (nfev >= maxfun) {
+        goto resort;
+      }
+      const f64 fxe = obj(xt, obj_ctx);
+      ++nfev;
+      if (fxe < fxr) {
+        memcpy(worst, xt, nd * sizeof(f64));
+        fsim[N] = fxe;
+      } else {
+        memcpy(worst, xr, nd * sizeof(f64));
+        fsim[N] = fxr;
+      }
+    } else if (fxr < fsim[N - 1]) {
+      /* Reflection accepted (better than the second-worst). */
+      memcpy(worst, xr, nd * sizeof(f64));
+      fsim[N] = fxr;
+    } else if (fxr < fsim[N]) {
+      /* Outside contraction. */
+      for (i64 j = 0; j < N; ++j) {
+        xt[j] = (1.0 + psi * rho) * xbar[j] - psi * rho * worst[j];
+      }
+      if (has_bounds) {
+        nm_clip(xt, lb, ub, N);
+      }
+      if (nfev >= maxfun) {
+        goto resort;
+      }
+      const f64 fxc = obj(xt, obj_ctx);
+      ++nfev;
+      if (fxc <= fxr) {
+        memcpy(worst, xt, nd * sizeof(f64));
+        fsim[N] = fxc;
+      } else {
+        doshrink = 1;
+      }
+    } else {
+      /* Inside contraction. */
+      for (i64 j = 0; j < N; ++j) {
+        xt[j] = (1.0 - psi) * xbar[j] + psi * worst[j];
+      }
+      if (has_bounds) {
+        nm_clip(xt, lb, ub, N);
+      }
+      if (nfev >= maxfun) {
+        goto resort;
+      }
+      const f64 fxcc = obj(xt, obj_ctx);
+      ++nfev;
+      if (fxcc < fsim[N]) {
+        memcpy(worst, xt, nd * sizeof(f64));
+        fsim[N] = fxcc;
+      } else {
+        doshrink = 1;
+      }
+    }
+
+    if (doshrink) {
+      /* Shrink every vertex toward the best (sim[0], never moved). */
+      for (i64 r = 1; r < np1; ++r) {
+        f64 *row = sim + (size_t)r * nd;
+        for (i64 j = 0; j < N; ++j) {
+          row[j] = sim[j] + sigma * (row[j] - sim[j]);
+        }
+        if (has_bounds) {
+          nm_clip(row, lb, ub, N);
+        }
+        if (nfev >= maxfun) {
+          goto resort;
+        }
+        fsim[r] = obj(row, obj_ctx);
+        ++nfev;
+      }
+    }
+
+    ++nit;
+  resort:
+    /* Re-sort even on a mid-iteration cap (scipy sorts at the loop bottom after
+     * catching its _MaxFuncCallError), so the returned sim[0] is the true best
+     * so far. The forward goto skips the nit increment above, matching scipy's
+     * "capped iteration does not count" behavior. */
+    nm_sort(sim, fsim, np1, N, tmprow);
+  }
+
+  i64 warnflag = 0;
+  const char *msg = MSG_SUCCESS;
+  if (nfev >= maxfun) {
+    warnflag = 1;
+    msg = MSG_MAXFEV;
+  } else if (nit >= maxiter) {
+    warnflag = 2;
+    msg = MSG_MAXITER;
+  }
+
+  /* The simplex is sorted at every exit (init, loop-bottom, or convergence
+   * break after a prior sort), so sim[0]/fsim[0] are the optimum. */
+  memcpy(x, sim, nd * sizeof(f64));
+  const f64 fval = fsim[0];
+
+  if (out) {
+    out->status = warnflag;
+    out->nfev = nfev;
+    out->nit = nit;
+    out->fun = fval;
+    out->success = (warnflag == 0);
+    out->message = msg;
+  }
+
+  free(buf);
+  return warnflag;
+}

--- a/SymbolicDSGE/_ckernels/optim/nelder_mead.h
+++ b/SymbolicDSGE/_ckernels/optim/nelder_mead.h
@@ -1,0 +1,52 @@
+#ifndef SDSGE_OPTIM_NELDER_MEAD_H
+#define SDSGE_OPTIM_NELDER_MEAD_H
+
+#include "../_common/sdsge_common.h" /* i64, f64, SDSGE_RESTRICT */
+#include "optim.h"                   /* sdsge_objective_fn, SDSGE_OPTIM_EALLOC */
+
+/* Native Nelder-Mead simplex driver (issue #335): a faithful transpilation of
+ * scipy's BSD-3 `_minimize_neldermead` (scipy/optimize/_optimize.py). Gradient
+ * free by construction: no FD gradient, no Hessian, no standard errors (the
+ * contrast with #329's L-BFGS-B). It shares the objective-cfunc ABI
+ * (`sdsge_objective_fn`) and the lean result-struct shape with that driver.
+ *
+ * Standard (non-adaptive) coefficients only: rho=1, chi=2, psi=0.5, sigma=0.5.
+ * Bounds use scipy's clipping scheme, not a transform: the initial simplex is
+ * reflected-then-clipped into the box and every trial point is clipped, so a
+ * BK-violation region never yields an out-of-box vertex. Non-finite objective
+ * returns (+INFINITY) rank worst in the simplex ordering and do not derail the
+ * search. Parity against scipy is asserted within tolerance on x/fun, never on
+ * the per-iteration trajectory: scipy re-sorts with a non-stable argsort, so
+ * tie ordering is not reproducible across implementations. */
+
+typedef struct {
+  i64 maxiter; /* iteration cap; <= 0 -> N*200 (scipy default) */
+  i64 maxfun;  /* objective-evaluation cap; <= 0 -> N*200 */
+  f64 xatol;   /* converge when max|vertex_i - best| <= xatol AND ... */
+  f64 fatol;   /* ... max|f_i - f_best| <= fatol */
+} sdsge_neldermead_options;
+
+typedef struct {
+  i64 status;          /* warnflag: 0 success, 1 maxfun, 2 maxiter */
+  i64 nfev;            /* objective evaluations */
+  i64 nit;             /* iterations */
+  f64 fun;             /* objective at the returned x */
+  int success;         /* warnflag == 0 */
+  const char *message; /* static string, keyed off status */
+} sdsge_neldermead_result;
+
+/* Nelder-Mead on a box-bounded objective. `x` is start -> optimum (length n).
+ * Bounds follow the L-BFGS-B ABI: lo[i]/hi[i] gated by nbd[i] in
+ * {0 none, 1 lower, 2 both, 3 upper}; nbd == NULL means fully unbounded (no
+ * clipping at all, matching scipy's bounds=None path). The driver makes one
+ * workspace allocation up front (never in the eval loop) and frees it on
+ * return; it never longjmps. Returns the exit status (also in out->status).
+ * SDSGE_OPTIM_EALLOC on a failed allocation, SDSGE_OPTIM_EINVAL on n < 1. */
+i64 sdsge_neldermead(sdsge_objective_fn obj, void *obj_ctx, i64 n,
+                     f64 *SDSGE_RESTRICT x, const f64 *lo, const f64 *hi,
+                     const i64 *nbd, const sdsge_neldermead_options *opt,
+                     sdsge_neldermead_result *out);
+
+#define SDSGE_OPTIM_EINVAL (-2)
+
+#endif /* SDSGE_OPTIM_NELDER_MEAD_H */

--- a/scripts/bench_native_neldermead.py
+++ b/scripts/bench_native_neldermead.py
@@ -1,0 +1,195 @@
+"""Benchmark the native Nelder-Mead optimizer against scipy's Python routine.
+
+Nelder-Mead has no inner linear algebra (no BLAS/LAPACK), so unlike the L-BFGS-B
+bench there is no backend axis: the comparison is native C driver vs scipy's
+pure-Python `_minimize_neldermead`. On a *cheap* synthetic objective the driver
+loop dominates, so this measures the win from moving the simplex bookkeeping and
+the per-eval dispatch out of Python; on a real DSGE objective the eval cost
+swamps the loop and the two converge in wall time.
+
+Cases:
+  * rosenbrock  -- unbounded parity + timing across dimensions.
+  * microbench  -- bounded quadratic; cheap eval, many iterations. Reports wall
+    time, nfev, nit for native vs scipy and the speedup, and asserts they land on
+    the same optimum within tolerance.
+  * bimodal     -- separable double well; off-center seeds must resolve to the
+    near basin identically and deterministically.
+  * halfplane   -- Rosenbrock on the feasible half-plane x[0] >= 0 (+inf outside),
+    a BK-violation analog: both must tolerate the +inf returns and still reach
+    the feasible minimum.
+
+Usage:
+    uv run python scripts/bench_native_neldermead.py
+    uv run python scripts/bench_native_neldermead.py --reps 500 --n 6
+
+Once the estimation<->optim wiring (issue #330) lands, an in-context run on the
+real DSGE solve+filter objective is the meaningful end-to-end bench; here the
+objective is synthetic so the optimizer internals are exposed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import numpy as np
+from scipy.optimize import minimize
+
+from SymbolicDSGE._ckernels.optim._optim import run_neldermead
+
+# Tight tol + generous budget so both sides fully converge (parity is meaningless
+# if either stops on the cap).
+_TOL = dict(xatol=1e-8, fatol=1e-8)
+
+
+def _time(fn, reps, warmup):
+    for _ in range(warmup):
+        fn()
+    ts = []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        fn()
+        ts.append(time.perf_counter() - t0)
+    return ts
+
+
+def _scipy_opts(budget):
+    return {**_TOL, "maxiter": budget, "maxfev": budget}
+
+
+def rosenbrock(n, budget):
+    print(f"=== rosenbrock parity n={n} ===")
+    x0 = np.full(n, -1.2)
+
+    def f(x):
+        return np.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2)
+
+    r = run_neldermead("rosenbrock", x0, maxiter=budget, maxfun=budget, **_TOL)
+    rs = minimize(f, x0, method="Nelder-Mead", options=_scipy_opts(budget))
+    for name, x, fun, nit, nfev in (
+        ("native", r["x"], r["fun"], r["nit"], r["nfev"]),
+        ("scipy", rs.x, rs.fun, rs.nit, rs.nfev),
+    ):
+        print(
+            f"  {name:7s} fun={fun:.3e} nit={nit:5d} nfev={nfev:5d} "
+            f"|x-1|_max={np.max(np.abs(x - 1)):.2e}"
+        )
+    print()
+
+
+def microbench(n, budget, reps, warmup):
+    print(f"=== microbench: bounded quadratic n={n} ===")
+    d = np.logspace(0.0, 1.5, n)
+    xstar = np.where(np.arange(n) % 2 == 0, 2.0, -2.0)
+    params = np.concatenate([d, xstar])
+    # Even coords bounded (active at the corner), odd coords free.
+    bounds = [(0.0, 1.0) if i % 2 == 0 else (None, None) for i in range(n)]
+    # Seed strictly inside every bound so the corner is actually reached.
+    x0 = np.where(np.arange(n) % 2 == 0, 0.5, 0.0)
+
+    def f(x):
+        return 0.5 * np.sum(d * (x - xstar) ** 2)
+
+    rn = run_neldermead(
+        "quad", x0, bounds=bounds, params=params, maxiter=budget, maxfun=budget, **_TOL
+    )
+    rs = minimize(
+        f, x0, method="Nelder-Mead", bounds=bounds, options=_scipy_opts(budget)
+    )
+
+    tn = _time(
+        lambda: run_neldermead(
+            "quad",
+            x0,
+            bounds=bounds,
+            params=params,
+            maxiter=budget,
+            maxfun=budget,
+            **_TOL,
+        ),
+        reps,
+        warmup,
+    )
+    ts = _time(
+        lambda: minimize(
+            f, x0, method="Nelder-Mead", bounds=bounds, options=_scipy_opts(budget)
+        ),
+        reps,
+        warmup,
+    )
+
+    hdr = f"{'impl':7s} {'fun':>14s} {'nit':>5s} {'nfev':>6s} {'med us':>12s} {'min us':>12s}"
+    print(hdr)
+    print("-" * len(hdr))
+    for name, r, tt in (
+        ("native", rn, tn),
+        ("scipy", {"fun": rs.fun, "nit": rs.nit, "nfev": rs.nfev}, ts),
+    ):
+        print(
+            f"{name:7s} {r['fun']:14.9f} {r['nit']:5d} {r['nfev']:6d} "
+            f"{statistics.median(tt) * 1e6:12.2f} {min(tt) * 1e6:12.2f}"
+        )
+    dx = np.max(np.abs(rn["x"] - rs.x))
+    print(f"  native vs scipy: |dfun|={abs(rn['fun'] - rs.fun):.2e} |dx|_max={dx:.2e}")
+    speedup = statistics.median(ts) / statistics.median(tn)
+    print(f"  native/scipy median wall speedup = {speedup:.1f}x\n")
+
+
+def bimodal():
+    print("=== bimodal: separable double well, off-center seeds ===")
+    n = 4
+
+    def f(x):
+        return np.sum((x**2 - 1.0) ** 2)
+
+    for seed in (0.05, -0.05):
+        rn = run_neldermead("double_well", np.full(n, seed), **_TOL)
+        rs = minimize(f, np.full(n, seed), method="Nelder-Mead", options=_TOL)
+        sn = np.sign(np.round(rn["x"], 6)).astype(int)
+        ss = np.sign(np.round(rs.x, 6)).astype(int)
+        print(
+            f"  seed {seed:+.2f}: native basin {sn}  scipy basin {ss}  agree={np.array_equal(sn, ss)}"
+        )
+    # Determinism: identical inputs -> byte-identical native results.
+    a = run_neldermead("double_well", np.full(n, 0.05), **_TOL)["x"]
+    b = run_neldermead("double_well", np.full(n, 0.05), **_TOL)["x"]
+    print(f"  native determinism (byte-identical repeat): {np.array_equal(a, b)}\n")
+
+
+def halfplane(budget):
+    print("=== halfplane: Rosenbrock on x[0] >= 0 (+inf outside) ===")
+    x0 = np.array([0.6, 0.6])
+
+    def f(x):
+        if x[0] < 0.0:
+            return np.inf
+        return 100.0 * (x[1] - x[0] ** 2) ** 2 + (1 - x[0]) ** 2
+
+    rn = run_neldermead("rosen_halfplane", x0, maxiter=budget, maxfun=budget, **_TOL)
+    rs = minimize(f, x0, method="Nelder-Mead", options=_scipy_opts(budget))
+    for name, x, fun, ok in (
+        ("native", rn["x"], rn["fun"], rn["success"]),
+        ("scipy", rs.x, rs.fun, rs.success),
+    ):
+        print(f"  {name:7s} x={np.round(x, 6)} fun={fun:.3e} ok={ok}")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=6)
+    ap.add_argument("--budget", type=int, default=8000, help="maxiter == maxfev cap")
+    ap.add_argument("--reps", type=int, default=200)
+    ap.add_argument("--warmup", type=int, default=20)
+    args = ap.parse_args()
+
+    rosenbrock(args.n, args.budget)
+    bimodal()
+    halfplane(args.budget)
+    microbench(args.n, args.budget, args.reps, args.warmup)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/optim/test_neldermead.py
+++ b/tests/optim/test_neldermead.py
@@ -1,0 +1,155 @@
+"""Parity + behavior tests for the native Nelder-Mead driver (issue #335).
+
+The driver is a faithful transpilation of scipy's `_minimize_neldermead`; these
+assert result-parity with scipy Nelder-Mead on standard benchmark objectives
+(Rosenbrock, bounded quadratic) and pin the driver's contracted behavior: bound
+clipping, +inf (BK-violation) tolerance, deterministic basin selection, and the
+maxfun cap. Parity is tolerance-based on x/fun, never on the trajectory: scipy
+re-sorts the simplex with a non-stable argsort, so tie ordering is not
+reproducible across implementations.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.optimize import minimize
+
+from SymbolicDSGE._ckernels.optim._optim import run_neldermead
+
+# Generous shared budget so both sides fully converge on the slow (gradient-free)
+# Rosenbrock descent; parity is meaningless if either stops on the cap.
+_TOL = dict(xatol=1e-8, fatol=1e-8)
+_BUDGET = dict(maxiter=8000, maxfun=8000)
+
+
+def _scipy_nm(f, x0, bounds=None):
+    return minimize(
+        f,
+        x0,
+        method="Nelder-Mead",
+        bounds=bounds,
+        options={**_TOL, "maxiter": _BUDGET["maxiter"], "maxfev": _BUDGET["maxfun"]},
+    )
+
+
+def _rosen(x):
+    return np.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2)
+
+
+def test_rosenbrock_matches_scipy():
+    x0 = np.full(3, -1.2, dtype=np.float64)
+    r = run_neldermead("rosenbrock", x0, **_TOL, **_BUDGET)
+    rs = _scipy_nm(_rosen, x0)
+
+    assert r["success"]
+    assert r["nfev"] > 0 and r["nit"] > 0
+    # Both reach the global minimum at the all-ones vector.
+    np.testing.assert_allclose(r["x"], np.ones(3), atol=1e-4)
+    assert r["fun"] < 1e-8
+    np.testing.assert_allclose(r["x"], rs.x, atol=1e-4)
+
+
+def test_bounded_quadratic_matches_scipy():
+    n = 4
+    d = np.array([1.0, 2.0, 4.0, 8.0])  # well-conditioned
+    xs = np.array([2.0, -2.0, 0.5, -0.5])
+    bounds = [(0.0, 1.0), (-1.0, 0.0), (None, None), (None, None)]
+    params = np.concatenate([d, xs])
+    # Interior seed: a start on a bound makes the zdelt-scale simplex stall there
+    # (scipy does the same), so seed strictly inside the box to reach the corner.
+    x0 = np.array([0.5, -0.5, 0.0, 0.0])
+
+    def f(x):
+        return 0.5 * np.sum(d * (x - xs) ** 2)
+
+    r = run_neldermead("quad", x0, bounds=bounds, params=params, **_TOL, **_BUDGET)
+    rs = _scipy_nm(f, x0, bounds=bounds)
+
+    assert r["success"]
+    # Active bounds clip coords 0,1 to their nearest bound; 2,3 hit xstar.
+    np.testing.assert_allclose(r["x"], [1.0, -1.0, 0.5, -0.5], atol=1e-4)
+    np.testing.assert_allclose(r["x"], rs.x, atol=1e-4)
+    np.testing.assert_allclose(r["fun"], rs.fun, rtol=1e-6, atol=1e-8)
+
+
+def test_bounds_are_respected():
+    n = 3
+    d = np.array([1.0, 1.0, 1.0])
+    xs = np.array([5.0, -5.0, 0.0])  # pulls outside the box
+    bounds = [(-1.0, 1.0)] * n
+    params = np.concatenate([d, xs])
+    r = run_neldermead("quad", np.zeros(n), bounds=bounds, params=params, **_TOL)
+
+    lo = np.array([b[0] for b in bounds])
+    hi = np.array([b[1] for b in bounds])
+    assert np.all(r["x"] >= lo - 1e-12)
+    assert np.all(r["x"] <= hi + 1e-12)
+
+
+def test_plus_inf_returns_do_not_derail_search():
+    # rosen_halfplane returns +inf for x[0] < 0 (a BK-violation analog). Starting
+    # feasible, the search probes into the infeasible region but must still reach
+    # the feasible minimum at all-ones.
+    x0 = np.array([0.6, 0.6], dtype=np.float64)
+    r = run_neldermead("rosen_halfplane", x0, **_TOL, **_BUDGET)
+    assert r["success"]
+    np.testing.assert_allclose(r["x"], np.ones(2), atol=1e-4)
+    assert np.isfinite(r["fun"]) and r["fun"] < 1e-8
+
+
+def test_all_infeasible_start_reports_failure_not_false_success():
+    # Every initial-simplex vertex is +inf: NM has no signal to escape, and the
+    # convergence delta is inf-inf == NaN. The NaN-propagating max must fail the
+    # convergence test (matching scipy's np.max), so the driver reports
+    # success=False rather than "converging" at the garbage start.
+    x0 = np.array([-5.0, 1.0], dtype=np.float64)
+    r = run_neldermead("rosen_halfplane", x0, **_TOL)
+    assert not r["success"]
+    assert not np.isfinite(r["fun"])
+
+
+def test_bimodal_deterministic_basin_selection():
+    # Separable double well: minima at +/-1 per coord, saddle at 0. An off-center
+    # seed must resolve to the near basin, deterministically and reproducibly.
+    n = 3
+    up1 = run_neldermead("double_well", np.full(n, 0.05), **_TOL)
+    up2 = run_neldermead("double_well", np.full(n, 0.05), **_TOL)
+    dn = run_neldermead("double_well", np.full(n, -0.05), **_TOL)
+
+    assert np.all(up1["x"] > 0.9)
+    assert np.all(dn["x"] < -0.9)
+    # Determinism: identical inputs give byte-identical results.
+    np.testing.assert_array_equal(up1["x"], up2["x"])
+
+
+def test_maxfun_cap_stops_and_flags():
+    # A tight eval cap must stop the search, report failure with the maxfev
+    # message, and never exceed the cap (per-eval guard, not a loop-top check).
+    cap = 25
+    r = run_neldermead("rosenbrock", np.full(4, -1.2), maxfun=cap, maxiter=100000)
+    assert not r["success"]
+    assert r["status"] == 1
+    assert r["nfev"] <= cap
+    assert "function evaluations" in r["message"]
+
+
+def test_maxiter_cap_stops_and_flags():
+    cap = 3
+    r = run_neldermead("rosenbrock", np.full(4, -1.2), maxiter=cap, maxfun=100000)
+    assert not r["success"]
+    assert r["status"] == 2
+    assert r["nit"] <= cap
+    assert "iterations" in r["message"]
+
+
+def test_result_reports_finite_fun_and_counts():
+    r = run_neldermead("rosenbrock", np.zeros(4), **_TOL)
+    assert np.isfinite(r["fun"])
+    assert isinstance(r["message"], str) and r["message"]
+    assert r["nfev"] >= r["nit"] > 0
+
+
+def test_unknown_objective_raises():
+    with pytest.raises(ValueError):
+        run_neldermead("nope", np.zeros(3))


### PR DESCRIPTION
This pull request adds a native Nelder-Mead simplex optimization driver to the codebase, closely matching the behavior of SciPy's implementation. It introduces new C and Cython interfaces, Python bindings, and updates type stubs to support the new optimizer. The implementation includes careful handling of bounds and infeasible regions, and provides a robust result structure for parity with existing drivers.

**New Nelder-Mead optimizer implementation:**

* Added a native Nelder-Mead optimizer (`nelder_mead.c`, `nelder_mead.h`) that faithfully mirrors SciPy's `_minimize_neldermead`, including bounds handling, convergence criteria, and result reporting. The implementation uses stable simplex sorting and supports both bounded and unbounded optimization. [[1]](diffhunk://#diff-6f91618889d48d4d43f6b29c4640962fda47c68af2a24666a030f961532f1eeeR1-R333) [[2]](diffhunk://#diff-895b08c8e85d35648a460a75df8a39bc1cb8421ea7d72a50240690847db760ceR1-R52)

**Cython and Python bindings:**

* Exposed the Nelder-Mead optimizer to Cython (`_optim.pyx`): added C-level interface, bound the new optimizer, and created the `_obj_rosen_halfplane` objective for infeasible region handling. [[1]](diffhunk://#diff-86fed5544767d05d1f813a239def33a824c6ad8605bea8c3ed905b250e917e9dR43-R64) [[2]](diffhunk://#diff-86fed5544767d05d1f813a239def33a824c6ad8605bea8c3ed905b250e917e9dR106-R124)
* Added the `run_neldermead` Python binding, matching the interface and result structure of `run_lbfgsb`, including bounds, parameter passing, and result dictionary.

**Type annotations and stubs:**

* Updated type stubs (`_optim.pyi`) to include the new `run_neldermead` function and its result type, ensuring parity and type safety for users.

**Other minor changes:**

* Imported `INFINITY` from `libc.math` to support infeasible region handling in objectives.

## Native v Scipy (Python) Benchmark
```text
=== rosenbrock parity n=6 ===                                                                                                                                                                                             
  native  fun=3.974e+00 nit=  643 nfev= 1024 |x-1|_max=1.99e+00
  scipy   fun=3.974e+00 nit=  644 nfev= 1026 |x-1|_max=1.99e+00

=== bimodal: separable double well, off-center seeds ===
  seed +0.05: native basin [1 1 1 1]  scipy basin [1 1 1 1]  agree=True
  seed -0.05: native basin [-1 -1 -1 -1]  scipy basin [-1 -1 -1 -1]  agree=True
  native determinism (byte-identical repeat): True

=== halfplane: Rosenbrock on x[0] >= 0 (+inf outside) ===
  native  x=[1. 1.] fun=5.856e-19 ok=True
  scipy   x=[1. 1.] fun=5.856e-19 ok=True

=== microbench: bounded quadratic n=6 ===
impl               fun   nit   nfev       med us       min us
-------------------------------------------------------------
native    10.415001815   495    837        79.35        77.90
scipy     10.415001815   496    846     19282.40     17338.20
  native vs scipy: |dfun|=0.00e+00 |dx|_max=1.48e-08
  native/scipy median wall speedup = 243.0x
```
> System Spec:
> - CPU: 10900K 4.9GHz
> - Memory: 32GB DDR4 2933MHz 
> - OS/Comp: Windows/MSVC
> - Scipy Version: `scipy==1.17.1`

closes #335 