### PR TITLE
Trace-based MC result reduction and pooled retention

### DIFF
--- a/SymbolicDSGE/_diag_tests/result.py
+++ b/SymbolicDSGE/_diag_tests/result.py
@@ -296,3 +296,95 @@ class MCResult:
 
         se = self.statistic_se
         return self.mean_statistic - z * se, self.mean_statistic + z * se
+
+
+def _df_metadata_matches(a: object, b: object) -> bool:
+    """Compare normalized df metadata across replications, treating NaN == NaN
+    as a match. Parameter-free reference distributions (CUSUM) carry a NaN df
+    placeholder, which a plain ``!=`` would otherwise flag as incompatible."""
+    at = a if isinstance(a, tuple) else (a,)
+    bt = b if isinstance(b, tuple) else (b,)
+    if len(at) != len(bt):
+        return False
+    for x, y in zip(at, bt):
+        if x == y:
+            continue
+        if (
+            isinstance(x, float | np.floating)
+            and isinstance(y, float | np.floating)
+            and np.isnan(x)
+            and np.isnan(y)
+        ):
+            continue
+        return False
+    return True
+
+
+class MCResultAccumulator:
+    """Streaming builder for an :class:`MCResult` over a replication loop.
+
+    Pulls the statistic and status off each per-replication :class:`TestResult` at
+    push time so the result object itself can be released, and keeps the
+    rep-invariant metadata (``dist`` / ``df`` / ``pval_method`` / ``alpha``) from
+    the first push, rejecting a later result that disagrees. The statistic buffer
+    is sized on ``n_rep`` up front and filled at a cursor, so a run with skipped
+    replications finalizes to the count actually pushed.
+    """
+
+    __slots__ = ("_statistic", "_status", "_metadata", "_cursor")
+
+    def __init__(self, n_rep: int) -> None:
+        if n_rep <= 0:
+            raise ValueError("MCResultAccumulator requires a positive n_rep.")
+        self._statistic: NDArray[float64] = np.empty(n_rep, dtype=np.float64)
+        self._status: list[TestStatus] = []
+        self._metadata: tuple[Any, ...] | None = None
+        self._cursor = 0
+
+    @property
+    def n_pushed(self) -> int:
+        """Replications pushed so far."""
+        return self._cursor
+
+    def push(self, result: TestResult, *, step_name: str = "") -> None:
+        """Record one replication's result, releasing the object to the caller."""
+        metadata = (result.dist, result.df, result.pval_method, result.alpha)
+        if self._metadata is None:
+            self._metadata = metadata
+        else:
+            dist, df, pval_method, alpha = self._metadata
+            if (
+                result.dist is not dist
+                or result.pval_method is not pval_method
+                or not _df_metadata_matches(result.df, df)
+                or result.alpha != alpha
+            ):
+                raise ValueError(
+                    f"Test results for step '{step_name}' have incompatible metadata."
+                )
+        if self._cursor >= self._statistic.size:
+            raise ValueError(
+                f"Test results for step '{step_name}' exceed the accumulator's "
+                f"capacity of {self._statistic.size} replications."
+            )
+        self._statistic[self._cursor] = result.statistic
+        self._status.append(result.status)
+        self._cursor += 1
+
+    def finalize(self, test_name: str) -> MCResult:
+        """Build the :class:`MCResult` over the replications pushed so far."""
+        if self._metadata is None:
+            raise ValueError(
+                f"Test results for step '{test_name}' are empty; MCResult requires "
+                "at least one replication."
+            )
+        dist, df, pval_method, alpha = self._metadata
+        return MCResult(
+            test_name=test_name,
+            dist=dist,
+            df=df,
+            pval_method=pval_method,
+            alpha=alpha,
+            statistic_trace=self._statistic[: self._cursor].copy(),
+            status_trace=tuple(self._status),
+        )

--- a/SymbolicDSGE/monte_carlo/__init__.py
+++ b/SymbolicDSGE/monte_carlo/__init__.py
@@ -28,6 +28,7 @@ from .postproc import Raw, Summary
 from .mc_constructs import (
     MCContext,
     MCData,
+    MCDataSummary,
     MCPipelineResult,
     MCStep,
     OpType,
@@ -46,6 +47,7 @@ __all__ = [
     "MCStep",
     "MCContext",
     "MCData",
+    "MCDataSummary",
     "OpType",
     "numpy_operation",
     "pandas_operation",

--- a/SymbolicDSGE/monte_carlo/builder.py
+++ b/SymbolicDSGE/monte_carlo/builder.py
@@ -370,9 +370,9 @@ def run_pipeline(
         reference=reference,
         dgp=dgp,
         n_rep=n_rep,
-        retain_payloads=False,
-        retain_test_results=False,
-        retain_contexts=True,
+        payload_poolsize=0,
+        test_result_poolsize=0,
+        context_poolsize=0,
         fail_fast=fail_fast,
         verbosity=0,
     )

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -11,14 +11,15 @@ if TYPE_CHECKING:
     from .graph import PipelineGraph
     from .spec import PipelineSpec
 
-from .._diag_tests.result import MCResult, TestResult
+from .._diag_tests.result import MCResultAccumulator, TestResult
 from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterRawResult, UnscentedFilterRawResult
-from ..regression.ols import MCRegressionResult
+from ..regression.ols import MCRegressionAccumulator
 from ..regression.result import RegressionResult
 from .mc_constructs import (
     MCContext,
     MCData,
+    MCDataAccumulator,
     MCFailure,
     MCPipelineResult,
     MCMeta,
@@ -148,9 +149,13 @@ class MCPipeline:
         reference: SolvedModel,
         dgp: SolvedModel | None = None,
         n_rep: int,
-        retain_payloads: bool = True,
-        retain_test_results: bool = True,
-        retain_contexts: bool = False,
+        payload_poolsize: int = 10000,
+        test_result_poolsize: int = 10000,
+        # Contexts are off by default: a retained ``MCContext`` transitively holds
+        # this replication's ``MCData`` and its result objects (designs included),
+        # so a context pool re-retains exactly what the trace accumulators exist to
+        # release. The native loop has no per-replication context at all.
+        context_poolsize: int = 0,
         fail_fast: bool = True,
         verbosity: int = 1,
     ) -> MCPipelineResult:
@@ -159,12 +164,25 @@ class MCPipeline:
         if verbosity not in (0, 1, 2):
             raise ValueError("verbosity must be 0, 1, or 2.")
 
-        contexts: list[MCContext] = []
         n_successful = 0
+        retain_payloads, payload_stride = _pool_stride(n_rep, payload_poolsize)
+        retain_test_results, test_stride = _pool_stride(n_rep, test_result_poolsize)
+        retain_contexts, context_stride = _pool_stride(n_rep, context_poolsize)
+
+        contexts: list[MCContext] = []
         payload_traces: list[Mapping[str, object]] = []
         failures: list[MCFailure] = []
-        results_by_step: dict[str, list[TestResult]] = {}
-        regression_results_by_step: dict[str, list[RegressionResult]] = {}
+        # Test / regression results are reduced to their traces as each
+        # replication finishes, so the result objects never accumulate. The
+        # strided pools below retain a bounded sample of the objects themselves
+        # for inspection; the traces they summarize stay full length, so pooling
+        # never costs MC granularity.
+        test_accumulators: dict[str, MCResultAccumulator] = {}
+        regression_accumulators: dict[str, MCRegressionAccumulator] = {}
+        test_result_pool: dict[str, list[TestResult]] = {}
+        # The generated data is the largest per-replication object, so it is
+        # summarized on the spot and dropped rather than retained behind a pool.
+        data_accumulator = MCDataAccumulator()
         # Per-replication step timings feed the it/s rates. Postproc runs once
         # after the loop and times itself (see ``_run_postproc``); its runtime is
         # never folded into the it/s denominator.
@@ -208,16 +226,26 @@ class MCPipeline:
                 continue
 
             n_successful += 1
-            if retain_contexts:
+            data_accumulator.push(context.data)
+            if retain_contexts and (rep_idx % context_stride == 0):
                 contexts.append(context)
-            if retain_payloads:
+            if retain_payloads and (rep_idx % payload_stride == 0):
                 payload_traces.append(dict(context.payloads))
+            pool_test_results = retain_test_results and (rep_idx % test_stride == 0)
             for name, test_result in context.results.items():
-                results_by_step.setdefault(name, []).append(test_result)
+                accumulator = test_accumulators.get(name)
+                if accumulator is None:
+                    accumulator = test_accumulators[name] = MCResultAccumulator(n_rep)
+                accumulator.push(test_result, step_name=name)
+                if pool_test_results:
+                    test_result_pool.setdefault(name, []).append(test_result)
             for name, regression_result in context.regressions.items():
-                regression_results_by_step.setdefault(name, []).append(
-                    regression_result
-                )
+                regression_accumulator = regression_accumulators.get(name)
+                if regression_accumulator is None:
+                    regression_accumulator = regression_accumulators[name] = (
+                        MCRegressionAccumulator(n_rep)
+                    )
+                regression_accumulator.push(regression_result)
             if postproc_steps:
                 _accumulate_payload_columns(payload_columns, context.payloads)
 
@@ -226,8 +254,14 @@ class MCPipeline:
         # separately and never enter the it/s denominator.
         elapsed_s = perf_counter() - loop_start
 
-        test_summaries = _summarize_tests(results_by_step)
-        regression_summaries = _summarize_regressions(regression_results_by_step)
+        test_summaries = {
+            name: accumulator.finalize(name)
+            for name, accumulator in test_accumulators.items()
+        }
+        regression_summaries = {
+            name: accumulator.finalize()
+            for name, accumulator in regression_accumulators.items()
+        }
         postproc, postproc_elapsed_s = self._run_postproc(
             postproc_steps,
             test_summaries=test_summaries,
@@ -262,7 +296,7 @@ class MCPipeline:
             n_successful=n_successful,
             test_summaries=test_summaries,
             test_results=(
-                {name: tuple(values) for name, values in results_by_step.items()}
+                {name: tuple(values) for name, values in test_result_pool.items()}
                 if retain_test_results
                 else None
             ),
@@ -271,6 +305,7 @@ class MCPipeline:
             failures=tuple(failures),
             regression_summaries=regression_summaries,
             postproc=postproc,
+            data_summaries=data_accumulator.finalize(),
         )
         if verbosity == 1:
             report_mc_performance(meta)
@@ -385,6 +420,21 @@ class MCPipeline:
         return postproc, postproc_elapsed_s
 
 
+def _pool_stride(n_rep: int, poolsize: int) -> tuple[bool, int]:
+    """Retention flag and replication stride for a fixed-size inspection pool.
+
+    A non-positive ``poolsize`` disables retention and reports a zero stride the
+    caller never applies (the flag short-circuits ahead of the modulo). Otherwise
+    the stride is ``ceil(n_rep / poolsize)``, which keeps the pool at or under
+    ``poolsize`` entries without a running count, and is 1 for a run shorter than
+    the pool so every replication is kept. Sampling the tail is not guaranteed:
+    the final ``stride - 1`` replications fall outside the sample.
+    """
+    if poolsize <= 0:
+        return False, 0
+    return True, (n_rep + poolsize - 1) // poolsize
+
+
 def _validate_source_producer(
     consumer: MCStep,
     selector: Any,
@@ -463,72 +513,3 @@ def _stack_payload_columns(
         if arrays and len({array.shape for array in arrays}) == 1:
             out[payload_trace_key(name)] = np.stack(arrays)
     return out
-
-
-def _df_metadata_matches(a: object, b: object) -> bool:
-    """Compare normalized df metadata across replications, treating NaN == NaN
-    as a match. Parameter-free reference distributions (CUSUM) carry a NaN df
-    placeholder, which a plain ``!=`` would otherwise flag as incompatible."""
-    at = a if isinstance(a, tuple) else (a,)
-    bt = b if isinstance(b, tuple) else (b,)
-    if len(at) != len(bt):
-        return False
-    for x, y in zip(at, bt):
-        if x == y:
-            continue
-        if (
-            isinstance(x, float | np.floating)
-            and isinstance(y, float | np.floating)
-            and np.isnan(x)
-            and np.isnan(y)
-        ):
-            continue
-        return False
-    return True
-
-
-def _summarize_tests(
-    results_by_step: Mapping[str, list[TestResult]],
-) -> dict[str, MCResult]:
-    test_summaries: dict[str, MCResult] = {}
-
-    for step_name, results in results_by_step.items():
-        if not results:
-            continue
-        first = results[0]
-        for result in results[1:]:
-            if (
-                result.dist is not first.dist
-                or result.pval_method is not first.pval_method
-                or not _df_metadata_matches(result.df, first.df)
-                or result.alpha != first.alpha
-            ):
-                raise ValueError(
-                    f"Test results for step '{step_name}' have incompatible metadata."
-                )
-        stat_trace = np.asarray(
-            [result.statistic for result in results], dtype=np.float64
-        )
-        summary = MCResult(
-            test_name=step_name,
-            dist=first.dist,
-            df=first.df,
-            pval_method=first.pval_method,
-            alpha=first.alpha,
-            statistic_trace=stat_trace,
-            status_trace=tuple(result.status for result in results),
-        )
-        test_summaries[step_name] = summary
-
-    return test_summaries
-
-
-def _summarize_regressions(
-    results_by_step: Mapping[str, list[RegressionResult]],
-) -> dict[str, MCRegressionResult]:
-    regression_summaries: dict[str, MCRegressionResult] = {}
-    for step_name, results in results_by_step.items():
-        if not results:
-            continue
-        regression_summaries[step_name] = MCRegressionResult.from_results(results)
-    return regression_summaries

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -56,6 +56,120 @@ class MCData(NamedTuple):
     observable_names: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class MCDataSummary:
+    """Across-replication summary of one named :class:`MCData` array.
+
+    Reduced in the loop (see :class:`MCDataAccumulator`), so the arrays it
+    describes are discarded with their replication.
+    """
+
+    #: Replications that contributed an array under this name.
+    n_rep: int
+    #: Shape of the first contributing replication's array.
+    shape: tuple[int, ...]
+    #: Total element count summed over contributing replications.
+    n_values: int
+    #: Elements of that total that were finite.
+    n_finite: int
+    mean: float | None
+    std: float | None
+    min: float | None
+    max: float | None
+
+
+class MCDataAccumulator:
+    """Streaming summary of the :class:`MCData` arrays a run produces.
+
+    One instance covers a whole run: :meth:`push` folds a replication's
+    ``states``, ``observables``, and raw series into per-name running sums, and
+    :meth:`finalize` divides out. Nothing here scales with ``n_rep`` or with the
+    sample dimension, so a replication's arrays are free the moment it ends.
+
+    Statistics are pooled over every finite element of every contributing
+    replication, not averaged over per-replication statistics.
+    """
+
+    #: Raw series carrying the state matrix under a reserved key; already
+    #: summarized as ``states``, so it never gets its own entry.
+    _SKIP_RAW = "_X"
+
+    def __init__(self) -> None:
+        self._n_rep: dict[str, int] = {}
+        self._shape: dict[str, tuple[int, ...]] = {}
+        self._n_values: dict[str, int] = {}
+        self._n_finite: dict[str, int] = {}
+        self._sum: dict[str, float] = {}
+        self._square_sum: dict[str, float] = {}
+        self._min: dict[str, float] = {}
+        self._max: dict[str, float] = {}
+
+    def push(self, data: MCData | None) -> None:
+        """Fold one replication's arrays into the running summaries."""
+        if data is None:
+            return
+        if data.states is not None:
+            self._push_array("states", np.asarray(data.states))
+        if data.observables is not None:
+            self._push_array("observables", np.asarray(data.observables))
+        for name, value in data.raw.items():
+            if name != self._SKIP_RAW:
+                self._push_array(f"raw:{name}", np.asarray(value))
+
+    def _push_array(self, name: str, array: np.ndarray) -> None:
+        if name not in self._n_rep:
+            self._n_rep[name] = 0
+            self._shape[name] = array.shape
+            self._n_values[name] = 0
+            self._n_finite[name] = 0
+            self._sum[name] = 0.0
+            self._square_sum[name] = 0.0
+            self._min[name] = np.inf
+            self._max[name] = -np.inf
+        self._n_rep[name] += 1
+        self._n_values[name] += int(array.size)
+        finite = array[np.isfinite(array)]
+        if finite.size == 0:
+            return
+        self._n_finite[name] += int(finite.size)
+        self._sum[name] += float(finite.sum())
+        self._square_sum[name] += float(np.square(finite).sum())
+        self._min[name] = min(self._min[name], float(finite.min()))
+        self._max[name] = max(self._max[name], float(finite.max()))
+
+    def finalize(self) -> dict[str, MCDataSummary]:
+        """The per-name summaries, in first-seen order."""
+        return {name: self._finalize_one(name) for name in self._n_rep}
+
+    def _finalize_one(self, name: str) -> MCDataSummary:
+        n_finite = self._n_finite[name]
+        if n_finite == 0:
+            return MCDataSummary(
+                n_rep=self._n_rep[name],
+                shape=self._shape[name],
+                n_values=self._n_values[name],
+                n_finite=0,
+                mean=None,
+                std=None,
+                min=None,
+                max=None,
+            )
+        mean = self._sum[name] / n_finite
+        # Clamped because the sum-of-squares form can go slightly negative on a
+        # near-constant series once cancellation bites.
+        variance = max(0.0, self._square_sum[name] / n_finite - mean**2)
+        return MCDataSummary(
+            n_rep=self._n_rep[name],
+            shape=self._shape[name],
+            n_values=self._n_values[name],
+            n_finite=n_finite,
+            mean=mean,
+            std=variance**0.5,
+            min=self._min[name],
+            max=self._max[name],
+        )
+
+
 MC_DATA_SOURCE_FIELDS: tuple[str, ...] = ("states", "observables")
 DYNAMIC_SOURCE_FIELDS: tuple[str, ...] = ("payload",)
 # The array-valued filter outputs, in tuple order. ``status`` is a scalar error
@@ -435,6 +549,11 @@ class MCPipelineResult:
     #: ``"<step>.<key>"`` for multi-artifact ops). Values are
     #: :class:`~SymbolicDSGE.monte_carlo.postproc.Summary` / ``Raw`` wrappers.
     postproc: Mapping[str, Any] = dataclass_field(default_factory=dict)
+
+    #: Across-replication summaries of the generated data, keyed by array name
+    #: (``"states"``, ``"observables"``, ``"raw:<name>"``). Reduced in the loop,
+    #: so these cover every successful replication whatever the pool sizes are.
+    data_summaries: Mapping[str, MCDataSummary] = dataclass_field(default_factory=dict)
 
     @property
     def succeeded(self) -> bool:

--- a/SymbolicDSGE/monte_carlo/serialize.py
+++ b/SymbolicDSGE/monte_carlo/serialize.py
@@ -19,8 +19,7 @@ from typing import Any, cast
 import numpy as np
 from numpy.typing import NDArray
 
-from ..regression.ols import OLSResult
-from .mc_constructs import MCContext, MCPipelineResult
+from .mc_constructs import MCDataSummary, MCPipelineResult
 from .postproc import Artifact, Raw, Summary, normalize_artifacts
 from .traces import regression_trace_keys, test_trace_keys
 
@@ -100,7 +99,10 @@ def serialize_pipeline_result(
             name: _serialize_regression_summary(summary)
             for name, summary in result.regression_summaries.items()
         },
-        "data_summaries": _summarize_context_data(result.contexts or ()),
+        "data_summaries": {
+            name: _serialize_data_summary(summary)
+            for name, summary in result.data_summaries.items()
+        },
         "postproc": {
             name: _serialize_artifact(artifact)
             for name, artifact in _normalized_postproc(result).items()
@@ -451,7 +453,7 @@ def _serialize_regression_summary(summary: Any) -> dict[str, Any]:
         "metrics": metrics,
         "ols": None,
     }
-    if all(isinstance(item, OLSResult) for item in summary.results):
+    if summary.is_ols:
         out["ols"] = {
             "mean_standard_errors": _json_value(np.mean(summary.se_trace, axis=0)),
             "mean_t_statistics": _json_value(np.mean(summary.t_stat_trace, axis=0)),
@@ -470,60 +472,17 @@ def _status_counts(status_trace: Sequence[Any]) -> dict[str, int]:
     return counts
 
 
-def _summarize_context_data(contexts: Sequence[MCContext]) -> dict[str, Any]:
-    arrays: dict[str, list[np.ndarray]] = {}
-    for context in contexts:
-        if context.data is None:
-            continue
-        data = context.data
-        if data.states is not None:
-            arrays.setdefault("states", []).append(np.asarray(data.states))
-        if data.observables is not None:
-            arrays.setdefault("observables", []).append(np.asarray(data.observables))
-        for name, value in data.raw.items():
-            if name != "_X":
-                arrays.setdefault(f"raw:{name}", []).append(np.asarray(value))
-    return {name: _array_collection_summary(values) for name, values in arrays.items()}
-
-
-def _array_collection_summary(values: Sequence[np.ndarray]) -> dict[str, Any]:
-    n_total = sum(int(arr.size) for arr in values)
-    n_finite = 0
-    value_sum = 0.0
-    square_sum = 0.0
-    minimum = np.inf
-    maximum = -np.inf
-    for arr in values:
-        finite = arr[np.isfinite(arr)]
-        if finite.size == 0:
-            continue
-        n_finite += int(finite.size)
-        value_sum += float(finite.sum())
-        square_sum += float(np.square(finite).sum())
-        minimum = min(minimum, float(finite.min()))
-        maximum = max(maximum, float(finite.max()))
-    if n_finite == 0:
-        return {
-            "n_rep": len(values),
-            "shape": list(values[0].shape),
-            "n_values": n_total,
-            "n_finite": 0,
-            "mean": None,
-            "std": None,
-            "min": None,
-            "max": None,
-        }
-    mean = value_sum / n_finite
-    variance = max(0.0, square_sum / n_finite - mean**2)
+def _serialize_data_summary(summary: MCDataSummary) -> dict[str, Any]:
+    """Wire entry for one in-loop :class:`MCDataSummary`."""
     return {
-        "n_rep": len(values),
-        "shape": list(values[0].shape),
-        "n_values": n_total,
-        "n_finite": n_finite,
-        "mean": _json_float(mean),
-        "std": _json_float(variance**0.5),
-        "min": _json_float(minimum),
-        "max": _json_float(maximum),
+        "n_rep": summary.n_rep,
+        "shape": [int(dim) for dim in summary.shape],
+        "n_values": summary.n_values,
+        "n_finite": summary.n_finite,
+        "mean": _json_value(summary.mean),
+        "std": _json_value(summary.std),
+        "min": _json_value(summary.min),
+        "max": _json_value(summary.max),
     }
 
 

--- a/SymbolicDSGE/regression/ols/__init__.py
+++ b/SymbolicDSGE/regression/ols/__init__.py
@@ -1,8 +1,9 @@
-from .ols_result import MCRegressionResult, OLSResult
+from .ols_result import MCRegressionAccumulator, MCRegressionResult, OLSResult
 from .core import ols
 from ..enums import RegressionStatus
 
 __all__ = [
+    "MCRegressionAccumulator",
     "MCRegressionResult",
     "OLSResult",
     "RegressionStatus",

--- a/SymbolicDSGE/regression/ols/ols_result.py
+++ b/SymbolicDSGE/regression/ols/ols_result.py
@@ -114,109 +114,109 @@ class OLSResult(RegressionResult):
 
 @dataclass(frozen=True)
 class MCRegressionResult:
-    variables: list[str]
-    results: tuple[RegressionResult, ...] = field(repr=False)
+    """Across-replication regression summary, held as traces.
 
-    coef_trace: NDF = field(init=False)
-    status_trace: tuple[RegressionStatus, ...] = field(init=False)
+    Carries only the sufficient statistics of each replication's solve, all
+    ``O(k)`` or ``O(1)`` per replication: the coefficient, standard-error, SSR,
+    SST, and status traces. The per-replication ``RegressionResult`` objects and
+    their ``y`` / ``X`` arrays are consumed by
+    :class:`MCRegressionAccumulator` and released, so a run's retained memory
+    does not scale with the regression sample size. Every reported quantity
+    derives from the stored traces.
+    """
+
+    variables: list[str]
+    coef_trace: NDF
+    status_trace: tuple[RegressionStatus, ...]
+    ssr_trace: NDF
+    sst_trace: NDF
+    n: int
+    is_ols: bool = False
+    #: OLS standard errors, computed per replication while the design was still
+    #: live. ``None`` for kinds that do not report them; read via ``se_trace``.
+    stored_se_trace: NDF | None = field(default=None, repr=False)
+
     n_rep: int = field(init=False)
-    n: int = field(init=False)
     k: int = field(init=False)
 
     def __post_init__(self) -> None:
-        results = tuple(self.results)
-        if not results:
-            raise ValueError("MCRegressionResult requires at least one result.")
-
-        first = results[0]
         variables = list(self.variables)
-        if variables != first.variables:
-            raise ValueError("MC regression variables must match the first result.")
-
-        n = first.n
-        k = first.k
+        coef_trace = np.ascontiguousarray(self.coef_trace, dtype=np.float64)
+        if coef_trace.ndim != 2:
+            raise ValueError("MC regression coef_trace must be a 2D array.")
+        n_rep, k = coef_trace.shape
+        if n_rep == 0:
+            raise ValueError("MCRegressionResult requires at least one result.")
         if len(variables) != k:
             raise ValueError(
                 "MC regression variables must match the number of coefficients."
             )
-
-        coef_trace: list[NDF] = []
-        status_trace: list[RegressionStatus] = []
-        for result in results:
-            if result.variables != variables:
-                raise ValueError("MC regression results have incompatible variables.")
-            if result.n != n or result.k != k:
-                raise ValueError("MC regression results have incompatible dimensions.")
-            if result.y.shape != (n,):
-                raise ValueError("MC regression results require 1D response arrays.")
-            if result.X.shape != (n, k):
-                raise ValueError("MC regression results have incompatible designs.")
-            if result.coefficients.shape != (k,):
+        status_trace = tuple(RegressionStatus(status) for status in self.status_trace)
+        if len(status_trace) != n_rep:
+            raise ValueError(
+                "MC regression status trace must match the coefficient trace length."
+            )
+        ssr_trace = np.ascontiguousarray(self.ssr_trace, dtype=np.float64)
+        sst_trace = np.ascontiguousarray(self.sst_trace, dtype=np.float64)
+        if ssr_trace.shape != (n_rep,) or sst_trace.shape != (n_rep,):
+            raise ValueError(
+                "MC regression SSR and SST traces must be 1D and match the "
+                "coefficient trace length."
+            )
+        se_trace = self.stored_se_trace
+        if se_trace is not None:
+            se_trace = np.ascontiguousarray(se_trace, dtype=np.float64)
+            if se_trace.shape != (n_rep, k):
                 raise ValueError(
-                    "MC regression results have incompatible coefficient shapes."
+                    "MC regression standard-error trace must match the coefficient "
+                    "trace shape."
                 )
-            coef_trace.append(result.coefficients)
-            status_trace.append(result.status)
 
         object.__setattr__(self, "variables", variables)
-        object.__setattr__(self, "results", results)
-        object.__setattr__(self, "coef_trace", np.vstack(coef_trace))
-        object.__setattr__(self, "status_trace", tuple(status_trace))
-        object.__setattr__(self, "n_rep", len(self.results))
-        object.__setattr__(self, "n", n)
-        object.__setattr__(self, "k", k)
+        object.__setattr__(self, "coef_trace", coef_trace)
+        object.__setattr__(self, "status_trace", status_trace)
+        object.__setattr__(self, "ssr_trace", ssr_trace)
+        object.__setattr__(self, "sst_trace", sst_trace)
+        object.__setattr__(self, "stored_se_trace", se_trace)
+        object.__setattr__(self, "n", int(self.n))
+        object.__setattr__(self, "is_ols", bool(self.is_ols))
+        object.__setattr__(self, "n_rep", int(n_rep))
+        object.__setattr__(self, "k", int(k))
+
+    @classmethod
+    def accumulator(cls, n_rep: int) -> "MCRegressionAccumulator":
+        """A streaming builder that consumes results and releases them."""
+        return MCRegressionAccumulator(n_rep)
 
     @classmethod
     def from_results(cls, results: Sequence[RegressionResult]) -> "MCRegressionResult":
         result_tuple = tuple(results)
         if not result_tuple:
             raise ValueError("MCRegressionResult requires at least one result.")
-        return cls(variables=list(result_tuple[0].variables), results=result_tuple)
+        accumulator = cls.accumulator(len(result_tuple))
+        for result in result_tuple:
+            accumulator.push(result)
+        return accumulator.finalize()
 
-    def _require_ols_results(self) -> tuple[OLSResult, ...]:
-        if not all(isinstance(result, OLSResult) for result in self.results):
+    def _require_ols(self) -> None:
+        if not self.is_ols:
             raise TypeError(
                 "OLS-specific MC diagnostics require all results to be OLSResult."
             )
-        return cast(tuple[OLSResult, ...], self.results)
 
     @property
     def coefficients(self) -> NDF:
         return self.coef_trace
 
-    @cached_property
-    def y_trace(self) -> NDF:
-        return np.ascontiguousarray(
-            np.stack([result.y for result in self.results]),
-            dtype=np.float64,
-        )
-
-    @cached_property
-    def x_trace(self) -> NDF:
-        return np.ascontiguousarray(
-            np.stack([result.X for result in self.results]),
-            dtype=np.float64,
-        )
-
-    @cached_property
-    def y_hat_trace(self) -> NDF:
-        return np.asarray(
-            np.einsum("rnk,rk->rn", self.x_trace, self.coef_trace),
-            dtype=np.float64,
-        )
-
-    @cached_property
-    def residual_trace(self) -> NDF:
-        return np.asarray(self.y_trace - self.y_hat_trace, dtype=np.float64)
-
-    @cached_property
-    def ssr_trace(self) -> NDF:
-        return np.asarray((self.residual_trace**2).sum(axis=1), dtype=np.float64)
-
-    @cached_property
-    def sst_trace(self) -> NDF:
-        centered = self.y_trace - self.y_trace.mean(axis=1, keepdims=True)
-        return np.asarray((centered**2).sum(axis=1), dtype=np.float64)
+    @property
+    def se_trace(self) -> NDF:
+        self._require_ols()
+        se_trace = self.stored_se_trace
+        if se_trace is None:
+            raise TypeError(
+                "OLS-specific MC diagnostics require all results to be OLSResult."
+            )
+        return se_trace
 
     @cached_property
     def mse_trace(self) -> NDF:
@@ -225,22 +225,6 @@ class MCRegressionResult:
     @cached_property
     def rmse_trace(self) -> NDF:
         return np.asarray(np.sqrt(self.mse_trace), dtype=np.float64)
-
-    @cached_property
-    def se_trace(self) -> NDF:
-        results = self._require_ols_results()
-        if all(result._L.shape == (self.k, self.k) for result in results):
-            sigma2 = self.ssr_trace / (self.n - self.k)
-            eye = np.eye(self.k, dtype=np.float64)
-            rhs = np.broadcast_to(eye, (self.n_rep, self.k, self.k))
-            L_trace = np.stack([result._L for result in results])
-            L_inv = np.linalg.solve(L_trace, rhs)
-            inv_diag = (L_inv * L_inv).sum(axis=1)
-            return np.asarray(np.sqrt(inv_diag * sigma2[:, None]), dtype=np.float64)
-
-        return np.asarray(
-            np.vstack([result.se for result in results]), dtype=np.float64
-        )
 
     @cached_property
     def t_stat_trace(self) -> NDF:
@@ -274,7 +258,7 @@ class MCRegressionResult:
 
     @cached_property
     def F_stat_trace(self) -> NDF:
-        self._require_ols_results()
+        self._require_ols()
         dfn, dfd = _f_test_degrees_of_freedom(self.n, self.k, self.variables)
         num = self.r2_trace / dfn
         denom = (1 - self.r2_trace) / dfd
@@ -287,7 +271,7 @@ class MCRegressionResult:
         return np.asarray(PvalMethod.SF(frozen, self.F_stat_trace), dtype=np.float64)
 
     def confidence_intervals(self, alpha: FloatScalar = 0.05) -> NDF:
-        self._require_ols_results()
+        self._require_ols()
         q = 1 - alpha / 2
         df = self.n - self.k
         t_crit = t.ppf(q, df)
@@ -301,7 +285,7 @@ class MCRegressionResult:
         index = pd.MultiIndex.from_product(
             [range(self.n_rep), self.variables], names=["rep", "variable"]
         )
-        if not all(isinstance(result, OLSResult) for result in self.results):
+        if not self.is_ols:
             return pd.DataFrame(
                 {
                     "coef": self.coef_trace.reshape(-1),
@@ -324,7 +308,7 @@ class MCRegressionResult:
         )
 
     def F_test(self, alpha: FloatScalar = 0.05) -> MCResult:
-        self._require_ols_results()
+        self._require_ols()
         dfn, dfd = _f_test_degrees_of_freedom(self.n, self.k, self.variables)
         return MCResult(
             test_name="F-test",
@@ -348,3 +332,99 @@ class MCRegressionResult:
             "n": self.n,
             "k": self.k,
         }
+
+
+class MCRegressionAccumulator:
+    """Streaming builder for an :class:`MCRegressionResult` over a replication loop.
+
+    Extracts each replication's sufficient statistics (coefficients, status, SSR,
+    SST, and OLS standard errors) at push time and releases the
+    :class:`RegressionResult`, so neither the design matrix nor the response
+    survives the replication. The standard errors are computed here rather than
+    lazily, since the design they need is gone once the object is released.
+
+    Buffers are sized on ``n_rep`` up front and filled at a cursor, so a run with
+    skipped replications finalizes to the count actually pushed.
+    """
+
+    __slots__ = (
+        "_coef",
+        "_se",
+        "_ssr",
+        "_sst",
+        "_status",
+        "_variables",
+        "_n",
+        "_k",
+        "_is_ols",
+        "_cursor",
+        "_capacity",
+    )
+
+    def __init__(self, n_rep: int) -> None:
+        if n_rep <= 0:
+            raise ValueError("MCRegressionAccumulator requires a positive n_rep.")
+        self._capacity = int(n_rep)
+        self._coef: NDF | None = None
+        self._se: NDF | None = None
+        self._ssr: NDF = np.empty(self._capacity, dtype=np.float64)
+        self._sst: NDF = np.empty(self._capacity, dtype=np.float64)
+        self._status: list[RegressionStatus] = []
+        self._variables: list[str] | None = None
+        self._n = -1
+        self._k = -1
+        self._is_ols = False
+        self._cursor = 0
+
+    @property
+    def n_pushed(self) -> int:
+        """Replications pushed so far."""
+        return self._cursor
+
+    def push(self, result: RegressionResult) -> None:
+        """Record one replication's result, releasing the object to the caller."""
+        if self._variables is None:
+            self._variables = list(result.variables)
+            self._n = result.n
+            self._k = result.k
+            self._is_ols = isinstance(result, OLSResult)
+            self._coef = np.empty((self._capacity, self._k), dtype=np.float64)
+            if self._is_ols:
+                self._se = np.empty((self._capacity, self._k), dtype=np.float64)
+        else:
+            if result.variables != self._variables:
+                raise ValueError("MC regression results have incompatible variables.")
+            if result.n != self._n or result.k != self._k:
+                raise ValueError("MC regression results have incompatible dimensions.")
+            if self._is_ols != isinstance(result, OLSResult):
+                raise ValueError("MC regression results have incompatible kinds.")
+        if self._cursor >= self._capacity:
+            raise ValueError(
+                "MC regression results exceed the accumulator's capacity of "
+                f"{self._capacity} replications."
+            )
+
+        assert self._coef is not None
+        self._coef[self._cursor] = result.coefficients
+        self._ssr[self._cursor] = result.ssr
+        self._sst[self._cursor] = result.sst
+        self._status.append(result.status)
+        if self._se is not None:
+            self._se[self._cursor] = cast(OLSResult, result).se
+        self._cursor += 1
+
+    def finalize(self) -> MCRegressionResult:
+        """Build the summary over the replications pushed so far."""
+        if self._variables is None or self._coef is None:
+            raise ValueError("MCRegressionResult requires at least one result.")
+        cursor = self._cursor
+        return MCRegressionResult(
+            variables=self._variables,
+            coef_trace=self._coef[:cursor].copy(),
+            status_trace=tuple(self._status),
+            ssr_trace=self._ssr[:cursor].copy(),
+            sst_trace=self._sst[:cursor].copy(),
+            n=self._n,
+            is_ols=self._is_ols,
+            stored_se_trace=(None if self._se is None else self._se[:cursor].copy()),
+        )

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -221,6 +221,7 @@ class MCPipelineResult(
     failures: tuple[MCFailure, ...] = (),
     regression_summaries: Mapping[str, MCRegressionResult] = {},
     postproc: Mapping[str, Any] = {},
+    data_summaries: Mapping[str, MCDataSummary] = {},
 )
 ```
 
@@ -240,6 +241,7 @@ __Fields and Properties:__
 | failures | `#!python tuple[MCFailure, ...]` | Failures collected when `fail_fast=False`. |
 | regression_summaries | `#!python Mapping[str, MCRegressionResult]` | Per-regression aggregate result containers. |
 | postproc | `#!python Mapping[str, Any]` | Post-loop artifacts keyed by step name or nested artifact key. |
+| data_summaries | `#!python Mapping[str, MCDataSummary]` | Across-replication summaries of the generated data, keyed by array name (`states`, `observables`, `raw:<name>`). Reduced inside the loop, so they cover every successful replication regardless of retention. |
 | succeeded | `#!python bool` | `True` when no failures were collected. |
 | statistic_traces | `#!python Mapping[str, ndarray]` | Shortcut for each test summary's statistic trace. |
 | pval_traces | `#!python Mapping[str, ndarray]` | Shortcut for each test summary's p-value trace. |

--- a/tests/_oracles/monte_carlo.py
+++ b/tests/_oracles/monte_carlo.py
@@ -1,0 +1,661 @@
+"""Python reference implementation of the Monte Carlo replication loop,
+retained as a parity oracle for the native loop.
+
+This is the driver as it stood before nativization: a Python loop that builds an
+:class:`MCContext` per replication, runs each step through ``step.func``, reduces
+the per-replication results into traces, and samples a bounded pool of the result
+objects themselves. The library's own driver is free to be refactored, deleted,
+or replaced by the native loop; this copy stays put so a native run can be
+compared against the semantics that were signed off.
+
+Frozen here rather than imported, so an edit to ``SymbolicDSGE.monte_carlo`` can
+never silently move the reference:
+
+- the loop driver (:func:`run_replication_loop`) and its step dispatch,
+- the retention model: :func:`pool_stride` plus the three pools,
+- the in-loop reductions: the test, regression, and data accumulators.
+
+Container types (``MCStep`` / ``MCContext`` / ``MCData`` / the result objects)
+are imported, not copied: they are the data model both sides agree on, and a
+divergence there should surface as an import error rather than as silent drift.
+"""
+
+from __future__ import annotations
+
+from time import perf_counter
+from typing import Any, Mapping, Sequence, cast
+
+import numpy as np
+from numpy import float64
+from numpy.typing import NDArray
+
+from SymbolicDSGE._diag_tests.result import MCResult, TestResult
+from SymbolicDSGE._diag_tests.status import TestStatus
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.kalman.filter import FilterRawResult, UnscentedFilterRawResult
+from SymbolicDSGE.monte_carlo.mc_constructs import (
+    MCContext,
+    MCData,
+    MCDataSummary,
+    MCFailure,
+    MCMeta,
+    MCPipelineResult,
+    MCStep,
+    OpType,
+    SourceArgs,
+    failed_postproc_names,
+    failed_step_counts,
+)
+from SymbolicDSGE.regression.enums import RegressionStatus
+from SymbolicDSGE.regression.ols import MCRegressionResult, OLSResult
+from SymbolicDSGE.regression.result import RegressionResult
+
+NDF = NDArray[float64]
+
+
+# --- retention model ---------------------------------------------------------
+def pool_stride(n_rep: int, poolsize: int) -> tuple[bool, int]:
+    """Retention flag and replication stride for a fixed-size inspection pool.
+
+    A non-positive ``poolsize`` disables retention and reports a zero stride the
+    caller never applies (the flag short-circuits ahead of the modulo). Otherwise
+    the stride is ``ceil(n_rep / poolsize)``, which keeps the pool at or under
+    ``poolsize`` entries without a running count, and is 1 for a run shorter than
+    the pool so every replication is kept. Sampling the tail is not guaranteed:
+    the final ``stride - 1`` replications fall outside the sample.
+    """
+    if poolsize <= 0:
+        return False, 0
+    return True, (n_rep + poolsize - 1) // poolsize
+
+
+# --- in-loop reductions ------------------------------------------------------
+def df_metadata_matches(a: object, b: object) -> bool:
+    """Compare normalized df metadata across replications, treating NaN == NaN
+    as a match. Parameter-free reference distributions (CUSUM) carry a NaN df
+    placeholder, which a plain ``!=`` would otherwise flag as incompatible."""
+    at = a if isinstance(a, tuple) else (a,)
+    bt = b if isinstance(b, tuple) else (b,)
+    if len(at) != len(bt):
+        return False
+    for x, y in zip(at, bt):
+        if x == y:
+            continue
+        if (
+            isinstance(x, float | np.floating)
+            and isinstance(y, float | np.floating)
+            and np.isnan(x)
+            and np.isnan(y)
+        ):
+            continue
+        return False
+    return True
+
+
+class TestResultAccumulator:
+    """Streaming builder for an :class:`MCResult` over a replication loop.
+
+    Pulls the statistic and status off each per-replication :class:`TestResult` at
+    push time so the result object itself can be released, and keeps the
+    rep-invariant metadata (``dist`` / ``df`` / ``pval_method`` / ``alpha``) from
+    the first push, rejecting a later result that disagrees. The statistic buffer
+    is sized on ``n_rep`` up front and filled at a cursor, so a run with skipped
+    replications finalizes to the count actually pushed.
+    """
+
+    def __init__(self, n_rep: int) -> None:
+        if n_rep <= 0:
+            raise ValueError("TestResultAccumulator requires a positive n_rep.")
+        self._statistic: NDF = np.empty(n_rep, dtype=np.float64)
+        self._status: list[TestStatus] = []
+        self._metadata: tuple[Any, ...] | None = None
+        self._cursor = 0
+
+    @property
+    def n_pushed(self) -> int:
+        """Replications pushed so far."""
+        return self._cursor
+
+    def push(self, result: TestResult, *, step_name: str = "") -> None:
+        """Record one replication's result, releasing the object to the caller."""
+        metadata = (result.dist, result.df, result.pval_method, result.alpha)
+        if self._metadata is None:
+            self._metadata = metadata
+        else:
+            dist, df, pval_method, alpha = self._metadata
+            if (
+                result.dist is not dist
+                or result.pval_method is not pval_method
+                or not df_metadata_matches(result.df, df)
+                or result.alpha != alpha
+            ):
+                raise ValueError(
+                    f"Test results for step '{step_name}' have incompatible metadata."
+                )
+        if self._cursor >= self._statistic.size:
+            raise ValueError(
+                f"Test results for step '{step_name}' exceed the accumulator's "
+                f"capacity of {self._statistic.size} replications."
+            )
+        self._statistic[self._cursor] = result.statistic
+        self._status.append(result.status)
+        self._cursor += 1
+
+    def finalize(self, test_name: str) -> MCResult:
+        """Build the :class:`MCResult` over the replications pushed so far."""
+        if self._metadata is None:
+            raise ValueError(
+                f"Test results for step '{test_name}' are empty; MCResult requires "
+                "at least one replication."
+            )
+        dist, df, pval_method, alpha = self._metadata
+        return MCResult(
+            test_name=test_name,
+            dist=dist,
+            df=df,
+            pval_method=pval_method,
+            alpha=alpha,
+            statistic_trace=self._statistic[: self._cursor].copy(),
+            status_trace=tuple(self._status),
+        )
+
+
+class RegressionAccumulator:
+    """Streaming builder for an :class:`MCRegressionResult` over a replication loop.
+
+    Extracts each replication's sufficient statistics (coefficients, status, SSR,
+    SST, and OLS standard errors) at push time and releases the
+    :class:`RegressionResult`, so neither the design matrix nor the response
+    survives the replication. The standard errors are computed here rather than
+    lazily, since the design they need is gone once the object is released.
+
+    Buffers are sized on ``n_rep`` up front and filled at a cursor, so a run with
+    skipped replications finalizes to the count actually pushed.
+    """
+
+    def __init__(self, n_rep: int) -> None:
+        if n_rep <= 0:
+            raise ValueError("RegressionAccumulator requires a positive n_rep.")
+        self._capacity = int(n_rep)
+        self._coef: NDF | None = None
+        self._se: NDF | None = None
+        self._ssr: NDF = np.empty(self._capacity, dtype=np.float64)
+        self._sst: NDF = np.empty(self._capacity, dtype=np.float64)
+        self._status: list[RegressionStatus] = []
+        self._variables: list[str] | None = None
+        self._n = -1
+        self._k = -1
+        self._is_ols = False
+        self._cursor = 0
+
+    @property
+    def n_pushed(self) -> int:
+        """Replications pushed so far."""
+        return self._cursor
+
+    def push(self, result: RegressionResult) -> None:
+        """Record one replication's result, releasing the object to the caller."""
+        if self._variables is None:
+            self._variables = list(result.variables)
+            self._n = result.n
+            self._k = result.k
+            self._is_ols = isinstance(result, OLSResult)
+            self._coef = np.empty((self._capacity, self._k), dtype=np.float64)
+            if self._is_ols:
+                self._se = np.empty((self._capacity, self._k), dtype=np.float64)
+        else:
+            if result.variables != self._variables:
+                raise ValueError("MC regression results have incompatible variables.")
+            if result.n != self._n or result.k != self._k:
+                raise ValueError("MC regression results have incompatible dimensions.")
+            if self._is_ols != isinstance(result, OLSResult):
+                raise ValueError("MC regression results have incompatible kinds.")
+        if self._cursor >= self._capacity:
+            raise ValueError(
+                "MC regression results exceed the accumulator's capacity of "
+                f"{self._capacity} replications."
+            )
+
+        assert self._coef is not None
+        self._coef[self._cursor] = result.coefficients
+        self._ssr[self._cursor] = result.ssr
+        self._sst[self._cursor] = result.sst
+        self._status.append(result.status)
+        if self._se is not None:
+            self._se[self._cursor] = cast(OLSResult, result).se
+        self._cursor += 1
+
+    def finalize(self) -> MCRegressionResult:
+        """Build the summary over the replications pushed so far."""
+        if self._variables is None or self._coef is None:
+            raise ValueError("MCRegressionResult requires at least one result.")
+        cursor = self._cursor
+        return MCRegressionResult(
+            variables=self._variables,
+            coef_trace=self._coef[:cursor].copy(),
+            status_trace=tuple(self._status),
+            ssr_trace=self._ssr[:cursor].copy(),
+            sst_trace=self._sst[:cursor].copy(),
+            n=self._n,
+            is_ols=self._is_ols,
+            stored_se_trace=(None if self._se is None else self._se[:cursor].copy()),
+        )
+
+
+class DataAccumulator:
+    """Streaming summary of the :class:`MCData` arrays a run produces.
+
+    One instance covers a whole run: :meth:`push` folds a replication's
+    ``states``, ``observables``, and raw series into per-name running sums, and
+    :meth:`finalize` divides out. Nothing here scales with ``n_rep`` or with the
+    sample dimension, so a replication's arrays are free the moment it ends.
+
+    Statistics are pooled over every finite element of every contributing
+    replication, not averaged over per-replication statistics.
+    """
+
+    #: Raw series carrying the state matrix under a reserved key; already
+    #: summarized as ``states``, so it never gets its own entry.
+    _SKIP_RAW = "_X"
+
+    def __init__(self) -> None:
+        self._n_rep: dict[str, int] = {}
+        self._shape: dict[str, tuple[int, ...]] = {}
+        self._n_values: dict[str, int] = {}
+        self._n_finite: dict[str, int] = {}
+        self._sum: dict[str, float] = {}
+        self._square_sum: dict[str, float] = {}
+        self._min: dict[str, float] = {}
+        self._max: dict[str, float] = {}
+
+    def push(self, data: MCData | None) -> None:
+        """Fold one replication's arrays into the running summaries."""
+        if data is None:
+            return
+        if data.states is not None:
+            self._push_array("states", np.asarray(data.states))
+        if data.observables is not None:
+            self._push_array("observables", np.asarray(data.observables))
+        for name, value in data.raw.items():
+            if name != self._SKIP_RAW:
+                self._push_array(f"raw:{name}", np.asarray(value))
+
+    def _push_array(self, name: str, array: np.ndarray) -> None:
+        if name not in self._n_rep:
+            self._n_rep[name] = 0
+            self._shape[name] = array.shape
+            self._n_values[name] = 0
+            self._n_finite[name] = 0
+            self._sum[name] = 0.0
+            self._square_sum[name] = 0.0
+            self._min[name] = np.inf
+            self._max[name] = -np.inf
+        self._n_rep[name] += 1
+        self._n_values[name] += int(array.size)
+        finite = array[np.isfinite(array)]
+        if finite.size == 0:
+            return
+        self._n_finite[name] += int(finite.size)
+        self._sum[name] += float(finite.sum())
+        self._square_sum[name] += float(np.square(finite).sum())
+        self._min[name] = min(self._min[name], float(finite.min()))
+        self._max[name] = max(self._max[name], float(finite.max()))
+
+    def finalize(self) -> dict[str, MCDataSummary]:
+        """The per-name summaries, in first-seen order."""
+        return {name: self._finalize_one(name) for name in self._n_rep}
+
+    def _finalize_one(self, name: str) -> MCDataSummary:
+        n_finite = self._n_finite[name]
+        if n_finite == 0:
+            return MCDataSummary(
+                n_rep=self._n_rep[name],
+                shape=self._shape[name],
+                n_values=self._n_values[name],
+                n_finite=0,
+                mean=None,
+                std=None,
+                min=None,
+                max=None,
+            )
+        mean = self._sum[name] / n_finite
+        # Clamped because the sum-of-squares form can go slightly negative on a
+        # near-constant series once cancellation bites.
+        variance = max(0.0, self._square_sum[name] / n_finite - mean**2)
+        return MCDataSummary(
+            n_rep=self._n_rep[name],
+            shape=self._shape[name],
+            n_values=self._n_values[name],
+            n_finite=n_finite,
+            mean=mean,
+            std=variance**0.5,
+            min=self._min[name],
+            max=self._max[name],
+        )
+
+
+# --- step dispatch -----------------------------------------------------------
+def resolve_source_array(context: MCContext, selector: SourceArgs) -> NDF:
+    """One step input, read out of an earlier step's payload slot."""
+    out: NDF = context.payload_slots[selector.source_idx][selector.field_idx][
+        selector.row_start :, selector.column_selector
+    ]
+    return out
+
+
+def run_step(context: MCContext, step: MCStep) -> None:
+    """Run one step against the replication's context, writing its output back."""
+    kwargs = dict(step.kwargs)
+    for selector in step.source_args:
+        kwargs[selector.arg] = resolve_source_array(context, selector)
+    if step.op_type is OpType.DATAGEN:
+        out = step.func(
+            reference=context.reference,
+            dgp=context.dgp,
+            rep_idx=context.rep_idx,
+            **kwargs,
+        )
+
+        if not isinstance(out, MCData):
+            raise TypeError("DATAGEN steps must return MCData.")
+        context.data = out
+        context.payload_slots.append(out)
+        context.payloads[step.output_key] = out
+        return
+
+    out = step.func(
+        context=context,
+        reference=context.reference,
+        dgp=context.dgp,
+        rep_idx=context.rep_idx,
+        **kwargs,
+    )
+    if step.op_type is OpType.TRANSFORM and isinstance(out, MCData):
+        context.data = out
+    if step.op_type is OpType.FILTER and not isinstance(
+        out,
+        (FilterRawResult, UnscentedFilterRawResult),
+    ):
+        raise TypeError("FILTER steps must return a raw filter result.")
+    if step.op_type is OpType.REGRESSION and not isinstance(out, RegressionResult):
+        raise TypeError("REGRESSION steps must return RegressionResult.")
+    if step.op_type is OpType.REGRESSION:
+        context.regressions[step.name] = out  # pyright: ignore
+    if step.op_type is OpType.TEST:
+        if not isinstance(out, TestResult):
+            raise TypeError("TEST steps must return TestResult.")
+        context.results[step.name] = out
+    context.payload_slots.append(source_slot(step, out))
+    context.payloads[step.output_key] = out
+
+
+def source_slot(step: MCStep, out: Any) -> Any:
+    if step.op_type is OpType.TRANSFORM:
+        if isinstance(out, MCData):
+            return (out,)
+        return (source_array(out),)
+    return out
+
+
+def source_array(value: Any) -> np.ndarray:
+    arr = np.asarray(value, dtype=np.float64)
+    if arr.ndim == 1:
+        return arr.reshape(-1, 1)
+    if arr.ndim != 2:
+        raise ValueError(
+            f"Transform payloads used as sources must be 1D or 2D, got shape {arr.shape}."
+        )
+    return arr
+
+
+# --- post-loop payload traces ------------------------------------------------
+def payload_to_array(value: object) -> np.ndarray | None:
+    """A per-rep payload value as a stackable numeric array, else ``None``.
+
+    Only numeric ndarray / scalar payloads (e.g. transform outputs) qualify;
+    structured payloads (``MCData`` / raw filter results / result objects) are
+    skipped from the post-loop trace registry.
+    """
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, (int, float, np.number)):
+        return np.asarray(value, dtype=np.float64)
+    return None
+
+
+def accumulate_payload_columns(
+    columns: dict[str, list[np.ndarray]], payloads: Mapping[str, object]
+) -> None:
+    for key, value in payloads.items():
+        array = payload_to_array(value)
+        if array is not None:
+            columns.setdefault(key, []).append(array)
+
+
+def stack_payload_columns(
+    columns: Mapping[str, list[np.ndarray]],
+) -> dict[str, np.ndarray]:
+    """Stack per-rep payload arrays into ``payload.<name>`` traces.
+
+    Only keys whose per-rep arrays share a shape across replications are stacked
+    (a transform whose output length varies per rep is skipped)."""
+    from SymbolicDSGE.monte_carlo.traces import payload_trace_key
+
+    out: dict[str, np.ndarray] = {}
+    for name, arrays in columns.items():
+        if arrays and len({array.shape for array in arrays}) == 1:
+            out[payload_trace_key(name)] = np.stack(arrays)
+    return out
+
+
+def run_postproc(
+    postproc_steps: Sequence[MCStep],
+    *,
+    test_summaries: Mapping[str, Any],
+    regression_summaries: Mapping[str, Any],
+    payload_columns: Mapping[str, list[np.ndarray]],
+    fail_fast: bool,
+    failures: list[MCFailure],
+) -> tuple[dict[str, Any], dict[str, float]]:
+    """Run POSTPROC ops once over the assembled traces; collect artifacts.
+
+    Owns its own timing: returns ``(artifacts, postproc_elapsed_s)`` where the
+    second maps each step name to its wall-clock seconds. ``traces`` carries
+    every keyed across-rep ndarray: the test/regression summary traces (shared
+    with the result wire) plus stacked transform payloads. A failing op honors
+    ``fail_fast`` (re-raise) or records an :class:`MCFailure` with ``rep_idx=-1``
+    (post-loop sentinel) and is skipped.
+    """
+    postproc_elapsed_s: dict[str, float] = {step.name: 0.0 for step in postproc_steps}
+    if not postproc_steps:
+        return {}, postproc_elapsed_s
+
+    from SymbolicDSGE.monte_carlo.serialize import traces_from_summaries
+
+    traces: dict[str, np.ndarray] = traces_from_summaries(
+        test_summaries, regression_summaries
+    )
+    traces.update(stack_payload_columns(payload_columns))
+
+    postproc: dict[str, Any] = {}
+    for step in postproc_steps:
+        step_start = perf_counter()
+        out: Any = None
+        failed = False
+        try:
+            out = step.func(traces=traces, **dict(step.kwargs))
+        except Exception as exc:
+            failed = True
+            if fail_fast:
+                raise
+            failures.append(
+                MCFailure(
+                    rep_idx=-1,
+                    step_name=step.name,
+                    error_type=type(exc).__name__,
+                    message=str(exc),
+                )
+            )
+        finally:
+            postproc_elapsed_s[step.name] += perf_counter() - step_start
+        if not failed:
+            postproc[step.name] = out
+    return postproc, postproc_elapsed_s
+
+
+# --- the loop ----------------------------------------------------------------
+def run_replication_loop(
+    per_rep_steps: Sequence[MCStep],
+    postproc_steps: Sequence[MCStep] = (),
+    *,
+    reference: SolvedModel,
+    dgp: SolvedModel | None = None,
+    n_rep: int,
+    payload_poolsize: int = 10000,
+    test_result_poolsize: int = 10000,
+    context_poolsize: int = 0,
+    fail_fast: bool = True,
+) -> MCPipelineResult:
+    """The pre-native replication loop, over already-bound steps.
+
+    Takes the step tuples rather than an ``MCPipeline`` so validation and source
+    binding stay with the library: this is the executor, not the compiler. Pass
+    ``pipeline.per_rep_steps`` / ``pipeline.postproc_steps`` to drive it from a
+    pipeline built the normal way.
+    """
+    if n_rep <= 0:
+        raise ValueError("n_rep must be positive.")
+
+    n_successful = 0
+    retain_payloads, payload_stride = pool_stride(n_rep, payload_poolsize)
+    retain_test_results, test_stride = pool_stride(n_rep, test_result_poolsize)
+    retain_contexts, context_stride = pool_stride(n_rep, context_poolsize)
+
+    contexts: list[MCContext] = []
+    payload_traces: list[Mapping[str, object]] = []
+    failures: list[MCFailure] = []
+    # Test / regression results are reduced to their traces as each replication
+    # finishes, so the result objects never accumulate. The strided pools below
+    # retain a bounded sample of the objects themselves for inspection; the
+    # traces they summarize stay full length, so pooling never costs MC
+    # granularity.
+    test_accumulators: dict[str, TestResultAccumulator] = {}
+    regression_accumulators: dict[str, RegressionAccumulator] = {}
+    test_result_pool: dict[str, list[TestResult]] = {}
+    # The generated data is the largest per-replication object, so it is
+    # summarized on the spot and dropped rather than retained behind a pool.
+    data_accumulator = DataAccumulator()
+    # Per-replication step timings feed the it/s rates. Postproc runs once after
+    # the loop and times itself; its runtime is never folded into the it/s
+    # denominator.
+    step_elapsed_s: dict[str, float] = {s.name: 0.0 for s in per_rep_steps}
+    step_counts: dict[str, int] = {s.name: 0 for s in per_rep_steps}
+    step_failures: dict[str, int] = {s.name: 0 for s in per_rep_steps}
+    payload_columns: dict[str, list[np.ndarray]] = {}
+
+    loop_start = perf_counter()
+    for rep_idx in range(n_rep):
+        context = MCContext(rep_idx=rep_idx, reference=reference, dgp=dgp)
+        failed_step_name: str | None = None
+        try:
+            for step in per_rep_steps:
+                failed_step_name = step.name
+                step_start = perf_counter()
+                try:
+                    run_step(context, step)
+                except Exception:
+                    step_failures[step.name] += 1
+                    raise
+                finally:
+                    step_elapsed_s[step.name] += perf_counter() - step_start
+                    step_counts[step.name] += 1
+        except Exception as exc:
+            if fail_fast:
+                raise
+            failures.append(
+                MCFailure(
+                    rep_idx=rep_idx,
+                    step_name=failed_step_name or "",
+                    error_type=type(exc).__name__,
+                    message=str(exc),
+                )
+            )
+            continue
+
+        n_successful += 1
+        data_accumulator.push(context.data)
+        if retain_contexts and (rep_idx % context_stride == 0):
+            contexts.append(context)
+        if retain_payloads and (rep_idx % payload_stride == 0):
+            payload_traces.append(dict(context.payloads))
+        pool_test_results = retain_test_results and (rep_idx % test_stride == 0)
+        for name, test_result in context.results.items():
+            accumulator = test_accumulators.get(name)
+            if accumulator is None:
+                accumulator = test_accumulators[name] = TestResultAccumulator(n_rep)
+            accumulator.push(test_result, step_name=name)
+            if pool_test_results:
+                test_result_pool.setdefault(name, []).append(test_result)
+        for name, regression_result in context.regressions.items():
+            regression_accumulator = regression_accumulators.get(name)
+            if regression_accumulator is None:
+                regression_accumulator = regression_accumulators[name] = (
+                    RegressionAccumulator(n_rep)
+                )
+            regression_accumulator.push(regression_result)
+        if postproc_steps:
+            accumulate_payload_columns(payload_columns, context.payloads)
+
+    # Stop the replication-loop clock here; it/s is n_rep over the loop alone.
+    # Post-loop aggregation and the once-run postproc phase are timed separately
+    # and never enter the it/s denominator.
+    elapsed_s = perf_counter() - loop_start
+
+    test_summaries = {
+        name: accumulator.finalize(name)
+        for name, accumulator in test_accumulators.items()
+    }
+    regression_summaries = {
+        name: accumulator.finalize()
+        for name, accumulator in regression_accumulators.items()
+    }
+    postproc, postproc_elapsed_s = run_postproc(
+        postproc_steps,
+        test_summaries=test_summaries,
+        regression_summaries=regression_summaries,
+        payload_columns=payload_columns,
+        fail_fast=fail_fast,
+        failures=failures,
+    )
+
+    meta = MCMeta(
+        n_rep=n_rep,
+        payloads_retained=retain_payloads,
+        test_results_retained=retain_test_results,
+        contexts_retained=retain_contexts,
+        elapsed_s=elapsed_s,
+        step_elapsed_s=step_elapsed_s,
+        step_counts=step_counts,
+        step_failures=step_failures,
+        postproc_elapsed_s=postproc_elapsed_s,
+        failed_postprocs=failed_postproc_names(failures),
+        failed_steps=failed_step_counts(failures),
+    )
+
+    return MCPipelineResult(
+        n_rep=n_rep,
+        meta=meta,
+        n_successful=n_successful,
+        test_summaries=test_summaries,
+        test_results=(
+            {name: tuple(values) for name, values in test_result_pool.items()}
+            if retain_test_results
+            else None
+        ),
+        payloads=tuple(payload_traces) if retain_payloads else None,
+        contexts=tuple(contexts) if retain_contexts else None,
+        failures=tuple(failures),
+        regression_summaries=regression_summaries,
+        postproc=postproc,
+        data_summaries=data_accumulator.finalize(),
+    )

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -204,7 +204,7 @@ def test_raw_model_data_pipeline_runs_without_dgp_and_aggregates_wald_results() 
         ]
     )
 
-    out = pipeline.run(reference=reference, n_rep=2, retain_contexts=True)
+    out = pipeline.run(reference=reference, n_rep=2, context_poolsize=10000)
 
     statistic = wald_mean_hac(states, target, bandwidth=0).statistic
     expected = np.full(2, statistic, dtype=np.float64)
@@ -241,7 +241,7 @@ def test_raw_model_data_pipeline_accepts_observables_without_states() -> None:
         ]
     )
 
-    out = pipeline.run(reference=reference, n_rep=2, retain_contexts=True)
+    out = pipeline.run(reference=reference, n_rep=2, context_poolsize=10000)
 
     statistic = wald_mean_hac(observables, target, bandwidth=0).statistic
     expected = np.full(2, statistic, dtype=np.float64)
@@ -508,7 +508,7 @@ def test_add_payload_step_registers_1d_payload_for_downstream_steps() -> None:
         ]
     )
 
-    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, retain_contexts=True)
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2, context_poolsize=10000)
 
     expected = wald_mean_hac(payload.reshape(-1, 1), target, bandwidth=0).statistic
     np.testing.assert_allclose(
@@ -872,8 +872,9 @@ def test_pipeline_retention_controls_drop_payload_and_result_traces() -> None:
     out = pipeline.run(
         reference=reference,
         n_rep=2,
-        retain_payloads=False,
-        retain_test_results=False,
+        payload_poolsize=0,
+        test_result_poolsize=0,
+        context_poolsize=0,
     )
 
     assert out.payloads is None
@@ -1127,7 +1128,7 @@ def test_transform_step_returning_mcdata_updates_downstream_data() -> None:
         ]
     )
 
-    out = pipeline.run(reference=reference, n_rep=2, retain_contexts=True)
+    out = pipeline.run(reference=reference, n_rep=2, context_poolsize=10000)
 
     np.testing.assert_allclose(reference.kalman_calls[0]["y"], observables + 1.0)
     assert out.contexts is not None
@@ -1201,7 +1202,7 @@ def test_regression_summary_does_not_depend_on_payload_retention() -> None:
         ]
     )
 
-    out = pipeline.run(reference=reference, n_rep=2, retain_payloads=False)
+    out = pipeline.run(reference=reference, n_rep=2, payload_poolsize=0)
 
     assert out.payloads is None
     assert out.test_summaries == {}

--- a/tests/monte_carlo/test_serialize.py
+++ b/tests/monte_carlo/test_serialize.py
@@ -98,7 +98,7 @@ def _run_demo_pipeline(n_rep: int = 3) -> MCPipelineResult:
     return pipeline.run(
         reference=cast(SolvedModel, object()),
         n_rep=n_rep,
-        retain_contexts=True,
+        context_poolsize=10000,
         verbosity=0,
     )
 

--- a/tests/regression/test_ols_solvers.py
+++ b/tests/regression/test_ols_solvers.py
@@ -308,10 +308,6 @@ def test_mc_regression_result_computes_vectorized_diagnostics() -> None:
         np.vstack([result.coefficients for result in results]),
     )
     np.testing.assert_allclose(
-        out.y_hat_trace,
-        np.vstack([result.y_hat for result in results]),
-    )
-    np.testing.assert_allclose(
         out.se_trace,
         np.vstack([result.se for result in results]),
     )

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -22,7 +22,8 @@ from SymbolicDSGE.ui.serializers import decode_array, encode_array
 from SymbolicDSGE._diag_tests.distributions import PvalMethod, ReferenceDistribution
 from SymbolicDSGE._diag_tests.result import MCResult
 from SymbolicDSGE._diag_tests.status import TestStatus
-from SymbolicDSGE.monte_carlo import MCContext, MCData, MCPipelineResult
+from SymbolicDSGE.monte_carlo import MCData, MCPipelineResult
+from SymbolicDSGE.monte_carlo.mc_constructs import MCDataAccumulator
 from SymbolicDSGE.monte_carlo.mc_constructs import MCMeta
 from SymbolicDSGE.regression.ols import MCRegressionResult, ols
 
@@ -1032,14 +1033,12 @@ def test_ui_backend_serializes_detailed_mc_summaries() -> None:
         statistic_trace=np.array([0.5, 1.5], dtype=np.float64),
         status_trace=(TestStatus.OK, TestStatus.BAD_SHAPE),
     )
-    context = MCContext(
-        rep_idx=0,
-        reference=None,  # type: ignore[arg-type]
-        dgp=None,
-        data=MCData(
+    data_accumulator = MCDataAccumulator()
+    data_accumulator.push(
+        MCData(
             states=np.arange(12, dtype=np.float64).reshape(4, 3),
             raw={"x": np.arange(4, dtype=np.float64)},
-        ),
+        )
     )
     result = MCPipelineResult(
         n_rep=2,
@@ -1053,8 +1052,9 @@ def test_ui_backend_serializes_detailed_mc_summaries() -> None:
         test_summaries={"diagnostic": tests},
         test_results=None,
         payloads=None,
-        contexts=(context,),
+        contexts=None,
         regression_summaries={"ols": regressions},
+        data_summaries=data_accumulator.finalize(),
     )
 
     payload = serialize_pipeline_result(result, run_id="run")


### PR DESCRIPTION
Reduces per-replication results to traces inside the replication loop, and replaces the boolean retention flags with fixed-size sample pools.

- `MCPipeline.run` takes `payload_poolsize` / `test_result_poolsize` / `context_poolsize` in place of `retain_payloads` / `retain_test_results` / `retain_contexts`. A pool retains at most `poolsize` replications on a `ceil(n_rep / poolsize)` stride; `0` disables retention. `context_poolsize` defaults to `0`.
- Test, regression, and data results are pushed into accumulators as each replication finishes and the objects released: `MCResultAccumulator`, `MCRegressionAccumulator`, `MCDataAccumulator`. Traces stay full length under any pool size.
- `MCPipelineResult.data_summaries` carries per-array `MCDataSummary` reductions and backs the wire's `data_summaries`, which now covers every successful replication instead of the retained contexts.
- `MCRegressionResult` holds the sufficient statistics of each solve: `coef_trace`, `stored_se_trace`, `ssr_trace`, `sst_trace`, `status_trace`, `n`, `is_ols`.
- `tests/_oracles/monte_carlo.py` freezes the Python replication loop as a parity oracle for the native port.

**Breaking surfaces**

- `MCRegressionResult.results`, `x_trace`, `y_trace`, `y_hat_trace`, and `residual_trace` removed. `MCRegressionResult(variables=..., results=...)` no longer constructs; use `from_results` or `accumulator`.
- `MCPipeline.run` retention keywords renamed and retyped from `bool` to `int`. Contexts are no longer retained by default.

closes #343 