### PR TITLE
Add native Monte Carlo kernels and buffer planning

### DIFF
--- a/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyi
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyi
@@ -1,0 +1,18 @@
+from numpy import float64
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+
+def ols_fit(
+    X: _F64,  # (n, p)
+    y: _F64,  # (n,)
+    coef: _F64,  # (p,)
+    se: _F64,  # (p,)
+    L: _F64,  # (p, p)
+    G: _F64,  # (p, p)
+    g: _F64,  # (p,)
+    work: _F64,  # (p,)
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+
+"""OLS backend for MC replications. Writes into {coef, se, L, G, g} and returns {ssr, sst, status}."""

--- a/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyi
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyi
@@ -1,7 +1,8 @@
-from numpy import float64
+from numpy import float64, int64
 from numpy.typing import NDArray
 
 _F64 = NDArray[float64]
+_I64 = NDArray[int64]
 
 def ols_fit(
     X: _F64,  # (n, p)
@@ -12,6 +13,94 @@ def ols_fit(
     G: _F64,  # (p, p)
     g: _F64,  # (p,)
     work: _F64,  # (p,)
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def ridge_fit(
+    X: _F64,
+    y: _F64,
+    coef: _F64,
+    alpha: float,
+    L: _F64,
+    G: _F64,
+    G_unpen: _F64,
+    g: _F64,
+    col: _F64,
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def ridge_gs_fit(
+    X: _F64,
+    y: _F64,
+    alphas: _F64,
+    criterion: int,
+    coef: _F64,
+    G_base: _F64,
+    G: _F64,
+    L: _F64,
+    g: _F64,
+    coef_work: _F64,
+    col: _F64,
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def lasso_fit(
+    X: _F64,
+    y: _F64,
+    coef: _F64,
+    alpha: float,
+    max_iter: int,
+    tol: float,
+    G_base: _F64,
+    G: _F64,
+    g: _F64,
+    Gcoef: _F64,
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def lasso_gs_fit(
+    X: _F64,
+    y: _F64,
+    alphas: _F64,
+    coef: _F64,
+    max_iter: int,
+    tol: float,
+    G_base: _F64,
+    G: _F64,
+    g: _F64,
+    lam_path: _F64,
+    beta_path: _F64,
+    beta_grid: _F64,
+    work: _F64,
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def elastic_net_fit(
+    X: _F64,
+    y: _F64,
+    coef: _F64,
+    alpha: float,
+    l1_ratio: float,
+    max_iter: int,
+    tol: float,
+    G_base: _F64,
+    G: _F64,
+    g: _F64,
+    Gcoef: _F64,
+    intercept: bool,
+) -> tuple[float64, float64, int]: ...
+def elastic_net_gs_fit(
+    X: _F64,
+    y: _F64,
+    alphas: _F64,
+    l1_ratio: float,
+    criterion: int,
+    coef: _F64,
+    max_iter: int,
+    tol: float,
+    G_base: _F64,
+    G: _F64,
+    g: _F64,
+    beta_grid: _F64,
+    statuses: _I64,
+    Gcoef: _F64,
+    beta: _F64,
+    dof_work: _F64,
     intercept: bool,
 ) -> tuple[float64, float64, int]: ...
 

--- a/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
@@ -30,6 +30,43 @@ cdef extern from "regression.h":
         double *g,
         double *work,
     ) nogil
+    void sdsge_mc_ridge_fit(
+        const double *X, const double *y, double alpha, int64_t intercept,
+        sdsge_mc_regression_record *rec, double *L, double *G,
+        double *G_unpen, double *g, double *col,
+    ) nogil
+    void sdsge_mc_ridge_gs_fit(
+        const double *X, const double *y, const double *alphas,
+        int64_t n_alpha, int64_t criterion, int64_t intercept,
+        sdsge_mc_regression_record *rec, double *G_base, double *G,
+        double *L, double *g, double *coef_work, double *col,
+    ) nogil
+    void sdsge_mc_lasso_fit(
+        const double *X, const double *y, double alpha, int64_t intercept,
+        int64_t max_iter, double tol, sdsge_mc_regression_record *rec,
+        double *G_base, double *G, double *g, double *Gcoef,
+    ) nogil
+    void sdsge_mc_lasso_gs_fit(
+        const double *X, const double *y, const double *alphas,
+        int64_t n_alpha, int64_t intercept, int64_t max_iter, double tol,
+        sdsge_mc_regression_record *rec, double *G_base, double *G,
+        double *g, double *lam_path, double *beta_path, double *beta_grid,
+        double *work,
+    ) nogil
+    void sdsge_mc_elastic_net_fit(
+        const double *X, const double *y, double alpha, double l1_ratio,
+        int64_t intercept, int64_t max_iter, double tol,
+        sdsge_mc_regression_record *rec, double *G_base, double *G,
+        double *g, double *Gcoef,
+    ) nogil
+    void sdsge_mc_elastic_net_gs_fit(
+        const double *X, const double *y, const double *alphas,
+        int64_t n_alpha, double l1_ratio, int64_t criterion,
+        int64_t intercept, int64_t max_iter, double tol,
+        sdsge_mc_regression_record *rec, double *G_base, double *G,
+        double *g, double *beta_grid, int64_t *statuses, double *Gcoef,
+        double *beta, double *dof_work,
+    ) nogil
 
 
 def ols_fit(X, y, coef, se, L, G, g, work, bint intercept=True):
@@ -91,4 +128,205 @@ def ols_fit(X, y, coef, se, L, G, g, work, bint intercept=True):
             &X_mv[0, 0], &y_mv[0], &rec, &L_mv[0], &G_mv[0], &g_mv[0], &work_mv[0]
         )
 
+    return rec.ssr, rec.sst, rec.status
+
+
+def ridge_fit(X, y, coef, double alpha, L, G, G_unpen, g, col,
+              bint intercept=True):
+    """Fit ridge into caller-owned result and solver buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] L_mv = L
+    cdef double[::1] G_mv = G
+    cdef double[::1] G_unpen_mv = G_unpen
+    cdef double[::1] g_mv = g
+    cdef double[::1] col_mv = col
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_ridge_fit(
+            &X_mv[0, 0], &y_mv[0], alpha, intercept, &rec, &L_mv[0],
+            &G_mv[0], &G_unpen_mv[0], &g_mv[0], &col_mv[0]
+        )
+    return rec.ssr, rec.sst, rec.status
+
+
+def ridge_gs_fit(X, y, alphas, int64_t criterion, coef, G_base, G, L, g,
+                 coef_work, col, bint intercept=True):
+    """Run native ridge grid search into caller-owned buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] alphas_mv = alphas
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] G_base_mv = G_base
+    cdef double[::1] G_mv = G
+    cdef double[::1] L_mv = L
+    cdef double[::1] g_mv = g
+    cdef double[::1] coef_work_mv = coef_work
+    cdef double[::1] col_mv = col
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_ridge_gs_fit(
+            &X_mv[0, 0], &y_mv[0], &alphas_mv[0], alphas_mv.shape[0], criterion,
+            intercept, &rec, &G_base_mv[0], &G_mv[0], &L_mv[0], &g_mv[0],
+            &coef_work_mv[0], &col_mv[0]
+        )
+    return rec.ssr, rec.sst, rec.status
+
+
+def lasso_fit(X, y, coef, double alpha, int64_t max_iter, double tol,
+              G_base, G, g, Gcoef, bint intercept=True):
+    """Fit lasso into caller-owned result and Gram-solver buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] G_base_mv = G_base
+    cdef double[::1] G_mv = G
+    cdef double[::1] g_mv = g
+    cdef double[::1] Gcoef_mv = Gcoef
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_lasso_fit(
+            &X_mv[0, 0], &y_mv[0], alpha, intercept, max_iter, tol, &rec,
+            &G_base_mv[0], &G_mv[0], &g_mv[0], &Gcoef_mv[0]
+        )
+    return rec.ssr, rec.sst, rec.status
+
+
+def lasso_gs_fit(X, y, alphas, coef, int64_t max_iter, double tol,
+                 G_base, G, g, lam_path, beta_path, beta_grid, work,
+                 bint intercept=True):
+    """Run native lasso grid search into caller-owned path and solver buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] alphas_mv = alphas
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] G_base_mv = G_base
+    cdef double[::1] G_mv = G
+    cdef double[::1] g_mv = g
+    cdef double[::1] lam_path_mv = lam_path
+    cdef double[::1] beta_path_mv = beta_path
+    cdef double[::1] beta_grid_mv = beta_grid
+    cdef double[::1] work_mv = work
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_lasso_gs_fit(
+            &X_mv[0, 0], &y_mv[0], &alphas_mv[0], alphas_mv.shape[0],
+            intercept, max_iter, tol, &rec, &G_base_mv[0], &G_mv[0], &g_mv[0],
+            &lam_path_mv[0], &beta_path_mv[0], &beta_grid_mv[0], &work_mv[0]
+        )
+    return rec.ssr, rec.sst, rec.status
+
+
+def elastic_net_fit(X, y, coef, double alpha, double l1_ratio,
+                    int64_t max_iter, double tol, G_base, G, g, Gcoef,
+                    bint intercept=True):
+    """Fit elastic net into caller-owned result and Gram-solver buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] G_base_mv = G_base
+    cdef double[::1] G_mv = G
+    cdef double[::1] g_mv = g
+    cdef double[::1] Gcoef_mv = Gcoef
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_elastic_net_fit(
+            &X_mv[0, 0], &y_mv[0], alpha, l1_ratio, intercept, max_iter, tol,
+            &rec, &G_base_mv[0], &G_mv[0], &g_mv[0], &Gcoef_mv[0]
+        )
+    return rec.ssr, rec.sst, rec.status
+
+
+def elastic_net_gs_fit(X, y, alphas, double l1_ratio, int64_t criterion,
+                       coef, int64_t max_iter, double tol, G_base, G, g,
+                       beta_grid, statuses, Gcoef, beta, dof_work,
+                       bint intercept=True):
+    """Run native elastic-net grid search into caller-owned buffers."""
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] alphas_mv = alphas
+    cdef double[::1] coef_mv = coef
+    cdef double[::1] G_base_mv = G_base
+    cdef double[::1] G_mv = G
+    cdef double[::1] g_mv = g
+    cdef double[::1] beta_grid_mv = beta_grid
+    cdef int64_t[::1] statuses_mv = statuses
+    cdef double[::1] Gcoef_mv = Gcoef
+    cdef double[::1] beta_mv = beta
+    cdef double[::1] dof_work_mv = dof_work
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+    X_mv = X_array
+    y_mv = y_array
+    rec.n = X_mv.shape[0]
+    rec.p = X_mv.shape[1]
+    rec.coef = &coef_mv[0]
+    rec.se = NULL
+    with nogil:
+        sdsge_mc_elastic_net_gs_fit(
+            &X_mv[0, 0], &y_mv[0], &alphas_mv[0], alphas_mv.shape[0], l1_ratio,
+            criterion, intercept, max_iter, tol, &rec, &G_base_mv[0], &G_mv[0],
+            &g_mv[0], &beta_grid_mv[0], &statuses_mv[0], &Gcoef_mv[0],
+            &beta_mv[0], &dof_work_mv[0]
+        )
     return rec.ssr, rec.sst, rec.status

--- a/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
@@ -1,0 +1,94 @@
+
+
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Thin Python shim for native Monte Carlo regression kernels.
+
+The caller owns result and solver-work buffers. The eventual native MC
+executor can use the same ABI with its preallocated trace rows and scratch
+space.
+"""
+
+from libc.stdint cimport int64_t
+import numpy as np
+
+cdef extern from "regression.h":
+    ctypedef struct sdsge_mc_regression_record:
+        int64_t n
+        int64_t p
+        double *coef
+        double *se
+        double ssr
+        double sst
+        int64_t status
+
+    void sdsge_mc_ols_fit(
+        const double *X,
+        const double *y,
+        sdsge_mc_regression_record *rec,
+        double *L,
+        double *G,
+        double *g,
+        double *work,
+    ) nogil
+
+
+def ols_fit(X, y, coef, se, L, G, g, work, bint intercept=True):
+    """Fit OLS and return raw native result fields.
+
+    ``X`` must be a two-dimensional design and ``y`` a one-dimensional
+    response with the same number of rows. ``coef`` and ``se`` must each have
+    one slot per effective regressor. ``L``, ``G``, ``g``, and ``work`` are
+    caller-owned solver scratch buffers of sizes ``p*p``, ``p*p``, ``p``, and
+    ``p``. When requested, the intercept column is materialized here before
+    the GIL is released.
+    """
+    cdef double[:, ::1] X_mv
+    cdef double[::1] y_mv
+    cdef double[::1] coef_mv
+    cdef double[::1] se_mv
+    cdef double[::1] L_mv
+    cdef double[::1] G_mv
+    cdef double[::1] g_mv
+    cdef double[::1] work_mv
+    cdef int64_t n
+    cdef int64_t p
+    cdef sdsge_mc_regression_record rec
+
+    X_array = np.ascontiguousarray(X, dtype=np.float64)
+    y_array = np.ascontiguousarray(y, dtype=np.float64)
+    if X_array.ndim != 2:
+        raise ValueError("X must be a two-dimensional array.")
+    if y_array.ndim != 1:
+        raise ValueError("y must be a one-dimensional array.")
+    if X_array.shape[0] != y_array.shape[0]:
+        raise ValueError("X and y must have the same number of rows.")
+    if X_array.shape[0] == 0:
+        raise ValueError("OLS requires at least one row.")
+    if X_array.shape[1] == 0 and not intercept:
+        raise ValueError("OLS without an intercept requires at least one regressor.")
+
+    if intercept:
+        X_array = np.column_stack((np.ones(X_array.shape[0]), X_array))
+
+    X_mv = X_array
+    y_mv = y_array
+    n = X_mv.shape[0]
+    p = X_mv.shape[1]
+
+    coef_mv = coef
+    se_mv = se
+    L_mv = L
+    G_mv = G
+    g_mv = g
+    work_mv = work
+
+    rec.n = n
+    rec.p = p
+    rec.coef = &coef_mv[0]
+    rec.se = &se_mv[0]
+    with nogil:
+        sdsge_mc_ols_fit(
+            &X_mv[0, 0], &y_mv[0], &rec, &L_mv[0], &G_mv[0], &g_mv[0], &work_mv[0]
+        )
+
+    return rec.ssr, rec.sst, rec.status

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.c
@@ -4,6 +4,7 @@
 #include "../regression/lasso.h"
 #include "../regression/regression.h"
 #include <math.h>
+#include <stddef.h>
 
 static void sdsge_mc_set_failure(sdsge_mc_regression_record *rec) {
   for (i64 i = 0; i < rec->p; ++i)
@@ -16,7 +17,7 @@ static void sdsge_mc_set_failure(sdsge_mc_regression_record *rec) {
 }
 
 static void sdsge_mc_compute_ssr_sst(const f64 *X, const f64 *y,
-                                      sdsge_mc_regression_record *rec) {
+                                     sdsge_mc_regression_record *rec) {
   const i64 n = rec->n;
   const i64 p = rec->p;
   f64 ssr = 0.0;
@@ -76,8 +77,7 @@ static void sdsge_mc_sparse_gram(const f64 *X, const f64 *y,
       g[i] = g[row] - G_base[row * p] * y_mean;
       for (i64 j = 0; j < k; ++j) {
         const i64 col = j + 1;
-        G[i * k + j] = G_base[row * p + col] -
-                           G_base[row * p] * G_base[col];
+        G[i * k + j] = G_base[row * p + col] - G_base[row * p] * G_base[col];
       }
     }
     g[k] = y_mean;
@@ -133,15 +133,15 @@ void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
   }
 }
 
-void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-                        f64 alpha, i64 intercept,
+void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X,
+                        const f64 *SDSGE_RESTRICT y, f64 alpha, i64 intercept,
                         sdsge_mc_regression_record *SDSGE_RESTRICT rec,
                         f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
                         f64 *SDSGE_RESTRICT G_unpen, f64 *SDSGE_RESTRICT g,
                         f64 *SDSGE_RESTRICT col) {
   f64 dof = 0.0;
   sdsge_chol_solve_L2(X, y, rec->n, rec->p, alpha, intercept, rec->coef, L,
-                       &dof, &rec->status, G, G_unpen, g, col);
+                      &dof, &rec->status, G, G_unpen, g, col);
   if (rec->status == REGRESSION_OK)
     sdsge_mc_compute_ssr_sst(X, y, rec);
   else
@@ -150,28 +150,27 @@ void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y
 
 void sdsge_mc_ridge_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion,
-    i64 intercept, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion, i64 intercept,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec, f64 *SDSGE_RESTRICT G_base,
+    f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
     f64 *SDSGE_RESTRICT coef_work, f64 *SDSGE_RESTRICT col) {
   f64 alpha = NAN;
   f64 objective = NAN;
   sdsge_ridge_grid_search(X, y, rec->n, rec->p, alphas, n_alpha, criterion,
-                           intercept, &alpha, rec->coef, &objective,
-                           &rec->status, G_base, G, g, L, coef_work, col);
+                          intercept, &alpha, rec->coef, &objective,
+                          &rec->status, G_base, G, g, L, coef_work, col);
   if (rec->status == REGRESSION_OK)
     sdsge_mc_compute_ssr_sst(X, y, rec);
   else
     sdsge_mc_set_failure(rec);
 }
 
-void sdsge_mc_lasso_fit(
-    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
-    i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
+void sdsge_mc_lasso_fit(const f64 *SDSGE_RESTRICT X,
+                        const f64 *SDSGE_RESTRICT y, f64 alpha, i64 intercept,
+                        i64 max_iter, f64 tol,
+                        sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                        f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+                        f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
   const i64 k = rec->p - (intercept ? 1 : 0);
   sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
   rec->status = sdsge_lasso_gram_cd(G, g, k, alpha, max_iter, tol,
@@ -187,17 +186,16 @@ void sdsge_mc_lasso_fit(
 
 void sdsge_mc_lasso_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept,
-    i64 max_iter, f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT lam_path,
-    f64 *SDSGE_RESTRICT beta_path, f64 *SDSGE_RESTRICT beta_grid,
-    f64 *SDSGE_RESTRICT work) {
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept, i64 max_iter,
+    f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT g,
+    f64 *SDSGE_RESTRICT lam_path, f64 *SDSGE_RESTRICT beta_path,
+    f64 *SDSGE_RESTRICT beta_grid, f64 *SDSGE_RESTRICT work) {
   const i64 k = rec->p - (intercept ? 1 : 0);
   i64 n_knots = 0;
   sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
   rec->status = sdsge_lars_lasso_gram(G, g, k, max_iter, tol, lam_path,
-                                       beta_path, &n_knots, work);
+                                      beta_path, &n_knots, work);
   if (rec->status != REGRESSION_OK) {
     sdsge_mc_set_failure(rec);
     return;
@@ -235,18 +233,16 @@ void sdsge_mc_lasso_gs_fit(
 void sdsge_mc_elastic_net_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
     f64 l1_ratio, i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec, f64 *SDSGE_RESTRICT G_base,
+    f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
   const i64 k = rec->p - (intercept ? 1 : 0);
   const f64 alpha_l1 = alpha * l1_ratio;
   const f64 alpha_l2 = alpha * (1.0 - l1_ratio);
   sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
   for (i64 j = 0; j < k; ++j)
     Gcoef[j] = 0.0;
-  rec->status = sdsge_en_gram_cd(G, g, k, alpha_l1, alpha_l2, Gcoef,
-                                 max_iter, tol,
-                                 rec->coef + (intercept ? 1 : 0), Gcoef);
+  rec->status = sdsge_en_gram_cd(G, g, k, alpha_l1, alpha_l2, Gcoef, max_iter,
+                                 tol, rec->coef + (intercept ? 1 : 0), Gcoef);
   if (rec->status == REGRESSION_OK) {
     if (intercept)
       sdsge_mc_restore_intercept(rec, G_base, g[k]);
@@ -258,11 +254,10 @@ void sdsge_mc_elastic_net_fit(
 
 void sdsge_mc_elastic_net_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio,
-    i64 criterion, i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio, i64 criterion,
+    i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec, f64 *SDSGE_RESTRICT G_base,
+    f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
     i64 *SDSGE_RESTRICT statuses, f64 *SDSGE_RESTRICT Gcoef,
     f64 *SDSGE_RESTRICT beta, f64 *SDSGE_RESTRICT dof_work) {
   const i64 k = rec->p - (intercept ? 1 : 0);

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.c
@@ -1,0 +1,73 @@
+#include "regression.h"
+#include "../_common/sdsge_linalg.h"
+#include "../regression/regression.h"
+#include <math.h>
+
+void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+                      sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                      f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
+                      f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT work) {
+  i64 n = rec->n;
+  i64 p = rec->p;
+
+  sdsge_ols_chol_solve(X, y, n, p, rec->coef, L, &rec->status, G, g);
+
+  if (rec->status == REGRESSION_OK) {
+    f64 ssr = 0.0;
+    f64 sst = 0.0;
+    f64 y_mean = 0.0;
+    for (i64 i = 0; i < n; ++i) {
+      y_mean += y[i];
+    }
+    y_mean /= (f64)n;
+
+    for (i64 i = 0; i < n; ++i) {
+      const f64 *row = X + i * p;
+      f64 fitted = 0.0;
+      for (i64 j = 0; j < p; ++j) {
+        fitted += row[j] * rec->coef[j];
+      }
+      const f64 residual = y[i] - fitted;
+      const f64 centered = y[i] - y_mean;
+      ssr += residual * residual;
+      sst += centered * centered;
+    }
+    rec->ssr = ssr;
+    rec->sst = sst;
+
+    if (rec->se != NULL) {
+      if (n <= p) {
+        for (i64 j = 0; j < p; ++j) {
+          rec->se[j] = NAN;
+        }
+      } else {
+        const f64 sigma2 = ssr / (f64)(n - p);
+        for (i64 j = 0; j < p; ++j) {
+          for (i64 i = 0; i < p; ++i) {
+            work[i] = (i == j) ? 1.0 : 0.0;
+          }
+          sdsge_forward_subst(L, work, work, p);
+
+          f64 inv_diag = 0.0;
+          for (i64 i = 0; i < p; ++i) {
+            inv_diag += work[i] * work[i];
+          }
+          rec->se[j] = sqrt(sigma2 * inv_diag);
+        }
+      }
+    }
+  } else {
+    for (i64 i = 0; i < p; i++) {
+      rec->coef[i] = NAN;
+    }
+
+    rec->ssr = NAN;
+    rec->sst = NAN;
+
+    if (rec->se != NULL) {
+      for (i64 i = 0; i < p; i++) {
+        rec->se[i] = NAN;
+      }
+    }
+  }
+}

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.c
@@ -1,7 +1,99 @@
 #include "regression.h"
 #include "../_common/sdsge_linalg.h"
+#include "../regression/elastic_net.h"
+#include "../regression/lasso.h"
 #include "../regression/regression.h"
 #include <math.h>
+
+static void sdsge_mc_set_failure(sdsge_mc_regression_record *rec) {
+  for (i64 i = 0; i < rec->p; ++i)
+    rec->coef[i] = NAN;
+  rec->ssr = NAN;
+  rec->sst = NAN;
+  if (rec->se != NULL)
+    for (i64 i = 0; i < rec->p; ++i)
+      rec->se[i] = NAN;
+}
+
+static void sdsge_mc_compute_ssr_sst(const f64 *X, const f64 *y,
+                                      sdsge_mc_regression_record *rec) {
+  const i64 n = rec->n;
+  const i64 p = rec->p;
+  f64 ssr = 0.0;
+  f64 sst = 0.0;
+  f64 y_mean = 0.0;
+  for (i64 i = 0; i < n; ++i)
+    y_mean += y[i];
+  y_mean /= (f64)n;
+
+  for (i64 i = 0; i < n; ++i) {
+    const f64 *row = X + i * p;
+    f64 fitted = 0.0;
+    for (i64 j = 0; j < p; ++j)
+      fitted += row[j] * rec->coef[j];
+    const f64 residual = y[i] - fitted;
+    const f64 centered = y[i] - y_mean;
+    ssr += residual * residual;
+    sst += centered * centered;
+  }
+  rec->ssr = ssr;
+  rec->sst = sst;
+}
+
+static f64 sdsge_mc_objective(i64 criterion, f64 rss, i64 n, f64 dof) {
+  if (criterion == REGRESSION_CRIT_LOSS)
+    return rss;
+  if (rss <= 0.0)
+    return -INFINITY;
+  const f64 nf = (f64)n;
+  const f64 base = nf * log(rss / nf);
+  return criterion == REGRESSION_CRIT_AIC ? base + 2.0 * dof
+                                          : base + log(nf) * dof;
+}
+
+/* Form the n-scaled Gram and rhs used by the sparse solvers. For an explicit
+ * intercept column, retain the raw first row of G_base to restore the intercept
+ * after solving the centered slope problem. G and g hold the compact centered
+ * slope Gram/rhs in their leading (p - 1)-square/vector entries. */
+static void sdsge_mc_sparse_gram(const f64 *X, const f64 *y,
+                                 const sdsge_mc_regression_record *rec,
+                                 i64 intercept, f64 *G_base, f64 *G, f64 *g) {
+  const i64 n = rec->n;
+  const i64 p = rec->p;
+  const i64 k = p - (intercept ? 1 : 0);
+  const f64 nf = (f64)n;
+  sdsge_gram(X, G_base, n, p);
+  sdsge_gram_rhs(X, y, g, n, p);
+  for (i64 i = 0; i < p * p; ++i)
+    G_base[i] /= nf;
+  for (i64 i = 0; i < p; ++i)
+    g[i] /= nf;
+
+  if (intercept) {
+    const f64 y_mean = g[0];
+    for (i64 i = 0; i < k; ++i) {
+      const i64 row = i + 1;
+      g[i] = g[row] - G_base[row * p] * y_mean;
+      for (i64 j = 0; j < k; ++j) {
+        const i64 col = j + 1;
+        G[i * k + j] = G_base[row * p + col] -
+                           G_base[row * p] * G_base[col];
+      }
+    }
+    g[k] = y_mean;
+  } else {
+    for (i64 i = 0; i < p * p; ++i)
+      G[i] = G_base[i];
+  }
+}
+
+static void sdsge_mc_restore_intercept(const sdsge_mc_regression_record *rec,
+                                       const f64 *G_base, f64 y_mean) {
+  f64 intercept = y_mean;
+  for (i64 j = 1; j < rec->p; ++j)
+    intercept -= G_base[j] * rec->coef[j];
+  rec->coef[0] = intercept;
+}
 
 void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
                       sdsge_mc_regression_record *SDSGE_RESTRICT rec,
@@ -13,27 +105,7 @@ void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
   sdsge_ols_chol_solve(X, y, n, p, rec->coef, L, &rec->status, G, g);
 
   if (rec->status == REGRESSION_OK) {
-    f64 ssr = 0.0;
-    f64 sst = 0.0;
-    f64 y_mean = 0.0;
-    for (i64 i = 0; i < n; ++i) {
-      y_mean += y[i];
-    }
-    y_mean /= (f64)n;
-
-    for (i64 i = 0; i < n; ++i) {
-      const f64 *row = X + i * p;
-      f64 fitted = 0.0;
-      for (i64 j = 0; j < p; ++j) {
-        fitted += row[j] * rec->coef[j];
-      }
-      const f64 residual = y[i] - fitted;
-      const f64 centered = y[i] - y_mean;
-      ssr += residual * residual;
-      sst += centered * centered;
-    }
-    rec->ssr = ssr;
-    rec->sst = sst;
+    sdsge_mc_compute_ssr_sst(X, y, rec);
 
     if (rec->se != NULL) {
       if (n <= p) {
@@ -41,7 +113,7 @@ void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
           rec->se[j] = NAN;
         }
       } else {
-        const f64 sigma2 = ssr / (f64)(n - p);
+        const f64 sigma2 = rec->ssr / (f64)(n - p);
         for (i64 j = 0; j < p; ++j) {
           for (i64 i = 0; i < p; ++i) {
             work[i] = (i == j) ? 1.0 : 0.0;
@@ -57,17 +129,181 @@ void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
       }
     }
   } else {
-    for (i64 i = 0; i < p; i++) {
-      rec->coef[i] = NAN;
+    sdsge_mc_set_failure(rec);
+  }
+}
+
+void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+                        f64 alpha, i64 intercept,
+                        sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                        f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
+                        f64 *SDSGE_RESTRICT G_unpen, f64 *SDSGE_RESTRICT g,
+                        f64 *SDSGE_RESTRICT col) {
+  f64 dof = 0.0;
+  sdsge_chol_solve_L2(X, y, rec->n, rec->p, alpha, intercept, rec->coef, L,
+                       &dof, &rec->status, G, G_unpen, g, col);
+  if (rec->status == REGRESSION_OK)
+    sdsge_mc_compute_ssr_sst(X, y, rec);
+  else
+    sdsge_mc_set_failure(rec);
+}
+
+void sdsge_mc_ridge_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion,
+    i64 intercept, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
+    f64 *SDSGE_RESTRICT coef_work, f64 *SDSGE_RESTRICT col) {
+  f64 alpha = NAN;
+  f64 objective = NAN;
+  sdsge_ridge_grid_search(X, y, rec->n, rec->p, alphas, n_alpha, criterion,
+                           intercept, &alpha, rec->coef, &objective,
+                           &rec->status, G_base, G, g, L, coef_work, col);
+  if (rec->status == REGRESSION_OK)
+    sdsge_mc_compute_ssr_sst(X, y, rec);
+  else
+    sdsge_mc_set_failure(rec);
+}
+
+void sdsge_mc_lasso_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
+    i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
+  const i64 k = rec->p - (intercept ? 1 : 0);
+  sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
+  rec->status = sdsge_lasso_gram_cd(G, g, k, alpha, max_iter, tol,
+                                    rec->coef + (intercept ? 1 : 0), Gcoef);
+  if (rec->status == REGRESSION_OK) {
+    if (intercept)
+      sdsge_mc_restore_intercept(rec, G_base, g[k]);
+    sdsge_mc_compute_ssr_sst(X, y, rec);
+  } else {
+    sdsge_mc_set_failure(rec);
+  }
+}
+
+void sdsge_mc_lasso_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept,
+    i64 max_iter, f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT lam_path,
+    f64 *SDSGE_RESTRICT beta_path, f64 *SDSGE_RESTRICT beta_grid,
+    f64 *SDSGE_RESTRICT work) {
+  const i64 k = rec->p - (intercept ? 1 : 0);
+  i64 n_knots = 0;
+  sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
+  rec->status = sdsge_lars_lasso_gram(G, g, k, max_iter, tol, lam_path,
+                                       beta_path, &n_knots, work);
+  if (rec->status != REGRESSION_OK) {
+    sdsge_mc_set_failure(rec);
+    return;
+  }
+  sdsge_lasso_path_eval(lam_path, beta_path, n_knots, k, alphas, n_alpha,
+                        beta_grid);
+
+  f64 best_rss = INFINITY;
+  for (i64 a = 0; a < n_alpha; ++a) {
+    const f64 *beta = beta_grid + a * k;
+    f64 rss = 0.0;
+    for (i64 row = 0; row < rec->n; ++row) {
+      const f64 *Xrow = X + row * rec->p;
+      f64 fitted = intercept ? g[k] : 0.0;
+      if (intercept)
+        for (i64 j = 1; j < rec->p; ++j)
+          fitted += (Xrow[j] - G_base[j]) * beta[j - 1];
+      else
+        for (i64 j = 0; j < rec->p; ++j)
+          fitted += Xrow[j] * beta[j];
+      const f64 residual = y[row] - fitted;
+      rss += residual * residual;
     }
-
-    rec->ssr = NAN;
-    rec->sst = NAN;
-
-    if (rec->se != NULL) {
-      for (i64 i = 0; i < p; i++) {
-        rec->se[i] = NAN;
-      }
+    if (a == 0 || rss < best_rss) {
+      best_rss = rss;
+      for (i64 j = 0; j < k; ++j)
+        rec->coef[j + (intercept ? 1 : 0)] = beta[j];
     }
   }
+  if (intercept)
+    sdsge_mc_restore_intercept(rec, G_base, g[k]);
+  sdsge_mc_compute_ssr_sst(X, y, rec);
+}
+
+void sdsge_mc_elastic_net_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
+    f64 l1_ratio, i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef) {
+  const i64 k = rec->p - (intercept ? 1 : 0);
+  const f64 alpha_l1 = alpha * l1_ratio;
+  const f64 alpha_l2 = alpha * (1.0 - l1_ratio);
+  sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
+  for (i64 j = 0; j < k; ++j)
+    Gcoef[j] = 0.0;
+  rec->status = sdsge_en_gram_cd(G, g, k, alpha_l1, alpha_l2, Gcoef,
+                                 max_iter, tol,
+                                 rec->coef + (intercept ? 1 : 0), Gcoef);
+  if (rec->status == REGRESSION_OK) {
+    if (intercept)
+      sdsge_mc_restore_intercept(rec, G_base, g[k]);
+    sdsge_mc_compute_ssr_sst(X, y, rec);
+  } else {
+    sdsge_mc_set_failure(rec);
+  }
+}
+
+void sdsge_mc_elastic_net_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio,
+    i64 criterion, i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
+    i64 *SDSGE_RESTRICT statuses, f64 *SDSGE_RESTRICT Gcoef,
+    f64 *SDSGE_RESTRICT beta, f64 *SDSGE_RESTRICT dof_work) {
+  const i64 k = rec->p - (intercept ? 1 : 0);
+  sdsge_mc_sparse_gram(X, y, rec, intercept, G_base, G, g);
+  sdsge_en_gram_cd_path(G, g, k, alphas, n_alpha, l1_ratio, max_iter, tol,
+                        beta_grid, statuses, Gcoef, beta);
+
+  f64 best_objective = INFINITY;
+  for (i64 a = 0; a < n_alpha; ++a) {
+    if (statuses[a] != REGRESSION_OK)
+      continue;
+    const f64 *coef = beta_grid + a * k;
+    f64 rss = 0.0;
+    for (i64 row = 0; row < rec->n; ++row) {
+      const f64 *Xrow = X + row * rec->p;
+      f64 fitted = intercept ? g[k] : 0.0;
+      if (intercept)
+        for (i64 j = 1; j < rec->p; ++j)
+          fitted += (Xrow[j] - G_base[j]) * coef[j - 1];
+      else
+        for (i64 j = 0; j < rec->p; ++j)
+          fitted += Xrow[j] * coef[j];
+      const f64 residual = y[row] - fitted;
+      rss += residual * residual;
+    }
+    const f64 dof = sdsge_en_active_dof(
+        G, coef, k, alphas[a] * (1.0 - l1_ratio), intercept, tol, dof_work);
+    const f64 objective = sdsge_mc_objective(criterion, rss, rec->n, dof);
+    if (objective < best_objective) {
+      best_objective = objective;
+      rec->status = REGRESSION_OK;
+      for (i64 j = 0; j < k; ++j)
+        rec->coef[j + (intercept ? 1 : 0)] = coef[j];
+    }
+  }
+  if (best_objective == INFINITY) {
+    rec->status = REGRESSION_NON_CONVERGENT;
+    sdsge_mc_set_failure(rec);
+    return;
+  }
+  if (intercept)
+    sdsge_mc_restore_intercept(rec, G_base, g[k]);
+  sdsge_mc_compute_ssr_sst(X, y, rec);
 }

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.h
@@ -21,4 +21,62 @@ void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
                       f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
                       f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT work);
 
+void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+                        f64 alpha, i64 intercept,
+                        sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                        f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
+                        f64 *SDSGE_RESTRICT G_unpen, f64 *SDSGE_RESTRICT g,
+                        f64 *SDSGE_RESTRICT col);
+
+void sdsge_mc_ridge_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion,
+    i64 intercept, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
+    f64 *SDSGE_RESTRICT coef_work, f64 *SDSGE_RESTRICT col);
+
+/* Sparse estimators receive a design with an explicit leading intercept column
+ * when intercept is nonzero. They center the slope Gram internally and restore
+ * that intercept in rec->coef. All listed buffers are caller-owned.
+ *
+ * lasso_fit: G_base(p*p), G(p*p), g(p), Gcoef(p).
+ * lasso_gs_fit: additionally lam_path(max_iter+1), beta_path((max_iter+1)*k),
+ * beta_grid(n_alpha*k), and work(k*k + 8*k), where k = p - intercept.
+ * elastic_net_fit: G_base(p*p), G(p*p), g(p), Gcoef(p).
+ * elastic_net_gs_fit: beta_grid(n_alpha*k), statuses(n_alpha), Gcoef(p),
+ * beta(p), and dof_work(3*k*k + k), in addition to G_base, G, and g. */
+void sdsge_mc_lasso_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
+    i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
+
+void sdsge_mc_lasso_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept,
+    i64 max_iter, f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT lam_path,
+    f64 *SDSGE_RESTRICT beta_path, f64 *SDSGE_RESTRICT beta_grid,
+    f64 *SDSGE_RESTRICT work);
+
+void sdsge_mc_elastic_net_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
+    f64 l1_ratio, i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
+
+void sdsge_mc_elastic_net_gs_fit(
+    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio,
+    i64 criterion, i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
+    i64 *SDSGE_RESTRICT statuses, f64 *SDSGE_RESTRICT Gcoef,
+    f64 *SDSGE_RESTRICT beta, f64 *SDSGE_RESTRICT dof_work);
+
 #endif /* SDSGE_MC_REGRESSION_H */

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.h
@@ -1,0 +1,24 @@
+#ifndef SDSGE_MC_REGRESSION_H
+#define SDSGE_MC_REGRESSION_H
+
+#include "../_common/sdsge_common.h"
+
+typedef struct {
+  i64 n; // number of samples
+  i64 p; // number of regressors (with intercept)
+
+  f64 *coef; // (p,)
+  f64 *se;   // NULL if not OLS. (p,)
+
+  f64 ssr;
+  f64 sst;
+  i64 status;
+} sdsge_mc_regression_record;
+
+/* Regression Wrappers for natve MC Steps */
+void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
+                      sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                      f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
+                      f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT work);
+
+#endif /* SDSGE_MC_REGRESSION_H */

--- a/SymbolicDSGE/_ckernels/regression/_regression.pyx
+++ b/SymbolicDSGE/_ckernels/regression/_regression.pyx
@@ -43,7 +43,7 @@ cdef extern from "elastic_net.h":
                                double *beta) nogil
     double sdsge_en_active_dof(const double *G, const double *beta, int64_t k,
                                double alpha_l2, int64_t intercept,
-                               double atol) nogil
+                               double atol, double *work) nogil
 
 
 cdef extern from "lasso.h":
@@ -52,7 +52,8 @@ cdef extern from "lasso.h":
                                 double *coef, double *Gcoef) nogil
     int64_t sdsge_lars_lasso_gram(const double *G, const double *c, int64_t k,
                                   int64_t max_iter, double tol, double *lam_path,
-                                  double *beta_path, int64_t *n_knots) nogil
+                                  double *beta_path, int64_t *n_knots,
+                                  double *work) nogil
     void sdsge_lasso_path_eval(const double *lam_path, const double *beta_path,
                                int64_t n_knots, int64_t k, const double *lam_grid,
                                int64_t n_grid, double *out) nogil
@@ -121,11 +122,13 @@ def lars_lasso_gram(double[:, ::1] G, double[::1] c, int64_t max_iter, double to
     cdef int64_t k = G.shape[0]
     cdef double[::1] lam_path = np.empty(max_iter + 1, dtype=np.float64)
     cdef double[:, ::1] beta_path = np.empty((max_iter + 1, k), dtype=np.float64)
+    cdef double[::1] work = np.empty(8 * k + k * k, dtype=np.float64)
     cdef int64_t n_knots = 0
     cdef int64_t status
     with nogil:
         status = sdsge_lars_lasso_gram(&G[0, 0], &c[0], k, max_iter, tol,
-                                       &lam_path[0], &beta_path[0, 0], &n_knots)
+                                       &lam_path[0], &beta_path[0, 0], &n_knots,
+                                       &work[0])
     return (
         np.asarray(lam_path[:n_knots]),
         np.asarray(beta_path[:n_knots]),
@@ -198,7 +201,10 @@ def elastic_net_active_dof(double[:, ::1] G, double[::1] beta, double alpha_l2,
                            bint intercept, double atol):
     """Active-set effective degrees of freedom. Returns a float."""
     cdef int64_t k = G.shape[0]
+    cdef double[::1] work = np.empty(3 * k * k + k, dtype=np.float64)
     cdef double dof
     with nogil:
-        dof = sdsge_en_active_dof(&G[0, 0], &beta[0], k, alpha_l2, intercept, atol)
+        dof = sdsge_en_active_dof(
+            &G[0, 0], &beta[0], k, alpha_l2, intercept, atol, &work[0]
+        )
     return dof

--- a/SymbolicDSGE/_ckernels/regression/elastic_net.c
+++ b/SymbolicDSGE/_ckernels/regression/elastic_net.c
@@ -73,7 +73,8 @@ void sdsge_en_gram_cd_path(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRIC
 }
 
 f64 sdsge_en_active_dof(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT beta,
-                        i64 k, f64 alpha_l2, i64 intercept, f64 atol) {
+                        i64 k, f64 alpha_l2, i64 intercept, f64 atol,
+                        f64 *SDSGE_RESTRICT work) {
   const f64 ic = (f64)(intercept ? 1 : 0);
 
   i64 na = 0;
@@ -83,30 +84,26 @@ f64 sdsge_en_active_dof(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT b
   if (na == 0)
     return ic;
 
-  i64 *active = (i64 *)malloc((size_t)na * sizeof(i64));
-  f64 *G_active = (f64 *)malloc((size_t)(na * na) * sizeof(f64));
-  f64 *pen = (f64 *)malloc((size_t)(na * na) * sizeof(f64));
-  f64 *L = (f64 *)malloc((size_t)(na * na) * sizeof(f64));
-  f64 *col = (f64 *)malloc((size_t)na * sizeof(f64));
-  if (active == NULL || G_active == NULL || pen == NULL || L == NULL ||
-      col == NULL) {
-    free(active);
-    free(G_active);
-    free(pen);
-    free(L);
-    free(col);
-    return (f64)na + ic; /* numba's except branch returns n_active */
-  }
-
-  i64 cur = 0;
-  for (i64 j = 0; j < k; ++j)
-    if (fabs(beta[j]) > atol)
-      active[cur++] = j;
+  f64 *G_active = work;
+  f64 *pen = work + k * k;
+  f64 *L = work + 2 * k * k;
+  f64 *col = work + 3 * k * k;
 
   for (i64 i = 0; i < na; ++i) {
-    const i64 row = active[i];
+    i64 row = -1;
+    for (i64 j = 0, active = 0; j < k; ++j)
+      if (fabs(beta[j]) > atol && active++ == i) {
+        row = j;
+        break;
+      }
     for (i64 j = 0; j < na; ++j) {
-      const f64 val = G[row * k + active[j]];
+      i64 column = -1;
+      for (i64 candidate = 0, active = 0; candidate < k; ++candidate)
+        if (fabs(beta[candidate]) > atol && active++ == j) {
+          column = candidate;
+          break;
+        }
+      const f64 val = G[row * k + column];
       G_active[i * na + j] = val;
       pen[i * na + j] = val;
     }
@@ -128,10 +125,5 @@ f64 sdsge_en_active_dof(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT b
     }
   }
 
-  free(active);
-  free(G_active);
-  free(pen);
-  free(L);
-  free(col);
   return dof + ic;
 }

--- a/SymbolicDSGE/_ckernels/regression/elastic_net.h
+++ b/SymbolicDSGE/_ckernels/regression/elastic_net.h
@@ -24,9 +24,9 @@ void sdsge_en_gram_cd_path(const f64 *G, const f64 *g, i64 k,
                            f64 *Gcoef, f64 *beta);
 
 /* Effective dof on the active set: trace(penalized^-1 @ G_active) + intercept,
- * where penalized = G_active + alpha_l2*I over the support of beta. Active-set
- * scratch is malloc'd. */
+ * where penalized = G_active + alpha_l2*I over the support of beta. ``work``
+ * has size 3*k*k + k. */
 f64 sdsge_en_active_dof(const f64 *G, const f64 *beta, i64 k, f64 alpha_l2,
-                        i64 intercept, f64 atol);
+                        i64 intercept, f64 atol, f64 *work);
 
 #endif /* SDSGE_ELASTIC_NET_H */

--- a/SymbolicDSGE/_ckernels/regression/lasso.c
+++ b/SymbolicDSGE/_ckernels/regression/lasso.c
@@ -70,36 +70,38 @@ static void sdsge_solve_small(f64 *A, f64 *b, i64 n, f64 *x) {
   }
 }
 
+static i64 sdsge_lars_active_index(const f64 *active, i64 k, i64 ordinal) {
+  i64 count = 0;
+  for (i64 j = 0; j < k; ++j) {
+    if (active[j] != 0.0) {
+      if (count == ordinal)
+        return j;
+      count += 1;
+    }
+  }
+  return -1;
+}
+
 i64 sdsge_lars_lasso_gram(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT c,
                           i64 k, i64 max_iter, f64 tol,
                           f64 *SDSGE_RESTRICT lam_path,
                           f64 *SDSGE_RESTRICT beta_path,
-                          i64 *SDSGE_RESTRICT n_knots) {
-  /* One f64 block (7 vectors of k + the k*k active Gram) and one i64 block
-   * (active flags + active indices). */
-  f64 *fbuf = (f64 *)malloc((size_t)(7 * k + k * k) * sizeof(f64));
-  i64 *ibuf = (i64 *)malloc((size_t)(2 * k) * sizeof(i64));
-  if (fbuf == NULL || ibuf == NULL) {
-    free(fbuf);
-    free(ibuf);
-    *n_knots = 0;
-    return REGRESSION_NON_CONVERGENT;
-  }
-  f64 *beta = fbuf;
-  f64 *signs = fbuf + k;
-  f64 *r = fbuf + 2 * k;
-  f64 *s_A = fbuf + 3 * k;
-  f64 *w = fbuf + 4 * k;
-  f64 *d = fbuf + 5 * k;
-  f64 *Gd = fbuf + 6 * k;
-  f64 *G_AA = fbuf + 7 * k;
-  i64 *active = ibuf;
-  i64 *act_idx = ibuf + k;
+                          i64 *SDSGE_RESTRICT n_knots,
+                          f64 *SDSGE_RESTRICT work) {
+  f64 *beta = work;
+  f64 *signs = work + k;
+  f64 *r = work + 2 * k;
+  f64 *s_A = work + 3 * k;
+  f64 *w = work + 4 * k;
+  f64 *d = work + 5 * k;
+  f64 *Gd = work + 6 * k;
+  f64 *G_AA = work + 7 * k;
+  f64 *active = work + 7 * k + k * k;
 
   for (i64 j = 0; j < k; ++j) {
     beta[j] = 0.0;
     signs[j] = 0.0;
-    active[j] = 0;
+    active[j] = 0.0;
     r[j] = c[j]; /* residual correlations r = c - G@beta, beta == 0 */
   }
   i64 n_active = 0;
@@ -148,21 +150,20 @@ i64 sdsge_lars_lasso_gram(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT
     drop = 0;
 
     /* Collect active indices and build (G_AA, s_A). */
-    i64 cnt = 0;
-    for (i64 j = 0; j < k; ++j)
-      if (active[j])
-        act_idx[cnt++] = j;
     for (i64 a = 0; a < n_active; ++a) {
-      s_A[a] = signs[act_idx[a]];
-      for (i64 b = 0; b < n_active; ++b)
-        G_AA[a * n_active + b] = G[act_idx[a] * k + act_idx[b]];
+      const i64 row = sdsge_lars_active_index(active, k, a);
+      s_A[a] = signs[row];
+      for (i64 b = 0; b < n_active; ++b) {
+        const i64 col = sdsge_lars_active_index(active, k, b);
+        G_AA[a * n_active + b] = G[row * k + col];
+      }
     }
 
     /* Equiangular direction: solve G_AA w = s_A (s_A is destroyed). */
     sdsge_solve_small(G_AA, s_A, n_active, w);
     f64 sw = 0.0;
     for (i64 a = 0; a < n_active; ++a)
-      sw += signs[act_idx[a]] * w[a];
+      sw += signs[sdsge_lars_active_index(active, k, a)] * w[a];
     if (sw <= 0.0 || !isfinite(sw)) {
       status = REGRESSION_NON_CONVERGENT;
       goto done;
@@ -172,12 +173,14 @@ i64 sdsge_lars_lasso_gram(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT
     for (i64 j = 0; j < k; ++j)
       d[j] = 0.0;
     for (i64 a = 0; a < n_active; ++a)
-      d[act_idx[a]] = A_scalar * w[a];
+      d[sdsge_lars_active_index(active, k, a)] = A_scalar * w[a];
 
     for (i64 j = 0; j < k; ++j) {
       Gd[j] = 0.0;
-      for (i64 a = 0; a < n_active; ++a)
-        Gd[j] += G[j * k + act_idx[a]] * d[act_idx[a]];
+      for (i64 a = 0; a < n_active; ++a) {
+        const i64 index = sdsge_lars_active_index(active, k, a);
+        Gd[j] += G[j * k + index] * d[index];
+      }
     }
 
     f64 step = lam / A_scalar;
@@ -202,7 +205,7 @@ i64 sdsge_lars_lasso_gram(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT
 
     /* Lasso drop: an active coefficient crosses zero. */
     for (i64 a = 0; a < n_active; ++a) {
-      const i64 j = act_idx[a];
+      const i64 j = sdsge_lars_active_index(active, k, a);
       if (d[j] != 0.0) {
         const f64 t = -beta[j] / d[j];
         if (0.0 < t && t < step) {
@@ -240,8 +243,6 @@ i64 sdsge_lars_lasso_gram(const f64 *SDSGE_RESTRICT G, const f64 *SDSGE_RESTRICT
 
 done:
   *n_knots = knot;
-  free(fbuf);
-  free(ibuf);
   return status;
 }
 

--- a/SymbolicDSGE/_ckernels/regression/lasso.h
+++ b/SymbolicDSGE/_ckernels/regression/lasso.h
@@ -15,12 +15,13 @@
 i64 sdsge_lasso_gram_cd(const f64 *G, const f64 *g, i64 k, f64 alpha,
                         i64 max_iter, f64 tol, f64 *coef, f64 *Gcoef);
 
-/* Full LARS-Lasso path on the Gram. The caller allocates lam_path(max_iter+1)
- * and beta_path((max_iter+1)*k); the number of knots actually written is
- * returned in *n_knots (slice both to that). Internal active-set scratch is
- * malloc'd. Returns REGRESSION_OK / REGRESSION_NON_CONVERGENT. */
+/* Full LARS-Lasso path on the Gram. The caller allocates lam_path(max_iter+1),
+ * beta_path((max_iter+1)*k), and work(8*k + k*k); the number of knots actually
+ * written is returned in *n_knots (slice both to that). Returns REGRESSION_OK
+ * / REGRESSION_NON_CONVERGENT. */
 i64 sdsge_lars_lasso_gram(const f64 *G, const f64 *c, i64 k, i64 max_iter, f64 tol,
-                          f64 *lam_path, f64 *beta_path, i64 *n_knots);
+                          f64 *lam_path, f64 *beta_path, i64 *n_knots,
+                          f64 *work);
 
 /* Evaluate a LARS-Lasso path (lam_path/beta_path, n_knots rows of width k) at a
  * descending lambda grid (n_grid), writing out(n_grid, k). */

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -1,0 +1,347 @@
+"""Monte Carlo shape resolution and pipeline-owned buffer allocation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, NamedTuple, Sequence, TypeAlias
+
+import numpy as np
+
+from ..core.solved_model import SolvedModel
+from .mc_constructs import MCStep, OpType, SourceArgs
+
+Shape: TypeAlias = tuple[int, ...]
+
+
+class BufferSpec(NamedTuple):
+    """Shape and dtype declaration for one array buffer."""
+
+    shape: Shape
+    dtype: Any
+
+
+BufferPlan: TypeAlias = dict[str, dict[str, BufferSpec]]
+AllocatedBuffers: TypeAlias = dict[str, dict[str, np.ndarray]]
+
+
+def resolve_output_specs(
+    steps: Sequence[MCStep],
+    source_indices: Sequence[Sequence[int]],
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+) -> BufferPlan:
+    """Resolve per-replication output specs without allocating buffers."""
+    specs: BufferPlan = {}
+    for step_index, step in enumerate(steps):
+        indices = source_indices[step_index]
+        match step.op_type:
+            case OpType.DATAGEN:
+                specs[step.name] = _resolve_datagen_specs(step, reference, dgp)
+            case OpType.TRANSFORM:
+                if step.step_type == "payload":
+                    specs[step.name] = _resolve_payload_specs(step)
+                else:
+                    specs[step.name] = _resolve_transform_specs(
+                        step,
+                        indices[0],
+                        specs,
+                        steps,
+                    )
+            case OpType.FILTER:
+                datagen_step = steps[0]
+                specs[step.name] = _resolve_filter_specs(
+                    step,
+                    datagen_step,
+                    specs[datagen_step.name],
+                    reference,
+                )
+            case OpType.REGRESSION:
+                specs[step.name] = _resolve_regression_specs(
+                    step,
+                    indices,
+                    specs,
+                    steps,
+                )
+            case OpType.TEST:
+                specs[step.name] = _resolve_test_specs()
+            case _:
+                raise NotImplementedError(
+                    f"Shape resolution is not implemented for step {step.name!r} "
+                    f"({step.step_type!r})."
+                )
+    return specs
+
+
+def allocate_buffers(plan: BufferPlan) -> AllocatedBuffers:
+    """Allocate a nested, pipeline-owned buffer plan.
+
+    Each spec defines ``shape`` and ``dtype``. Algorithms that require
+    cleared workspace initialize it locally before use.
+    """
+    allocated: AllocatedBuffers = {}
+    for step_name, step_plan in plan.items():
+        step_buffers: dict[str, np.ndarray] = {}
+        for buffer_name, spec in step_plan.items():
+            shape = spec.shape
+            if any(size < 0 for size in shape):
+                raise ValueError(
+                    f"Buffer {step_name}.{buffer_name} has a negative dimension."
+                )
+            dtype = np.dtype(spec.dtype)
+            step_buffers[buffer_name] = np.empty(shape, dtype=dtype)
+        allocated[step_name] = step_buffers
+    return allocated
+
+
+def _raw_data_shape(field: str, value: object) -> Shape:
+    array = np.asarray(value)
+    if array.ndim == 1:
+        return (array.shape[0], 1)
+    if array.ndim == 2:
+        return tuple(int(size) for size in array.shape)
+    if array.ndim == 3:
+        return tuple(int(size) for size in array.shape[1:])
+    raise ValueError(f"Raw data for {field!r} must be 1D, 2D, or 3D.")
+
+
+def _payload_shape(value: object) -> Shape:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim == 1:
+        return array.shape[0], 1
+    if array.ndim == 2:
+        return tuple(int(size) for size in array.shape)
+    raise ValueError(f"Payload must be 1-D, or 2-D; got {array.ndim}-D.")
+
+
+def _float_specs(shapes: Mapping[str, Shape]) -> dict[str, BufferSpec]:
+    return {
+        name: BufferSpec(shape=shape, dtype=np.float64)
+        for name, shape in shapes.items()
+    }
+
+
+def _selected_source_shape(
+    specs: BufferPlan,
+    steps: Sequence[MCStep],
+    source_idx: int,
+    selector: SourceArgs,
+) -> Shape:
+    producer = steps[source_idx]
+    try:
+        n_rows, n_columns = specs[producer.name][selector.field].shape
+    except KeyError as exc:
+        raise ValueError(
+            f"Step {producer.name!r} does not produce source field {selector.field!r}."
+        ) from exc
+
+    n_rows = max(0, n_rows - selector.row_start)
+    columns = selector.column_selector
+    if isinstance(columns, slice):
+        n_columns = len(range(*columns.indices(n_columns)))
+    else:
+        n_columns = len(columns)
+    return n_rows, n_columns
+
+
+def _transform_output_shape(
+    step_type: str,
+    input_shape: Shape,
+    kwargs: Mapping[str, Any],
+) -> Shape:
+    n_rows, n_columns = input_shape
+    match step_type:
+        case "standardize" | "log":
+            return n_rows, n_columns
+        case "log_diff":
+            return max(0, n_rows - 1), n_columns
+        case "diff":
+            return max(0, n_rows - int(kwargs["order"])), n_columns
+        case "rolling_mean" | "rolling_std" | "rolling_var":
+            window = int(kwargs["window"])
+            return max(0, n_rows - window + 1), n_columns
+        case _:
+            raise NotImplementedError(
+                f"Shape resolution is not implemented for transform step type {step_type!r}."
+            )
+
+
+def _resolve_datagen_specs(
+    step: MCStep,
+    reference: SolvedModel,
+    dgp: SolvedModel | None,
+) -> dict[str, BufferSpec]:
+    match step.step_type:
+        case "simulation":
+            model = reference if step.kwargs["target"] == "reference" else dgp
+            if model is None:
+                raise ValueError(
+                    "Simulation shape resolution requires its target model."
+                )
+            T = int(step.kwargs["T"])
+            shapes: dict[str, Shape] = {
+                "states": (T + 1, len(model.compiled.var_names))
+            }
+            if step.kwargs["observables"]:
+                shapes["observables"] = (T, len(model.compiled.observable_names))
+            return _float_specs(shapes)
+        case "raw_model_data":
+            return _float_specs(
+                {
+                    field: _raw_data_shape(field, value)
+                    for field in ("states", "observables")
+                    if (value := step.kwargs[field]) is not None
+                }
+            )
+        case _:
+            raise NotImplementedError(
+                f"Shape resolution is not implemented for datagen step type "
+                f"{step.step_type!r}."
+            )
+
+
+def _resolve_filter_specs(
+    step: MCStep,
+    datagen_step: MCStep,
+    datagen_specs: dict[str, BufferSpec],
+    reference: SolvedModel,
+) -> dict[str, BufferSpec]:
+    try:
+        T, datagen_n_obs = datagen_specs["observables"].shape
+    except KeyError as exc:
+        raise ValueError(
+            "Filter shape resolution requires datagen observables."
+        ) from exc
+
+    selected_observables = step.kwargs["observables"]
+    if selected_observables is not None:
+        n_obs = len(selected_observables)
+    elif (
+        datagen_step.step_type == "raw_model_data"
+        and not datagen_step.kwargs["observable_names"]
+    ):
+        n_obs = len(reference.compiled.observable_names)
+    else:
+        n_obs = datagen_n_obs
+    n_var = len(reference.compiled.var_names)
+
+    common: dict[str, Shape] = dict(
+        x_pred=(T, n_var),
+        x_filt=(T, n_var),
+        y_pred=(T, n_obs),
+        y_filt=(T, n_obs),
+        S=(T, n_obs, n_obs),
+        innov=(T, n_obs),
+        std_innov=(T, n_obs),
+    )
+    match step.kwargs["filter_mode"]:
+        case "linear" | "extended":
+            linear_shapes = common | dict(
+                P_pred=(T, n_var, n_var),
+                P_filt=(T, n_var, n_var),
+            )
+            if step.kwargs["return_shocks"]:
+                linear_shapes["eps_hat"] = (T, reference.compiled.n_exog)
+            return _float_specs(linear_shapes)
+        case "unscented":
+            n_state = reference.compiled.n_state
+            n_z = 2 * n_state
+            return _float_specs(
+                common
+                | dict(
+                    P_pred=(T, n_z, n_z),
+                    P_filt=(T, n_z, n_z),
+                    x1_pred=(T, n_state),
+                    x1_filt=(T, n_state),
+                    x2_pred=(T, n_state),
+                    x2_filt=(T, n_state),
+                )
+            )
+        case _:
+            raise ValueError(
+                f"Unrecognized filter mode {step.kwargs['filter_mode']!r}."
+            )
+
+
+def _resolve_transform_specs(
+    step: MCStep,
+    source_idx: int,
+    specs: BufferPlan,
+    steps: Sequence[MCStep],
+) -> dict[str, BufferSpec]:
+    if len(step.source_args) != 1:
+        raise ValueError(f"Transform step {step.name!r} must have one source argument.")
+    input_shape = _selected_source_shape(
+        specs,
+        steps,
+        source_idx,
+        step.source_args[0],
+    )
+    return _float_specs(
+        {
+            "payload": _transform_output_shape(
+                step.step_type or "", input_shape, step.kwargs
+            )
+        }
+    )
+
+
+def _resolve_payload_specs(step: MCStep) -> dict[str, BufferSpec]:
+    return _float_specs({"payload": _payload_shape(step.kwargs["value"])})
+
+
+def _resolve_regression_specs(
+    step: MCStep,
+    source_indices: Sequence[int],
+    specs: BufferPlan,
+    steps: Sequence[MCStep],
+) -> dict[str, BufferSpec]:
+    if len(step.source_args) != 2 or len(source_indices) != 2:
+        raise ValueError(
+            f"Regression step {step.name!r} must have response and design sources."
+        )
+    y_rows, y_columns = _selected_source_shape(
+        specs, steps, source_indices[0], step.source_args[0]
+    )
+    X_rows, X_columns = _selected_source_shape(
+        specs, steps, source_indices[1], step.source_args[1]
+    )
+    if y_columns != 1:
+        raise ValueError(
+            f"Regression step {step.name!r} response must resolve to one column."
+        )
+    if y_rows != X_rows:
+        raise ValueError(
+            f"Regression step {step.name!r} response and design must have the "
+            "same number of rows."
+        )
+    if step.kwargs["kind"] != "ols":
+        raise NotImplementedError(
+            f"Native Monte Carlo regression shape resolution supports only OLS, "
+            f"not {step.kwargs['kind']!r}."
+        )
+
+    p = X_columns + int(step.kwargs["intercept"])
+    if p == 0:
+        raise ValueError(
+            f"Regression step {step.name!r} requires a regressor or an intercept."
+        )
+    return {
+        "coef": BufferSpec((p,), np.float64),
+        "se": BufferSpec((p,), np.float64),
+        "ssr": BufferSpec((), np.float64),
+        "sst": BufferSpec((), np.float64),
+        "status": BufferSpec((), np.int64),
+    }
+
+
+def _resolve_test_specs() -> dict[str, BufferSpec]:
+    """Return the scalar per-replication channels common to all tests.
+
+    The allocation phase adds the replication axis, yielding one trace for each
+    channel. Test-specific scratch buffers are planned separately from their
+    resolved input shapes.
+    """
+    return {
+        "statistic": BufferSpec((), np.float64),
+        "pval": BufferSpec((), np.float64),
+        "status": BufferSpec((), np.int64),
+    }

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -313,24 +313,20 @@ def _resolve_regression_specs(
             f"Regression step {step.name!r} response and design must have the "
             "same number of rows."
         )
-    if step.kwargs["kind"] != "ols":
-        raise NotImplementedError(
-            f"Native Monte Carlo regression shape resolution supports only OLS, "
-            f"not {step.kwargs['kind']!r}."
-        )
-
     p = X_columns + int(step.kwargs["intercept"])
     if p == 0:
         raise ValueError(
             f"Regression step {step.name!r} requires a regressor or an intercept."
         )
-    return {
+    output_specs: dict[str, BufferSpec] = {
         "coef": BufferSpec((p,), np.float64),
-        "se": BufferSpec((p,), np.float64),
         "ssr": BufferSpec((), np.float64),
         "sst": BufferSpec((), np.float64),
         "status": BufferSpec((), np.int64),
     }
+    if step.kwargs["kind"] == "ols":
+        output_specs["se"] = BufferSpec((p,), np.float64)
+    return output_specs
 
 
 def _resolve_test_specs() -> dict[str, BufferSpec]:

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from functools import cached_property
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
@@ -42,6 +42,9 @@ class MCPipeline:
     #: Post-loop ops, run once after the loop over the assembled across-rep
     #: traces. This is a terminal phase, not part of the graph.
     postproc_steps: tuple[MCStep, ...]
+    #: Producer indices for each per-replication step's source arguments.
+    #: Kept separate from the authored ``SourceArgs`` objects.
+    _source_indices: tuple[tuple[int, ...], ...]
 
     def __init__(
         self,
@@ -51,9 +54,10 @@ class MCPipeline:
         rep_tuple = tuple(per_rep_steps)
         postproc_tuple = tuple(postproc_steps)
         self._validate_steps(rep_tuple, postproc_tuple)
-        rep_tuple = self._bind_source_args(rep_tuple)
+        source_indices = self._resolve_source_indices(rep_tuple)
         object.__setattr__(self, "per_rep_steps", rep_tuple)
         object.__setattr__(self, "postproc_steps", postproc_tuple)
+        object.__setattr__(self, "_source_indices", source_indices)
 
     @staticmethod
     def _validate_steps(
@@ -84,39 +88,39 @@ class MCPipeline:
                 )
 
     @staticmethod
-    def _bind_source_args(per_rep_steps: tuple[MCStep, ...]) -> tuple[MCStep, ...]:
-        index_by_name: dict[str, int] = {}
-        canonical_name: dict[str, str] = {}
+    def _resolve_source_indices(
+        per_rep_steps: tuple[MCStep, ...],
+    ) -> tuple[tuple[int, ...], ...]:
+        index_by_source: dict[str, int] = {}
         for index, step in enumerate(per_rep_steps):
-            index_by_name[step.name] = index
-            canonical_name[step.name] = step.name
-            index_by_name[step.output_key] = index
-            canonical_name[step.output_key] = step.name
-        bound_steps: list[MCStep] = []
-        for step_index, step in enumerate(per_rep_steps):
-            bound_args = []
-            for selector in step.source_args:
-                producer = selector.source_step
-                if producer not in index_by_name:
+            for source_name in (step.name, step.output_key):
+                prior_index = index_by_source.get(source_name)
+                if prior_index is not None and prior_index != index:
                     raise ValueError(
-                        f"Step {step.name!r} depends on unknown producer {producer!r}."
+                        f"Pipeline source name {source_name!r} is ambiguous."
                     )
-                source_idx = index_by_name[producer]
+                index_by_source[source_name] = index
+
+        resolved: list[tuple[int, ...]] = []
+        for step_index, step in enumerate(per_rep_steps):
+            step_indices: list[int] = []
+            for selector in step.source_args:
+                source_name = selector.source_step
+                source_idx = index_by_source.get(source_name)
+                if source_idx is None:
+                    raise ValueError(
+                        f"Step {step.name!r} depends on unknown producer {source_name!r}."
+                    )
                 producer_step = per_rep_steps[source_idx]
-                producer = canonical_name[producer]
                 if source_idx >= step_index:
                     raise ValueError(
-                        f"Step {step.name!r} depends on {producer!r}, which does not "
+                        f"Step {step.name!r} depends on {producer_step.name!r}, which does not "
                         "appear earlier in the pipeline."
                     )
                 _validate_source_producer(step, selector, producer_step)
-                bound_args.append(
-                    replace(selector, source_step=producer, source_idx=source_idx)
-                )
-            if tuple(bound_args) != step.source_args:
-                step = replace(step, source_args=tuple(bound_args))
-            bound_steps.append(step)
-        return tuple(bound_steps)
+                step_indices.append(source_idx)
+            resolved.append(tuple(step_indices))
+        return tuple(resolved)
 
     @cached_property
     def graph(self) -> "PipelineGraph":
@@ -128,7 +132,7 @@ class MCPipeline:
         """
         from .graph import PipelineGraph
 
-        return PipelineGraph.from_steps(self.per_rep_steps)
+        return PipelineGraph.from_steps(self.per_rep_steps, self._source_indices)
 
     def to_spec(self) -> "PipelineSpec":
         """Serialize this pipeline to its graph-form :class:`PipelineSpec`.
@@ -183,11 +187,11 @@ class MCPipeline:
             context = MCContext(rep_idx=rep_idx, reference=reference, dgp=dgp)
             failed_step_name: str | None = None
             try:
-                for step in rep_steps:
+                for step_index, step in enumerate(rep_steps):
                     failed_step_name = step.name
                     step_start = perf_counter()
                     try:
-                        self._run_step(context, step)
+                        self._run_step(context, step, self._source_indices[step_index])
                     except Exception:
                         step_failures[step.name] += 1
                         raise
@@ -278,10 +282,15 @@ class MCPipeline:
             report_mc_step_performance(meta)
         return result
 
-    def _run_step(self, context: MCContext, step: MCStep) -> None:
+    def _run_step(
+        self,
+        context: MCContext,
+        step: MCStep,
+        source_indices: Sequence[int],
+    ) -> None:
         kwargs = dict(step.kwargs)
-        for selector in step.source_args:
-            kwargs[selector.arg] = _resolve_source_array(context, selector)
+        for selector, source_idx in zip(step.source_args, source_indices):
+            kwargs[selector.arg] = _resolve_source_array(context, selector, source_idx)
         if step.op_type is OpType.DATAGEN:
             out = step.func(
                 reference=context.reference,

--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -16,6 +16,7 @@ from ..core.solved_model import SolvedModel
 from ..kalman.filter import FilterRawResult, UnscentedFilterRawResult
 from ..regression.ols import MCRegressionResult
 from ..regression.result import RegressionResult
+from .allocation import BufferPlan, resolve_output_specs
 from .mc_constructs import (
     MCContext,
     MCData,
@@ -39,11 +40,12 @@ from .operations.utils import _resolve_source_array
 class MCPipeline:
     #: Per-replication steps: the dependency DAG, a single DATAGEN root first.
     per_rep_steps: tuple[MCStep, ...]
+
     #: Post-loop ops, run once after the loop over the assembled across-rep
     #: traces. This is a terminal phase, not part of the graph.
     postproc_steps: tuple[MCStep, ...]
+
     #: Producer indices for each per-replication step's source arguments.
-    #: Kept separate from the authored ``SourceArgs`` objects.
     _source_indices: tuple[tuple[int, ...], ...]
 
     def __init__(
@@ -133,6 +135,15 @@ class MCPipeline:
         from .graph import PipelineGraph
 
         return PipelineGraph.from_steps(self.per_rep_steps, self._source_indices)
+
+    def _resolve_output_specs(
+        self,
+        reference: SolvedModel,
+        dgp: SolvedModel | None,
+    ) -> BufferPlan:
+        return resolve_output_specs(
+            self.per_rep_steps, self._source_indices, reference, dgp
+        )
 
     def to_spec(self) -> "PipelineSpec":
         """Serialize this pipeline to its graph-form :class:`PipelineSpec`.

--- a/SymbolicDSGE/monte_carlo/graph.py
+++ b/SymbolicDSGE/monte_carlo/graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 
 from .catalog import FILTER_SOURCES
 from .mc_constructs import MCStep, OpType
@@ -80,7 +80,11 @@ class PipelineGraph:
         self.order: tuple[str, ...] = tuple(nodes)
 
     @classmethod
-    def from_steps(cls, steps: tuple[MCStep, ...]) -> PipelineGraph:
+    def from_steps(
+        cls,
+        steps: tuple[MCStep, ...],
+        source_indices: Sequence[Sequence[int]] | None = None,
+    ) -> PipelineGraph:
         if not steps:
             raise ValueError("Cannot build a graph from an empty pipeline.")
         index = {step.name: i for i, step in enumerate(steps)}
@@ -88,7 +92,13 @@ class PipelineGraph:
 
         inputs_by_name: dict[str, tuple[InputEdge, ...]] = {}
         for position, step in enumerate(steps):
-            edges = _resolve_inputs(step, root_name=root)
+            indices = None if source_indices is None else source_indices[position]
+            edges = _resolve_inputs(
+                step,
+                root_name=root,
+                steps=steps,
+                source_indices=indices,
+            )
             for edge in edges:
                 if edge.producer not in index:
                     raise ValueError(
@@ -134,17 +144,34 @@ class PipelineGraph:
         return out
 
 
-def _resolve_inputs(step: MCStep, *, root_name: str) -> tuple[InputEdge, ...]:
+def _resolve_inputs(
+    step: MCStep,
+    *,
+    root_name: str,
+    steps: tuple[MCStep, ...],
+    source_indices: Sequence[int] | None,
+) -> tuple[InputEdge, ...]:
     if step.op_type is OpType.DATAGEN:
         return ()
     if step.op_type is OpType.FILTER:
         return (InputEdge(role="source", producer=root_name, channel="observables"),)
 
+    if source_indices is None:
+        return tuple(
+            InputEdge(
+                role=selector.arg,
+                producer=selector.source_step,
+                channel=selector.field,
+            )
+            for selector in step.source_args
+        )
+    if len(source_indices) != len(step.source_args):
+        raise ValueError(f"Step {step.name!r} has inconsistent resolved sources.")
     return tuple(
         InputEdge(
             role=selector.arg,
-            producer=selector.source_step,
+            producer=steps[source_idx].name,
             channel=selector.field,
         )
-        for selector in step.source_args
+        for selector, source_idx in zip(step.source_args, source_indices)
     )

--- a/SymbolicDSGE/monte_carlo/graph.py
+++ b/SymbolicDSGE/monte_carlo/graph.py
@@ -76,7 +76,7 @@ class PipelineGraph:
     def __init__(self, nodes: dict[str, PipelineNode], root: str) -> None:
         self.nodes = nodes
         self.root = root
-        #: authored (and validated) execution order — a valid topological order.
+        #: authored (and validated) execution order; a valid topological order.
         self.order: tuple[str, ...] = tuple(nodes)
 
     @classmethod

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -223,7 +223,6 @@ SOURCE_KIND_FILTER = 2
 class SourceArgs:
     arg: str
     source_step: str
-    source_idx: int
     source_kind: int
     field: str
     field_idx: int
@@ -308,7 +307,6 @@ def _compile_source_args(
         return SourceArgs(
             arg=arg,
             source_step=source_step,
-            source_idx=-1,
             source_kind=SOURCE_KIND_DATA,
             field=source_field,
             field_idx=MC_DATA_FIELD_INDEX[source_field],
@@ -320,7 +318,6 @@ def _compile_source_args(
         return SourceArgs(
             arg=arg,
             source_step=source_step,
-            source_idx=-1,
             source_kind=SOURCE_KIND_FILTER,
             field=source_field,
             field_idx=FILTER_RAW_FIELD_INDEX[source_field],
@@ -333,7 +330,6 @@ def _compile_source_args(
         return SourceArgs(
             arg=arg,
             source_step=source_step,
-            source_idx=-1,
             source_kind=SOURCE_KIND_PAYLOAD,
             field=source_field,
             field_idx=DYNAMIC_FIELD_INDEX[source_field],

--- a/SymbolicDSGE/monte_carlo/operations/utils.py
+++ b/SymbolicDSGE/monte_carlo/operations/utils.py
@@ -64,8 +64,12 @@ def _resolve_seed_increment(
     return increment
 
 
-def _resolve_source_array(context: MCContext, selector: SourceArgs) -> NDF:
-    out: NDF = context.payload_slots[selector.source_idx][selector.field_idx][
+def _resolve_source_array(
+    context: MCContext,
+    selector: SourceArgs,
+    source_idx: int,
+) -> NDF:
+    out: NDF = context.payload_slots[source_idx][selector.field_idx][
         selector.row_start :, selector.column_selector
     ]
     return out

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ _COMMON = os.path.join(_CKERNELS, "_common")
 # extension already; this is for the higher-level subsystems (core, kalman, ...).
 _EXTRA_DEPS = {
     "estimation": ["core", "kalman", "optim", "rng"],
+    "monte_carlo": ["core", "kalman", "rng", "regression"],
 }
 
 # Subsystems whose hand-written C draws randoms through numpy's low-level RNG

--- a/tests/monte_carlo/test_allocation.py
+++ b/tests/monte_carlo/test_allocation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE.monte_carlo.allocation import BufferSpec, allocate_buffers
+
+
+def test_allocate_buffers_creates_nested_pipeline_owned_arrays() -> None:
+    buffers = allocate_buffers(
+        {
+            "ols": {
+                "coef_trace": BufferSpec((4, 3), np.float64),
+                "status_trace": BufferSpec((4,), np.int64),
+            }
+        }
+    )
+
+    assert buffers["ols"]["coef_trace"].shape == (4, 3)
+    assert buffers["ols"]["coef_trace"].dtype == np.float64
+    assert buffers["ols"]["status_trace"].dtype == np.int64
+
+
+def test_allocate_buffers_rejects_invalid_requests() -> None:
+    with pytest.raises(ValueError, match="negative dimension"):
+        allocate_buffers({"step": {"bad": BufferSpec((-1,), np.float64)}})

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -1493,7 +1493,6 @@ def test_pipeline_collects_failures_when_fail_fast_is_false() -> None:
                     SourceArgs(
                         arg="sample",
                         source_step="datagen",
-                        source_idx=-1,
                         source_kind=SOURCE_KIND_DATA,
                         field="states",
                         field_idx=MC_DATA_FIELD_INDEX["states"],
@@ -1589,7 +1588,6 @@ def test_mc_operation_utils_resolve_context_and_raw_arrays() -> None:
         SourceArgs(
             arg="sample",
             source_step="datagen",
-            source_idx=0,
             source_kind=SOURCE_KIND_DATA,
             field="states",
             field_idx=MC_DATA_FIELD_INDEX["states"],
@@ -1597,6 +1595,7 @@ def test_mc_operation_utils_resolve_context_and_raw_arrays() -> None:
             burn_in=1,
             drop_initial=True,
         ),
+        0,
     )
     np.testing.assert_allclose(selected, states[1:, [1]])
 
@@ -1605,12 +1604,12 @@ def test_mc_operation_utils_resolve_context_and_raw_arrays() -> None:
         SourceArgs(
             arg="sample",
             source_step="vector",
-            source_idx=1,
             source_kind=SOURCE_KIND_PAYLOAD,
             field="payload",
             field_idx=DYNAMIC_FIELD_INDEX["payload"],
             burn_in=2,
         ),
+        1,
     )
     np.testing.assert_allclose(payload, np.arange(2.0, 5.0).reshape(3, 1))
 
@@ -1623,12 +1622,12 @@ def test_mc_operation_utils_resolve_context_and_raw_arrays() -> None:
             SourceArgs(
                 arg="sample",
                 source_step="filter",
-                source_idx=2,
                 source_kind=SOURCE_KIND_FILTER,
                 field="std_innov",
                 field_idx=FILTER_RAW_FIELD_INDEX["std_innov"],
                 columns=slice(0, 1),
             ),
+            2,
         ),
         filt.std_innov[:, :1],
     )

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -1178,6 +1178,37 @@ def test_output_shape_resolution_tracks_selected_transform_payloads() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "kind",
+    ("ridge", "lasso", "elastic_net", "ridge_gs", "lasso_gs", "elastic_net_gs"),
+)
+def test_output_specs_for_non_ols_regressions(kind: str) -> None:
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(observables=np.zeros((8, 2), dtype=np.float64)),
+            regression_step(
+                kind,
+                y_source="datagen",
+                y_field="observables",
+                y_column=0,
+                X_source="datagen",
+                X_field="observables",
+                X_columns=1,
+                kind=kind,
+            ),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(_FakeSolvedModel(), None)
+
+    assert specs[kind] == {
+        "coef": BufferSpec((2,), np.float64),
+        "ssr": BufferSpec((), np.float64),
+        "sst": BufferSpec((), np.float64),
+        "status": BufferSpec((), np.int64),
+    }
+
+
 def test_output_shape_resolution_includes_linear_filter_fields() -> None:
     reference = _FakeSolvedModel()
     reference.compiled.observable_names = ["a", "b", "c"]

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from SymbolicDSGE import Shock
+from SymbolicDSGE import DSGESolver, ModelParser, Shock
 from SymbolicDSGE._diag_tests.breusch_godfrey import breusch_godfrey
 from SymbolicDSGE._diag_tests.breusch_pagan import (
     breusch_pagan,
@@ -20,6 +20,8 @@ from SymbolicDSGE._diag_tests.status import TestStatus
 from SymbolicDSGE._diag_tests.wald_test import wald_mean_hac
 from SymbolicDSGE.core.solved_model import SolvedModel
 from SymbolicDSGE.kalman.filter import FilterRawResult
+from SymbolicDSGE.kalman.config import KalmanConfig
+from SymbolicDSGE.monte_carlo.allocation import BufferSpec
 from SymbolicDSGE.monte_carlo import (
     MCPipeline,
     MCContext,
@@ -56,7 +58,7 @@ from SymbolicDSGE.monte_carlo.operations.tests import (
     ljung_box_test_step,
     wald_test_step,
 )
-from SymbolicDSGE.monte_carlo.operations.transforms import transform_step
+from SymbolicDSGE.monte_carlo.operations.transforms import log_diff_step, transform_step
 from SymbolicDSGE.monte_carlo.operations.utils import (
     _clone_or_pass_shocks,
     _resolve_source_array,
@@ -1135,6 +1137,161 @@ def test_transform_step_returning_mcdata_updates_downstream_data() -> None:
     np.testing.assert_allclose(out.contexts[0].data.observables, observables + 1.0)
     assert out.payloads is not None
     assert isinstance(out.payloads[0]["add_noise"], MCData)
+
+
+def test_output_shape_resolution_tracks_selected_transform_payloads() -> None:
+    observables = np.zeros((2, 8, 3), dtype=np.float64)
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(observables=observables),
+            log_diff_step(
+                "growth",
+                source="datagen",
+                field="observables",
+                columns=[1, 2],
+                burn_in=1,
+            ),
+            regression_step(
+                "ols",
+                y_source="growth",
+                y_field="payload",
+                y_column=0,
+                X_source="growth",
+                X_field="payload",
+                X_columns=1,
+            ),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(_FakeSolvedModel(), None)
+
+    assert specs == {
+        "datagen": {"observables": BufferSpec((8, 3), np.float64)},
+        "growth": {"payload": BufferSpec((6, 2), np.float64)},
+        "ols": {
+            "coef": BufferSpec((2,), np.float64),
+            "se": BufferSpec((2,), np.float64),
+            "ssr": BufferSpec((), np.float64),
+            "sst": BufferSpec((), np.float64),
+            "status": BufferSpec((), np.int64),
+        },
+    }
+
+
+def test_output_shape_resolution_includes_linear_filter_fields() -> None:
+    reference = _FakeSolvedModel()
+    reference.compiled.observable_names = ["a", "b", "c"]
+    observables = np.zeros((2, 8, 3), dtype=np.float64)
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(
+                observables=observables,
+                observable_names=("a", "b", "c"),
+            ),
+            reference_filter_step(
+                observables=["a", "c"],
+                return_shocks=True,
+            ),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(reference, None)
+
+    assert specs["filter"] == {
+        "x_pred": BufferSpec((8, 2), np.float64),
+        "x_filt": BufferSpec((8, 2), np.float64),
+        "P_pred": BufferSpec((8, 2, 2), np.float64),
+        "P_filt": BufferSpec((8, 2, 2), np.float64),
+        "y_pred": BufferSpec((8, 2), np.float64),
+        "y_filt": BufferSpec((8, 2), np.float64),
+        "innov": BufferSpec((8, 2), np.float64),
+        "std_innov": BufferSpec((8, 2), np.float64),
+        "S": BufferSpec((8, 2, 2), np.float64),
+        "eps_hat": BufferSpec((8, 1), np.float64),
+    }
+
+
+def test_output_shape_resolution_includes_scalar_test_channels() -> None:
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(
+                observables=np.zeros((8, 1), dtype=np.float64),
+                observable_names=("obs",),
+            ),
+            jarque_bera_test_step("jb", source="datagen", field="observables"),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(_FakeSolvedModel(), None)
+
+    assert specs["jb"] == {
+        "statistic": BufferSpec((), np.float64),
+        "pval": BufferSpec((), np.float64),
+        "status": BufferSpec((), np.int64),
+    }
+
+
+def test_output_shape_resolution_normalizes_payload_values_to_source_shapes() -> None:
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(observables=np.zeros((4, 1), dtype=np.float64)),
+            add_payload_step("vector", np.arange(4.0, dtype=np.float64)),
+            add_payload_step("matrix", np.zeros((4, 2), dtype=np.float64)),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(_FakeSolvedModel(), None)
+
+    assert specs["vector"] == {"payload": BufferSpec((4, 1), np.float64)}
+    assert specs["matrix"] == {"payload": BufferSpec((4, 2), np.float64)}
+
+
+def test_output_shape_resolution_includes_unscented_filter_fields(
+    rbc_second_order_test_model_path,
+) -> None:
+    model, _ = ModelParser(rbc_second_order_test_model_path).get_all()
+    n_var = len(model.variables.variables)
+    solver = DSGESolver(
+        model,
+        KalmanConfig(
+            R=np.array([[0.01]], dtype=np.float64),
+            P0=0.1 * np.eye(n_var, dtype=np.float64),
+        ),
+    )
+    compiled = solver.compile()
+    reference = solver.solve(compiled=compiled, order=2)
+
+    T = 6
+    n_obs = len(reference.compiled.observable_names)
+    pipeline = MCPipeline(
+        [
+            raw_model_data_step(
+                observables=np.zeros((T, n_obs), dtype=np.float64),
+                observable_names=reference.compiled.observable_names,
+            ),
+            reference_filter_step(filter_mode="unscented"),
+        ]
+    )
+
+    specs = pipeline._resolve_output_specs(reference, None)
+    n_state = reference.compiled.n_state
+    n_z = 2 * n_state
+
+    assert specs["filter"] == {
+        "x_pred": BufferSpec((T, n_var), np.float64),
+        "x_filt": BufferSpec((T, n_var), np.float64),
+        "y_pred": BufferSpec((T, n_obs), np.float64),
+        "y_filt": BufferSpec((T, n_obs), np.float64),
+        "S": BufferSpec((T, n_obs, n_obs), np.float64),
+        "innov": BufferSpec((T, n_obs), np.float64),
+        "std_innov": BufferSpec((T, n_obs), np.float64),
+        "P_pred": BufferSpec((T, n_z, n_z), np.float64),
+        "P_filt": BufferSpec((T, n_z, n_z), np.float64),
+        "x1_pred": BufferSpec((T, n_state), np.float64),
+        "x1_filt": BufferSpec((T, n_state), np.float64),
+        "x2_pred": BufferSpec((T, n_state), np.float64),
+        "x2_filt": BufferSpec((T, n_state), np.float64),
+    }
 
 
 def test_regression_step_runs_ols_and_stores_result_payload() -> None:


### PR DESCRIPTION
## Summary

- Add allocation-free native Monte Carlo transform kernels and route built-in transforms through them.
- Add caller-owned native Monte Carlo kernels for OLS, Ridge, Lasso, Elastic Net, and their grid-search variants.
- Add AOT output buffer-spec resolution for built-in pipeline steps, including regression outputs.
- Precompute Monte Carlo source producer indices during pipeline construction.

## Validation

- Add native transform parity coverage.
- Add allocation, regression-buffer resolution, and Monte Carlo pipeline coverage.

Partly closes: #361, #359 