### PR TITLE
Add native Monte Carlo core steps

### DIFF
--- a/SymbolicDSGE/_ckernels/core/_core.pyi
+++ b/SymbolicDSGE/_ckernels/core/_core.pyi
@@ -36,10 +36,9 @@ def affine_observations_into(
     states: _F64,
     C: _F64,
     d: _F64,
-    state_start: int,
     out: _F64,
 ) -> None:
-    """out[(T, m)] <- d + C @ states[state_start + t]. Mirrors the numba kernel."""
+    """out[(T, m)] <- d + C @ states[t]. Mirrors the numba kernel."""
 
 def simulate_second_order_pruned(
     hx: _F64,

--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -30,7 +30,7 @@ cdef extern from "core.h" nogil:
         const double *shock, double *out, int64_t T, int64_t n, int64_t k)
     void sdsge_affine_observations(
         const double *states, const double *C, const double *d,
-        int64_t state_start, double *out, int64_t T, int64_t m, int64_t n)
+        double *out, int64_t T, int64_t m, int64_t n)
     int64_t sdsge_simulate_second_order_pruned(
         const double *hx, const double *gx, const double *bx,
         const double *hxx, const double *gxx,
@@ -176,7 +176,7 @@ def assemble_state_space(p, f, n_state, n_control, n_exog):
 
 
 def simulate_linear_states_into(A, B, x0, shock_mat, double[:, ::1] out):
-    """out[(T+1, n)] <- linear state recursion. ``out`` is the caller's
+    """out[(T, n)] <- post-shock linear state recursion. ``out`` is the caller's
     C-contiguous f64 output buffer, written in place; inputs are coerced."""
     cdef double[:, ::1] Av = np.ascontiguousarray(A, dtype=np.float64)
     cdef double[:, ::1] Bv = np.ascontiguousarray(B, dtype=np.float64)
@@ -185,17 +185,15 @@ def simulate_linear_states_into(A, B, x0, shock_mat, double[:, ::1] out):
     cdef int64_t n = Av.shape[0]
     cdef int64_t k = Bv.shape[1]
     cdef int64_t T = shockv.shape[0]
-    # out[0] = x0 is written even when T == 0, so the C call always runs; only
-    # the shock pointer can dangle on an empty (0, k) buffer.
-    cdef const double *shock_ptr = &shockv[0, 0] if T > 0 else NULL
+    cdef const double *shock_ptr = &shockv[0, 0]
     with nogil:
         sdsge_simulate_linear_states(
             &Av[0, 0], &Bv[0, 0], &x0v[0], shock_ptr, &out[0, 0], T, n, k
         )
 
 
-def affine_observations_into(states, C, d, int64_t state_start, double[:, ::1] out):
-    """out[(T, m)] <- d + C @ states[state_start + t]. ``out`` is the caller's
+def affine_observations_into(states, C, d, double[:, ::1] out):
+    """out[(T, m)] <- d + C @ states[t]. ``out`` is the caller's
     C-contiguous f64 output buffer, written in place; inputs are coerced."""
     cdef int64_t T = out.shape[0]
     if T == 0:
@@ -207,7 +205,7 @@ def affine_observations_into(states, C, d, int64_t state_start, double[:, ::1] o
     cdef int64_t n = Cv.shape[1]
     with nogil:
         sdsge_affine_observations(
-            &statesv[0, 0], &Cv[0, 0], &dv[0], state_start, &out[0, 0], T, m, n
+            &statesv[0, 0], &Cv[0, 0], &dv[0], &out[0, 0], T, m, n
         )
 
 
@@ -260,8 +258,8 @@ def simulate_second_order_pruned(hx, gx, bx, hxx, gxx, hss, gss, x0, shock_mat):
     if shockv.shape[1] != n_exog:
         raise ValueError("shock_mat must have shape (T, n_exog).")
 
-    x_out = np.empty((T + 1, nx), dtype=np.float64)
-    y_out = np.empty((T + 1, ny), dtype=np.float64)
+    x_out = np.empty((T, nx), dtype=np.float64)
+    y_out = np.empty((T, ny), dtype=np.float64)
     xoutv = x_out
     youtv = y_out
     x_ptr = &xoutv[0, 0]

--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -22,6 +22,8 @@ cdef extern from "../_common/sdsge_complex.h":
 
 
 cdef extern from "core.h" nogil:
+    ctypedef void (*sdsge_measurement_fn)(
+        double *vars, double *par, double *out) noexcept
     void sdsge_assemble_state_space(
         const c128 *p, const c128 *f, const int64_t n_state, int64_t n_control,
         const int64_t n_exog, double *A, double *B)
@@ -143,12 +145,6 @@ cdef extern from "bicomplex_hessian.h" nogil:
         bc_residual_fn residual, const double *ss, const double *par,
         int64_t n_var, int64_t n_par, int64_t n_eq, double step,
         double *hessian)
-
-
-# Measurement / observable-jacobian @cfunc (build_measurement_cfunc, real ABI):
-# ``void(vars*, par*, out*)``. Held Python-side; called here by ``.address``, nogil.
-ctypedef void (*sdsge_measurement_fn)(
-    double *vars, double *par, double *out) noexcept nogil
 
 
 def assemble_state_space(p, f, n_state, n_control, n_exog):

--- a/SymbolicDSGE/_ckernels/core/core.c
+++ b/SymbolicDSGE/_ckernels/core/core.c
@@ -74,13 +74,10 @@ void sdsge_simulate_linear_states(const f64 *SDSGE_RESTRICT A,
                                   const f64 *SDSGE_RESTRICT shock,
                                   f64 *SDSGE_RESTRICT out, i64 T, i64 n,
                                   i64 k) {
-  for (i64 i = 0; i < n; ++i)
-    out[i] = x0[i];
-
   for (i64 t = 0; t < T; ++t) {
-    const f64 *xt = out + t * n;
+    const f64 *xt = t == 0 ? x0 : out + (t - 1) * n;
     const f64 *st = shock + t * k;
-    f64 *xn = out + (t + 1) * n;
+    f64 *xn = out + t * n;
     for (i64 i = 0; i < n; ++i) {
       const f64 *Ai = A + i * n;
       const f64 *Bi = B + i * k;
@@ -96,10 +93,10 @@ void sdsge_simulate_linear_states(const f64 *SDSGE_RESTRICT A,
 
 void sdsge_affine_observations(const f64 *SDSGE_RESTRICT states,
                                const f64 *SDSGE_RESTRICT C,
-                               const f64 *SDSGE_RESTRICT d, i64 state_start,
+                               const f64 *SDSGE_RESTRICT d,
                                f64 *SDSGE_RESTRICT out, i64 T, i64 m, i64 n) {
   for (i64 t = 0; t < T; ++t) {
-    const f64 *row = states + (state_start + t) * n;
+    const f64 *row = states + t * n;
     f64 *ot = out + t * m;
     for (i64 i = 0; i < m; ++i) {
       const f64 *Ci = C + i * n;
@@ -138,44 +135,13 @@ i64 sdsge_simulate_second_order_pruned(
     x2_cur[i] = 0.0;
   }
 
-  for (i64 t = 0; t <= T; ++t) {
-    f64 *SDSGE_RESTRICT xt = x_out + t * nx;
-
-    for (i64 i = 0; i < nx; ++i) {
-      xt[i] = x1_cur[i] + x2_cur[i];
-    }
-
+  for (i64 t = 0; t < T; ++t) {
     for (i64 j = 0; j < nx; ++j) {
       const f64 xj = x1_cur[j];
       f64 *SDSGE_RESTRICT row = x1_outer + j * nx;
       for (i64 k = 0; k < nx; ++k) {
         row[k] = xj * x1_cur[k];
       }
-    }
-
-    if (ny > 0) {
-      f64 *SDSGE_RESTRICT yt = y_out + t * ny;
-      for (i64 i = 0; i < ny; ++i) {
-        const f64 *SDSGE_RESTRICT gxi = gx + i * nx;
-        const f64 *SDSGE_RESTRICT gxxi = gxx + i * nx * nx;
-        f64 s = 0.5 * gss[i];
-
-        for (i64 j = 0; j < nx; ++j) {
-          s += gxi[j] * xt[j];
-        }
-        for (i64 j = 0; j < nx; ++j) {
-          const f64 *SDSGE_RESTRICT gxxij = gxxi + j * nx;
-          const f64 *SDSGE_RESTRICT outerj = x1_outer + j * nx;
-          for (i64 k = 0; k < nx; ++k) {
-            s += 0.5 * gxxij[k] * outerj[k];
-          }
-        }
-        yt[i] = s;
-      }
-    }
-
-    if (t == T) {
-      break;
     }
 
     const f64 *SDSGE_RESTRICT shock_t = n_exog > 0 ? shock + t * n_exog : NULL;
@@ -212,6 +178,40 @@ i64 sdsge_simulate_second_order_pruned(
     tmp = x2_cur;
     x2_cur = x2_next;
     x2_next = tmp;
+
+    f64 *SDSGE_RESTRICT xt = x_out + t * nx;
+    for (i64 i = 0; i < nx; ++i) {
+      xt[i] = x1_cur[i] + x2_cur[i];
+    }
+
+    if (ny > 0) {
+      for (i64 j = 0; j < nx; ++j) {
+        const f64 xj = x1_cur[j];
+        f64 *SDSGE_RESTRICT row = x1_outer + j * nx;
+        for (i64 k = 0; k < nx; ++k) {
+          row[k] = xj * x1_cur[k];
+        }
+      }
+
+      f64 *SDSGE_RESTRICT yt = y_out + t * ny;
+      for (i64 i = 0; i < ny; ++i) {
+        const f64 *SDSGE_RESTRICT gxi = gx + i * nx;
+        const f64 *SDSGE_RESTRICT gxxi = gxx + i * nx * nx;
+        f64 s = 0.5 * gss[i];
+
+        for (i64 j = 0; j < nx; ++j) {
+          s += gxi[j] * xt[j];
+        }
+        for (i64 j = 0; j < nx; ++j) {
+          const f64 *SDSGE_RESTRICT gxxij = gxxi + j * nx;
+          const f64 *SDSGE_RESTRICT outerj = x1_outer + j * nx;
+          for (i64 k = 0; k < nx; ++k) {
+            s += 0.5 * gxxij[k] * outerj[k];
+          }
+        }
+        yt[i] = s;
+      }
+    }
   }
 
   free(arena);

--- a/SymbolicDSGE/_ckernels/core/core.h
+++ b/SymbolicDSGE/_ckernels/core/core.h
@@ -5,6 +5,9 @@
 #include "../_common/sdsge_complex.h"
 #include "../_common/sdsge_linalg.h"
 
+/* Measurement / observable-jacobian @cfunc ABI: ``void(vars*, par*, out*)``. */
+typedef void (*sdsge_measurement_fn)(f64 *vars, f64 *par, f64 *out);
+
 /* Assemble state-space */
 void sdsge_assemble_state_space(const c128 *SDSGE_RESTRICT p,
                                 const c128 *SDSGE_RESTRICT f, const i64 n_state,

--- a/SymbolicDSGE/_ckernels/core/core.h
+++ b/SymbolicDSGE/_ckernels/core/core.h
@@ -21,13 +21,13 @@ void sdsge_simulate_linear_states(const f64 *SDSGE_RESTRICT A,     /* (n, n) */
                                   f64 *SDSGE_RESTRICT out, /* (T+1, n) */
                                   i64 T, i64 n, i64 k);
 
-/* out[(T, m)] : out[t] = d + C @ states[state_start + t]. */
-void sdsge_affine_observations(
-    const f64 *SDSGE_RESTRICT states, /* (>= state_start + T, n) row-major */
-    const f64 *SDSGE_RESTRICT C,      /* (m, n) */
-    const f64 *SDSGE_RESTRICT d,      /* (m,)   */
-    i64 state_start, f64 *SDSGE_RESTRICT out, /* (T, m) */
-    i64 T, i64 m, i64 n);
+/* out[(T, m)] : out[t] = d + C @ states[t]. */
+void sdsge_affine_observations(const f64 *SDSGE_RESTRICT
+                                   states, /* (T, n) row-major */
+                               const f64 *SDSGE_RESTRICT C, /* (m, n) */
+                               const f64 *SDSGE_RESTRICT d, /* (m,)   */
+                               f64 *SDSGE_RESTRICT out,     /* (T, m) */
+                               i64 T, i64 m, i64 n);
 
 /* Pruned second order simulation.
  * x_out[(T+1, nx)] and y_out[(T+1, ny)] are dense split outputs. */

--- a/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
@@ -121,6 +121,7 @@ cdef extern from "estimation.h":
         double *corr_r
         double *std_q
         double *std_r
+        double *filter_arena
         int64_t bk_violations
 
     ctypedef struct sdsge_linear_ctx:
@@ -165,6 +166,14 @@ cdef extern from "estimation.h":
                               int has_priors) nogil
     double sdsge_obj_unscented(sdsge_unscented_ctx *ctx, const double *theta,
                                int has_priors) nogil
+
+
+cdef extern from "../kalman/kalman.h":
+    int64_t kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    int64_t ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    int64_t ukf_arena_size(
+        int64_t n_state, int64_t n_ctrl, int64_t n_exog, int64_t n_obs,
+    ) nogil
 
 
 cdef extern from "optim.h":
@@ -358,6 +367,9 @@ def obj_linear_base(
     b.std_q = NULL
     b.std_r = NULL
     b.bk_violations = 0
+    filter_arena = np.empty(kf_arena_size(n_var, n_obs, n_exog), dtype=np.float64)
+    cdef double[::1] filter_arena_v = filter_arena
+    b.filter_arena = &filter_arena_v[0]
 
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
@@ -490,6 +502,9 @@ def obj_extended_base(
     b.std_q = NULL
     b.std_r = NULL
     b.bk_violations = 0
+    filter_arena = np.empty(ekf_arena_size(n_var, n_obs, n_exog), dtype=np.float64)
+    cdef double[::1] filter_arena_v = filter_arena
+    b.filter_arena = &filter_arena_v[0]
 
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
@@ -656,6 +671,11 @@ def obj_unscented_base(
     b.std_q = NULL
     b.std_r = NULL
     b.bk_violations = 0
+    filter_arena = np.empty(
+        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+    )
+    cdef double[::1] filter_arena_v = filter_arena
+    b.filter_arena = &filter_arena_v[0]
 
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
@@ -951,6 +971,7 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     cdef int64_t[::1] p_ml_v
     cdef double[::1] p_me_v
     cdef double[::1] p_mlc_v
+    cdef double[::1] filter_arena_v
     cdef int64_t p_nscalar = 0
     cdef int64_t p_nblocks = 0
 
@@ -1123,6 +1144,22 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     b.std_q = &sqv[0]
     b.std_r = &srv[0]
     b.bk_violations = 0
+
+    if mode == "linear":
+        filter_arena = np.empty(
+            kf_arena_size(n_var, n_obs, n_exog), dtype=np.float64
+        )
+    elif mode == "extended":
+        filter_arena = np.empty(
+            ekf_arena_size(n_var, n_obs, n_exog), dtype=np.float64
+        )
+    else:
+        filter_arena = np.empty(
+            ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+        )
+    nc.keep.append(filter_arena)
+    filter_arena_v = filter_arena
+    b.filter_arena = &filter_arena_v[0]
 
     s1.ss = &ssv2[0]
     s1.a_real = &arv[0, 0]

--- a/SymbolicDSGE/_ckernels/estimation/estimation.c
+++ b/SymbolicDSGE/_ckernels/estimation/estimation.c
@@ -285,7 +285,7 @@ f64 sdsge_obj_linear(sdsge_linear_ctx *ctx, const f64 *SDSGE_RESTRICT theta,
                   .return_shocks = 0,
                   .store_history = 0};
   kf_outputs out = {.loglik = &ll};
-  if (kf_hot_loop(&in, &out) != KF_OK) {
+  if (kf_hot_loop(&in, b->filter_arena, &out) != KF_OK) {
     return -INFINITY;
   }
   return sdsge_add_lp(b, theta, ll, has_priors);
@@ -335,7 +335,7 @@ f64 sdsge_obj_extended(sdsge_extended_ctx *ctx, const f64 *SDSGE_RESTRICT theta,
                    .return_shocks = 0,
                    .store_history = 0};
   ekf_outputs out = {.loglik = &ll};
-  if (ekf_hot_loop(&in, &out) != KF_OK) {
+  if (ekf_hot_loop(&in, b->filter_arena, &out) != KF_OK) {
     return -INFINITY;
   }
   return sdsge_add_lp(b, theta, ll, has_priors);
@@ -426,7 +426,7 @@ f64 sdsge_obj_unscented(sdsge_unscented_ctx *ctx,
                    .store_history = 0};
 
   ukf_outputs out = {.loglik = &ll};
-  if (ukf_hot_loop(&in, &out) != KF_OK) {
+  if (ukf_hot_loop(&in, b->filter_arena, &out) != KF_OK) {
 
     return -INFINITY;
   }

--- a/SymbolicDSGE/_ckernels/estimation/estimation.h
+++ b/SymbolicDSGE/_ckernels/estimation/estimation.h
@@ -60,14 +60,14 @@ typedef struct {
 
 /* Model and data dimensions. */
 typedef struct {
-  i64 n_theta;  /* estimated params */
-  i64 n_var;    /* nx + ny (pencil / filter dim) */
-  i64 n_state;  /* nx */
-  i64 n_ctrl;   /* ny */
-  i64 n_exog;   /* k */
-  i64 n_obs;    /* m */
-  i64 n_par; /* calib params */
-  i64 T;     /* observations */
+  i64 n_theta; /* estimated params */
+  i64 n_var;   /* nx + ny (pencil / filter dim) */
+  i64 n_state; /* nx */
+  i64 n_ctrl;  /* ny */
+  i64 n_exog;  /* k */
+  i64 n_obs;   /* m */
+  i64 n_par;   /* calib params */
+  i64 T;       /* observations */
 } sdsge_dims;
 
 /* theta -> params resolution tables. base_params and every slot index
@@ -134,13 +134,16 @@ typedef struct {
   sdsge_cov_spec r_spec;
   sdsge_prior_tables prior;
 
-  f64 *params;    /* n_par; calib_params order, residual/meas argument vector */
-  f64 *Q;         /* n_exog*n_exog */
-  f64 *R;         /* n_obs*n_obs */
-  f64 *corr_q;    /* n_exog*n_exog */
-  f64 *corr_r;    /* n_obs*n_obs */
-  f64 *std_q;     /* n_exog */
-  f64 *std_r;     /* n_obs */
+  f64 *params; /* n_par; calib_params order, residual/meas argument vector */
+  f64 *Q;      /* n_exog*n_exog */
+  f64 *R;      /* n_obs*n_obs */
+  f64 *corr_q; /* n_exog*n_exog */
+  f64 *corr_r; /* n_obs*n_obs */
+  f64 *std_q;  /* n_exog */
+  f64 *std_r;  /* n_obs */
+
+  f64 *filter_arena; /* scratch for the filter sizeof(f64)*<filter>_arena_size()
+                      */
 
   i64 bk_violations;
 } sdsge_obj_common;
@@ -175,9 +178,9 @@ void sdsge_init_params(f64 *SDSGE_RESTRICT params,
                        const f64 *SDSGE_RESTRICT base_params, i64 n_par);
 
 /* Post-loop resolution at a theta (e.g. x_best): scatter into params, and the
- * log-prior from the packed tables. Both are scatter / prior only, no filter, so
- * they are cheap to call once after the optimizer returns. Shared by every mode
- * (they operate on the common base). */
+ * log-prior from the packed tables. Both are scatter / prior only, no filter,
+ * so they are cheap to call once after the optimizer returns. Shared by every
+ * mode (they operate on the common base). */
 void sdsge_scatter_params(sdsge_obj_common *SDSGE_RESTRICT base,
                           const f64 *SDSGE_RESTRICT theta);
 f64 sdsge_logprior_at(const sdsge_obj_common *SDSGE_RESTRICT base,

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -50,7 +50,12 @@ cdef extern from "kalman.h":
         double *eps_hat
         double *loglik
 
-    int kf_hot_loop(const kf_inputs *inp, kf_outputs *outp) nogil
+    int64_t kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    int kf_hot_loop(
+        const kf_inputs *inp,
+        double *arena,
+        kf_outputs *outp,
+    ) nogil
 
     ctypedef void (*meas_fn)(
         const double *x,
@@ -93,8 +98,10 @@ cdef extern from "kalman.h":
         double *eps_hat
         double *loglik
 
+    int64_t ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
     int c_ekf_hot_loop "ekf_hot_loop"(
         const ekf_inputs *inp,
+        double *arena,
         ekf_outputs *outp,
     ) nogil
 
@@ -150,8 +157,15 @@ cdef extern from "kalman.h":
 
         double *loglik
 
+    int64_t ukf_arena_size(
+        int64_t n_state,
+        int64_t n_ctrl,
+        int64_t n_exog,
+        int64_t n_obs,
+    ) nogil
     int64_t c_ukf_hot_loop "ukf_hot_loop"(
         const ukf_inputs *inp,
+        double *arena,
         ukf_outputs *outp,
     ) nogil
 
@@ -205,6 +219,7 @@ def kalman_hot_loop(
     std_innov = np.zeros((hist_T, m), dtype=np.float64)
     S = np.zeros((hist_T, m, m), dtype=np.float64)
     eps_hat = np.zeros((shock_T, k), dtype=np.float64)
+    arena = np.empty(kf_arena_size(n, m, k), dtype=np.float64)
     cdef double loglik = 0.0
 
     cdef double[:, ::1] x_pred_mv = x_pred
@@ -217,6 +232,7 @@ def kalman_hot_loop(
     cdef double[:, ::1] std_innov_mv = std_innov
     cdef double[:, :, ::1] S_mv = S
     cdef double[:, ::1] eps_hat_mv = eps_hat
+    cdef double[::1] arena_mv = arena
 
     cdef kf_inputs inp
     inp.n = n
@@ -252,7 +268,7 @@ def kalman_hot_loop(
 
     cdef int64_t status
     with nogil:
-        status = kf_hot_loop(&inp, &outp)
+        status = kf_hot_loop(&inp, &arena_mv[0], &outp)
 
     return (
         status,
@@ -334,6 +350,7 @@ def ekf_hot_loop(
     std_innov = np.zeros((hist_T, m), dtype=np.float64)
     S = np.zeros((hist_T, m, m), dtype=np.float64)
     eps_hat = np.zeros((shock_T, k), dtype=np.float64)
+    arena = np.empty(ekf_arena_size(n, m, k), dtype=np.float64)
     cdef double loglik = 0.0
 
     cdef double[:, ::1] x_pred_mv = x_pred
@@ -346,6 +363,7 @@ def ekf_hot_loop(
     cdef double[:, ::1] std_innov_mv = std_innov
     cdef double[:, :, ::1] S_mv = S
     cdef double[:, ::1] eps_hat_mv = eps_hat
+    cdef double[::1] arena_mv = arena
 
     cdef ekf_inputs inp
     inp.meas = <meas_fn><void*>meas_addr
@@ -384,7 +402,7 @@ def ekf_hot_loop(
 
     cdef int status
     with nogil:
-        status = c_ekf_hot_loop(&inp, &outp)
+        status = c_ekf_hot_loop(&inp, &arena_mv[0], &outp)
 
     return (
         status,
@@ -506,6 +524,9 @@ def ukf_hot_loop(
     innov = np.zeros((hist_T, n_obs), dtype=np.float64)
     std_innov = np.zeros((hist_T, n_obs), dtype=np.float64)
     S = np.zeros((hist_T, n_obs, n_obs), dtype=np.float64)
+    arena = np.empty(
+        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+    )
     cdef double loglik = 0.0
 
     cdef double[:, ::1] x1_pred_mv = x1_pred
@@ -521,6 +542,7 @@ def ukf_hot_loop(
     cdef double[:, ::1] innov_mv = innov
     cdef double[:, ::1] std_innov_mv = std_innov
     cdef double[:, :, ::1] S_mv = S
+    cdef double[::1] arena_mv = arena
 
     cdef ukf_inputs inp
     inp.meas = <meas_fn><void*>meas_addr
@@ -575,7 +597,7 @@ def ukf_hot_loop(
 
     cdef int64_t status
     with nogil:
-        status = c_ukf_hot_loop(&inp, &outp)
+        status = c_ukf_hot_loop(&inp, &arena_mv[0], &outp)
 
     return (
         status,

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -142,21 +142,18 @@ void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B,
   sdsge_matmul(Q, temp_km, out, k, k, m);
 }
 
-int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
+i64 kf_arena_size(const i64 n, const i64 m, const i64 k) {
+  return 2 * n + 7 * m /* vectors + triangular-solve scratch */
+         + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+         + 2 * m * m   /* S_buf, L */
+         + 3 * n * m   /* PCt, K, temp_nm */
+         + m * n       /* temp_mn */
+         + n * k       /* temp_nk */
+         + 2 * k * m;  /* M, temp_km */
+}
+int kf_hot_loop(const kf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                kf_outputs *out) {
   const i64 n = in->n, m = in->m, k = in->k, T = in->T;
-
-  /* One scratch arena carved into every per-step buffer (allocated once). */
-  const i64 total =
-      2 * n + 7 * m /* vectors + triangular-solve scratch */
-      + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
-      + 2 * m * m   /* S_buf, L */
-      + 3 * n * m   /* PCt, K, temp_nm */
-      + m * n       /* temp_mn */
-      + n * k       /* temp_nk */
-      + 2 * k * m;  /* M, temp_km */
-  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-  if (arena == NULL)
-    return KF_ERR_ALLOC;
 
   f64 *p = arena;
   f64 *x_pred_buf = p;
@@ -276,28 +273,22 @@ int kf_hot_loop(const kf_inputs *in, kf_outputs *out) {
   }
 
   *out->loglik = loglik;
-  free(arena);
   return status;
 }
 
-int ekf_hot_loop(const ekf_inputs *in, ekf_outputs *out) {
-  const i64 n = in->n, m = in->m, k = in->k, T = in->T;
+i64 ekf_arena_size(const i64 n, const i64 m, const i64 k) {
+  return 2 * n + 6 * m /* vectors + triangular-solve scratch */
+         + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+         + 2 * m * m   /* S_buf, L */
+         + 4 * n * m   /* PCt, K, temp_nm, H_buf */
+         + m * n       /* temp_mn */
+         + n * k       /* temp_nk */
+         + 2 * k * m;  /* M, temp_km */
+}
 
-  /* One scratch arena carved into every per-step buffer (allocated once). Same
-   * layout as the linear filter, plus a per-step measurement jacobian H_buf(m,n)
-   * since the EKF relinearizes each step. y_filt is written straight into the
-   * output (only when compute_y_filt), so it needs no scratch vector. */
-  const i64 total =
-      2 * n + 6 * m /* vectors + triangular-solve scratch */
-      + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
-      + 2 * m * m   /* S_buf, L */
-      + 4 * n * m   /* PCt, K, temp_nm, H_buf */
-      + m * n       /* temp_mn */
-      + n * k       /* temp_nk */
-      + 2 * k * m;  /* M, temp_km */
-  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-  if (arena == NULL)
-    return KF_ERR_ALLOC;
+int ekf_hot_loop(const ekf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                 ekf_outputs *out) {
+  const i64 n = in->n, m = in->m, k = in->k, T = in->T;
 
   f64 *p = arena;
   f64 *x_pred_buf = p;
@@ -420,14 +411,12 @@ int ekf_hot_loop(const ekf_inputs *in, ekf_outputs *out) {
   }
 
   *out->loglik = loglik;
-  free(arena);
   return status;
 }
 
 static void ukf_build_sigma_points(const f64 *SDSGE_RESTRICT mean,
-                                   const f64 *SDSGE_RESTRICT chol,
-                                   f64 gamma, f64 *SDSGE_RESTRICT sigma,
-                                   i64 n) {
+                                   const f64 *SDSGE_RESTRICT chol, f64 gamma,
+                                   f64 *SDSGE_RESTRICT sigma, i64 n) {
   memcpy(sigma, mean, (size_t)n * sizeof(f64));
   for (i64 col = 0; col < n; ++col) {
     f64 *plus = sigma + (1 + col) * n;
@@ -492,8 +481,7 @@ static void ukf_pruned_transition(const ukf_inputs *in,
   }
 }
 
-static void ukf_project_vars(const ukf_inputs *in,
-                             const f64 *SDSGE_RESTRICT z,
+static void ukf_project_vars(const ukf_inputs *in, const f64 *SDSGE_RESTRICT z,
                              f64 *SDSGE_RESTRICT vars) {
   const i64 ns = in->n_state;
   const i64 nc = in->n_ctrl;
@@ -518,8 +506,7 @@ static void ukf_project_vars(const ukf_inputs *in,
 
 static void ukf_eval_measurement_sigma(const ukf_inputs *in,
                                        const f64 *SDSGE_RESTRICT sigma_z,
-                                       i64 n_sig,
-                                       f64 *SDSGE_RESTRICT vars_buf,
+                                       i64 n_sig, f64 *SDSGE_RESTRICT vars_buf,
                                        f64 *SDSGE_RESTRICT sigma_y) {
   const i64 nz = 2 * in->n_state;
   const i64 no = in->n_obs;
@@ -529,11 +516,13 @@ static void ukf_eval_measurement_sigma(const ukf_inputs *in,
   }
 }
 
-static void ukf_weighted_meas_cov_cross(
-    const f64 *SDSGE_RESTRICT sigma_z, const f64 *SDSGE_RESTRICT z_mean,
-    const f64 *SDSGE_RESTRICT sigma_y, const f64 *SDSGE_RESTRICT y_mean, f64 w0,
-    f64 wi, i64 n_sig, i64 nz, i64 no, f64 *SDSGE_RESTRICT S,
-    f64 *SDSGE_RESTRICT Pzy) {
+static void ukf_weighted_meas_cov_cross(const f64 *SDSGE_RESTRICT sigma_z,
+                                        const f64 *SDSGE_RESTRICT z_mean,
+                                        const f64 *SDSGE_RESTRICT sigma_y,
+                                        const f64 *SDSGE_RESTRICT y_mean,
+                                        f64 w0, f64 wi, i64 n_sig, i64 nz,
+                                        i64 no, f64 *SDSGE_RESTRICT S,
+                                        f64 *SDSGE_RESTRICT Pzy) {
   sdsge_zero_mat(S, no, no);
   sdsge_zero_mat(Pzy, nz, no);
 
@@ -575,11 +564,9 @@ static void ukf_cov_update(const f64 *SDSGE_RESTRICT P_pred,
   }
 }
 
-static void ukf_store_history(const ukf_inputs *in,
-                              const f64 *SDSGE_RESTRICT z,
+static void ukf_store_history(const ukf_inputs *in, const f64 *SDSGE_RESTRICT z,
                               const f64 *SDSGE_RESTRICT P,
-                              f64 *SDSGE_RESTRICT x1,
-                              f64 *SDSGE_RESTRICT x2,
+                              f64 *SDSGE_RESTRICT x1, f64 *SDSGE_RESTRICT x2,
                               f64 *SDSGE_RESTRICT x, i64 t) {
   const i64 ns = in->n_state;
   const i64 nc = in->n_ctrl;
@@ -615,10 +602,10 @@ static void ukf_store_history(const ukf_inputs *in,
 
 /* Sigma-point Cholesky with an on-failure floor. Factor at the caller's jitter
  * first, so a well-conditioned covariance is unperturbed (parity with the plain
- * path); only when that fails add a scale-relative floor to lift a rank-deficient
- * covariance (e.g. a zero-risk-correction second order, whose augmented block is
- * degenerate) above the pivot threshold. A genuinely unfilterable matrix still
- * returns SDSGE_NOT_PD. */
+ * path); only when that fails add a scale-relative floor to lift a
+ * rank-deficient covariance (e.g. a zero-risk-correction second order, whose
+ * augmented block is degenerate) above the pivot threshold. A genuinely
+ * unfilterable matrix still returns SDSGE_NOT_PD. */
 #define UKF_CHOL_FLOOR_REL 1e-10
 static int ukf_chol_auto(const f64 *SDSGE_RESTRICT P, f64 jitter,
                          f64 *SDSGE_RESTRICT L, i64 n) {
@@ -631,7 +618,18 @@ static int ukf_chol_auto(const f64 *SDSGE_RESTRICT P, f64 jitter,
   return sdsge_chol(P, jitter + scale * UKF_CHOL_FLOOR_REL, L, n);
 }
 
-i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
+i64 ukf_arena_size(const i64 n_state, const i64 n_ctrl, const i64 n_exog,
+                   const i64 n_obs) {
+  const i64 nz = 2 * n_state;
+  const i64 n_sig = 2 * nz + 1;
+  const i64 nv = n_state + n_ctrl;
+
+  return 3 * nz + 4 * nz * nz + 2 * n_sig * nz + n_sig * n_obs +
+         n_state * n_state + n_state * n_exog + 6 * n_obs + 2 * n_obs * n_obs +
+         2 * nz * n_obs + nv;
+}
+i64 ukf_hot_loop(const ukf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                 ukf_outputs *out) {
   const i64 ns = in->n_state;
   const i64 nc = in->n_ctrl;
   const i64 ne = in->n_exog;
@@ -652,14 +650,6 @@ i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
   const f64 w0_m = lambda / scale;
   const f64 w0_c = w0_m + (1.0 - in->alpha * in->alpha + in->beta);
   const f64 wi = 1.0 / (2.0 * scale);
-
-  const i64 total =
-      3 * nz + 4 * nz * nz + 2 * n_sig * nz + n_sig * no + ns * ns +
-      ns * ne + 6 * no + 2 * no * no + 2 * nz * no + nv;
-
-  f64 *arena = (f64 *)malloc((size_t)total * sizeof(f64));
-  if (arena == NULL)
-    return KF_ERR_ALLOC;
 
   f64 *p = arena;
   f64 *z_prev = p;
@@ -788,6 +778,5 @@ i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out) {
   }
 
   *out->loglik = loglik;
-  free(arena);
   return status;
 }

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -108,8 +108,10 @@ typedef struct {
 } kf_outputs;
 
 /* Run the linear Kalman filter. Returns KF_OK, KF_ERR_MATRIX_CONDITION (non-PD
- * innovation covariance), or KF_ERR_ALLOC (scratch allocation failed). */
-int kf_hot_loop(const kf_inputs *in, kf_outputs *out);
+ * innovation covariance) */
+i64 kf_arena_size(const i64 n, const i64 m, const i64 k);
+int kf_hot_loop(const kf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                kf_outputs *out);
 
 /* Function Ptr for Non-Linear Measurement Function */
 typedef void (*meas_fn)(const f64 *SDSGE_RESTRICT x,
@@ -141,8 +143,10 @@ typedef struct {
 
 /* Run the extended Kalman filter: linear transition, nonlinear measurement via
  * the meas/jac cfunc pointers (relinearized each step). Returns KF_OK,
- * KF_ERR_MATRIX_CONDITION (non-PD innovation covariance), or KF_ERR_ALLOC. */
-int ekf_hot_loop(const ekf_inputs *in, ekf_outputs *out);
+ * KF_ERR_MATRIX_CONDITION (non-PD innovation covariance) */
+i64 ekf_arena_size(const i64 n, const i64 m, const i64 k);
+int ekf_hot_loop(const ekf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                 ekf_outputs *out);
 
 /* Unscented Kalman Filter */
 
@@ -200,6 +204,9 @@ typedef struct {
   f64 *loglik;
 } ukf_outputs;
 
-i64 ukf_hot_loop(const ukf_inputs *in, ukf_outputs *out);
+i64 ukf_arena_size(const i64 n_state, const i64 n_ctrl, const i64 n_exog,
+                   const i64 n_obs);
+i64 ukf_hot_loop(const ukf_inputs *in, f64 *SDSGE_RESTRICT arena,
+                 ukf_outputs *out);
 
 #endif /* SDSGE_KALMAN_H */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -163,3 +163,252 @@ void sdsge_simulate_order2_step(f64 *SDSGE_RESTRICT arena,
     }
   }
 }
+
+i64 sdsge_filter_linear_input_arena_size(const i64 n, const i64 m,
+                                          const i64 k, const i64 T) {
+  return n * n + n * k + m * n + m + k * k + m * m + T * m + n + n * n;
+}
+
+i64 sdsge_filter_linear_output_arena_size(const i64 n, const i64 m,
+                                           const i64 k, const i64 T,
+                                           const int return_shocks) {
+  return 2 * T * n + 2 * T * n * n + 4 * T * m + T * m * m +
+         (return_shocks ? T * k : 0) + 1;
+}
+
+int sdsge_filter_linear_step(const f64 *SDSGE_RESTRICT input_arena,
+                             f64 *SDSGE_RESTRICT scratch_arena, const i64 T,
+                             const i64 n, const i64 m, const i64 k,
+                             const int symmetrize, const f64 jitter,
+                             const int return_shocks,
+                             f64 *SDSGE_RESTRICT output_arena) {
+  const f64 *A = input_arena;
+  const f64 *B = A + n * n;
+  const f64 *C = B + n * k;
+  const f64 *d = C + m * n;
+  const f64 *Q = d + m;
+  const f64 *R = Q + k * k;
+  const f64 *y = R + m * m;
+  const f64 *x0 = y + T * m;
+  const f64 *P0 = x0 + n;
+  f64 *p = output_arena;
+  kf_outputs out = {.x_pred = p};
+  p += T * n;
+  out.x_filt = p;
+  p += T * n;
+  out.P_pred = p;
+  p += T * n * n;
+  out.P_filt = p;
+  p += T * n * n;
+  out.y_pred = p;
+  p += T * m;
+  out.y_filt = p;
+  p += T * m;
+  out.innov = p;
+  p += T * m;
+  out.std_innov = p;
+  p += T * m;
+  out.S = p;
+  p += T * m * m;
+  out.eps_hat = return_shocks ? p : NULL;
+  p += return_shocks ? T * k : 0;
+  out.loglik = p;
+
+  const kf_inputs in = {.n = n,
+                        .m = m,
+                        .k = k,
+                        .T = T,
+                        .A = A,
+                        .B = B,
+                        .C = C,
+                        .d = d,
+                        .Q = Q,
+                        .R = R,
+                        .y = y,
+                        .x0 = x0,
+                        .P0 = P0,
+                        .symmetrize = symmetrize,
+                        .jitter = jitter,
+                        .return_shocks = return_shocks,
+                        .store_history = 1};
+  return kf_hot_loop(&in, scratch_arena, &out);
+}
+
+i64 sdsge_filter_extended_input_arena_size(const i64 n, const i64 m,
+                                            const i64 k, const i64 T,
+                                            const i64 n_par) {
+  return n * n + n * k + n_par + k * k + m * m + T * m + n + n * n;
+}
+
+i64 sdsge_filter_extended_output_arena_size(const i64 n, const i64 m,
+                                             const i64 k, const i64 T,
+                                             const int return_shocks) {
+  return sdsge_filter_linear_output_arena_size(n, m, k, T, return_shocks);
+}
+
+int sdsge_filter_extended_step(const f64 *SDSGE_RESTRICT input_arena,
+                               f64 *SDSGE_RESTRICT scratch_arena,
+                               const meas_fn meas, const meas_fn jac,
+                               const i64 T, const i64 n, const i64 m,
+                               const i64 k, const i64 n_par,
+                               const int symmetrize, const f64 jitter,
+                               const int return_shocks,
+                               f64 *SDSGE_RESTRICT output_arena) {
+  const f64 *A = input_arena;
+  const f64 *B = A + n * n;
+  const f64 *params = B + n * k;
+  const f64 *Q = params + n_par;
+  const f64 *R = Q + k * k;
+  const f64 *y = R + m * m;
+  const f64 *x0 = y + T * m;
+  const f64 *P0 = x0 + n;
+  f64 *p = output_arena;
+  ekf_outputs out = {.x_pred = p};
+  p += T * n;
+  out.x_filt = p;
+  p += T * n;
+  out.P_pred = p;
+  p += T * n * n;
+  out.P_filt = p;
+  p += T * n * n;
+  out.y_pred = p;
+  p += T * m;
+  out.y_filt = p;
+  p += T * m;
+  out.innov = p;
+  p += T * m;
+  out.std_innov = p;
+  p += T * m;
+  out.S = p;
+  p += T * m * m;
+  out.eps_hat = return_shocks ? p : NULL;
+  p += return_shocks ? T * k : 0;
+  out.loglik = p;
+
+  const ekf_inputs in = {.meas = meas,
+                         .jac = jac,
+                         .A = A,
+                         .B = B,
+                         .calib_params = params,
+                         .Q = Q,
+                         .R = R,
+                         .y = y,
+                         .x0 = x0,
+                         .P0 = P0,
+                         .T = T,
+                         .n = n,
+                         .m = m,
+                         .k = k,
+                         .n_par = n_par,
+                         .jitter = jitter,
+                         .symmetrize = symmetrize,
+                         .compute_y_filt = 1,
+                         .return_shocks = return_shocks,
+                         .store_history = 1};
+  return ekf_hot_loop(&in, scratch_arena, &out);
+}
+
+i64 sdsge_filter_unscented_input_arena_size(const i64 n_state,
+                                             const i64 n_ctrl,
+                                             const i64 n_exog,
+                                             const i64 n_obs, const i64 T,
+                                             const i64 n_par) {
+  const i64 nz = 2 * n_state;
+  return n_state * n_state + n_ctrl * n_state + n_state * n_exog +
+         n_state * n_state * n_state + n_ctrl * n_state * n_state + n_state +
+         n_ctrl + n_state + n_ctrl + n_par + n_exog * n_exog + n_obs * n_obs +
+         T * n_obs + nz + nz * nz;
+}
+
+i64 sdsge_filter_unscented_output_arena_size(const i64 n_state,
+                                              const i64 n_ctrl,
+                                              const i64 n_obs, const i64 T) {
+  const i64 n_var = n_state + n_ctrl;
+  const i64 nz = 2 * n_state;
+  return 2 * T * n_var + 2 * T * nz * nz + 4 * T * n_obs + T * n_obs * n_obs +
+         4 * T * n_state + 1;
+}
+
+i64 sdsge_filter_unscented_step(const f64 *SDSGE_RESTRICT input_arena,
+                                f64 *SDSGE_RESTRICT scratch_arena,
+                                const meas_fn meas, const i64 T,
+                                const i64 n_state, const i64 n_ctrl,
+                                const i64 n_exog, const i64 n_obs,
+                                const i64 n_par, const f64 alpha,
+                                const f64 beta, const f64 kappa,
+                                const int symmetrize, const f64 jitter,
+                                f64 *SDSGE_RESTRICT output_arena) {
+  const i64 n_var = n_state + n_ctrl;
+  const i64 nz = 2 * n_state;
+  const f64 *hx = input_arena;
+  const f64 *gx = hx + n_state * n_state;
+  const f64 *bx = gx + n_ctrl * n_state;
+  const f64 *hxx = bx + n_state * n_exog;
+  const f64 *gxx = hxx + n_state * n_state * n_state;
+  const f64 *hss = gxx + n_ctrl * n_state * n_state;
+  const f64 *gss = hss + n_state;
+  const f64 *steady_state = gss + n_ctrl;
+  const f64 *params = steady_state + n_var;
+  const f64 *Q = params + n_par;
+  const f64 *R = Q + n_exog * n_exog;
+  const f64 *obs = R + n_obs * n_obs;
+  const f64 *z0 = obs + T * n_obs;
+  const f64 *P0 = z0 + nz;
+  f64 *p = output_arena;
+  ukf_outputs out = {.x_pred = p};
+  p += T * n_var;
+  out.x_filt = p;
+  p += T * n_var;
+  out.P_pred = p;
+  p += T * nz * nz;
+  out.P_filt = p;
+  p += T * nz * nz;
+  out.y_pred = p;
+  p += T * n_obs;
+  out.y_filt = p;
+  p += T * n_obs;
+  out.innov = p;
+  p += T * n_obs;
+  out.std_innov = p;
+  p += T * n_obs;
+  out.S = p;
+  p += T * n_obs * n_obs;
+  out.loglik = p;
+  p += 1;
+  out.x1_pred = p;
+  p += T * n_state;
+  out.x2_pred = p;
+  p += T * n_state;
+  out.x1_filt = p;
+  p += T * n_state;
+  out.x2_filt = p;
+
+  const ukf_inputs in = {.meas = meas,
+                         .hx = hx,
+                         .gx = gx,
+                         .bx = bx,
+                         .hxx = hxx,
+                         .gxx = gxx,
+                         .hss = hss,
+                         .gss = gss,
+                         .steady_state = steady_state,
+                         .params = params,
+                         .Q = Q,
+                         .R = R,
+                         .obs = obs,
+                         .z0 = z0,
+                         .P0 = P0,
+                         .T = T,
+                         .n_state = n_state,
+                         .n_ctrl = n_ctrl,
+                         .n_exog = n_exog,
+                         .n_obs = n_obs,
+                         .n_params = n_par,
+                         .alpha = alpha,
+                         .beta = beta,
+                         .kappa = kappa,
+                         .jitter = jitter,
+                         .symmetrize = symmetrize,
+                         .store_history = 1};
+  return ukf_hot_loop(&in, scratch_arena, &out);
+}

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -1,11 +1,20 @@
 #include "core_steps.h"
 #include "../core/core.h"
 
-void sdsge_simulate_order1_step(
-    const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
-    const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT d,
-    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock, const i64 T,
-    const i64 n, const i64 k, const i64 m, f64 *SDSGE_RESTRICT simout) {
+i64 sdsge_simulate_order1_arena_size(const i64 n, const i64 k, const i64 T,
+                                     const i64 n_par) {
+  return n * n + n * k + n + T * k + n_par;
+}
+void sdsge_simulate_order1_step(f64 *SDSGE_RESTRICT arena,
+                                sdsge_measurement_fn measurement, const i64 T,
+                                const i64 n, const i64 k, const i64 n_par,
+                                const i64 m, f64 *SDSGE_RESTRICT simout) {
+  const f64 *SDSGE_RESTRICT A = arena;
+  const f64 *SDSGE_RESTRICT B = A + n * n;
+  const f64 *SDSGE_RESTRICT x0 = B + n * k;
+  const f64 *SDSGE_RESTRICT shock = x0 + n;
+  f64 *SDSGE_RESTRICT params = (f64 *)(shock + T * k);
+  (void)n_par;
   f64 *states = simout;
   f64 *observables = simout + T * n;
 
@@ -26,26 +35,37 @@ void sdsge_simulate_order1_step(
       state_t[i] = value;
     }
 
-    for (i64 i = 0; i < m; ++i) {
-      const f64 *Ci = C + i * n;
-      f64 value = d[i];
-      for (i64 j = 0; j < n; ++j)
-        value += Ci[j] * state_t[j];
-      observable_t[i] = value;
+    if (m > 0) {
+      measurement(state_t, params, observable_t);
     }
   }
 }
 
-void sdsge_simulate_order2_step(
-    const f64 *SDSGE_RESTRICT hx, const f64 *SDSGE_RESTRICT gx,
-    const f64 *SDSGE_RESTRICT bx, const f64 *SDSGE_RESTRICT hxx,
-    const f64 *SDSGE_RESTRICT gxx, const f64 *SDSGE_RESTRICT hss,
-    const f64 *SDSGE_RESTRICT gss, const f64 *SDSGE_RESTRICT steady_state,
-    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock,
-    sdsge_measurement_fn measurement, f64 *SDSGE_RESTRICT params, i64 T, i64 nx,
-    i64 ny, i64 n_exog, i64 m, f64 *SDSGE_RESTRICT simout,
-    f64 *SDSGE_RESTRICT scratch) {
+i64 sdsge_simulate_order2_arena_size(const i64 n_state, const i64 n_var,
+                                     const i64 n_exog, const i64 T,
+                                     const i64 n_par) {
+  i64 nx = n_state;
+  i64 ny = n_var - n_state;
+  return nx * nx + ny * nx + nx * n_exog + nx * nx * nx + ny * nx * nx + nx +
+         ny + (nx + ny) + nx + T * n_exog + n_par + 4 * nx + nx * nx;
+}
+void sdsge_simulate_order2_step(f64 *SDSGE_RESTRICT arena,
+                                sdsge_measurement_fn measurement, i64 T, i64 nx,
+                                i64 ny, i64 n_exog, i64 n_par, i64 m,
+                                f64 *SDSGE_RESTRICT simout) {
   const i64 n = nx + ny;
+  const f64 *SDSGE_RESTRICT hx = arena;
+  const f64 *SDSGE_RESTRICT gx = hx + nx * nx;
+  const f64 *SDSGE_RESTRICT bx = gx + ny * nx;
+  const f64 *SDSGE_RESTRICT hxx = bx + nx * n_exog;
+  const f64 *SDSGE_RESTRICT gxx = hxx + nx * nx * nx;
+  const f64 *SDSGE_RESTRICT hss = gxx + ny * nx * nx;
+  const f64 *SDSGE_RESTRICT gss = hss + nx;
+  const f64 *SDSGE_RESTRICT steady_state = gss + ny;
+  const f64 *SDSGE_RESTRICT x0 = steady_state + n;
+  const f64 *SDSGE_RESTRICT shock = x0 + nx;
+  f64 *SDSGE_RESTRICT params = (f64 *)(shock + T * n_exog);
+  f64 *SDSGE_RESTRICT scratch = params + n_par;
   f64 *SDSGE_RESTRICT states = simout;
   f64 *SDSGE_RESTRICT observables = simout + T * n;
   f64 *SDSGE_RESTRICT x1_cur = scratch;

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -1,0 +1,37 @@
+#include "core_steps.h"
+#include "../core/core.h"
+
+void sdsge_simulate_order1_step(
+    const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+    const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT d,
+    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock, const i64 T,
+    const i64 n, const i64 k, const i64 m, f64 *SDSGE_RESTRICT simout) {
+  f64 *states = simout;
+  f64 *observables = simout + T * n;
+
+  for (i64 t = 0; t < T; ++t) {
+    const f64 *xt = t == 0 ? x0 : states + (t - 1) * n;
+    const f64 *shock_t = shock + t * k;
+    f64 *state_t = states + t * n;
+    f64 *observable_t = observables + t * m;
+
+    for (i64 i = 0; i < n; ++i) {
+      const f64 *Ai = A + i * n;
+      const f64 *Bi = B + i * k;
+      f64 value = 0.0;
+      for (i64 j = 0; j < n; ++j)
+        value += Ai[j] * xt[j];
+      for (i64 j = 0; j < k; ++j)
+        value += Bi[j] * shock_t[j];
+      state_t[i] = value;
+    }
+
+    for (i64 i = 0; i < m; ++i) {
+      const f64 *Ci = C + i * n;
+      f64 value = d[i];
+      for (i64 j = 0; j < n; ++j)
+        value += Ci[j] * state_t[j];
+      observable_t[i] = value;
+    }
+  }
+}

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -1,5 +1,30 @@
 #include "core_steps.h"
 #include "../core/core.h"
+#include <string.h>
+
+void sdsge_add_payload_step(const f64 *SDSGE_RESTRICT input, const i64 n,
+                            f64 *SDSGE_RESTRICT output) {
+  if (n > 0)
+    memcpy(output, input, (size_t)n * sizeof(f64));
+}
+
+void sdsge_raw_model_data_step(
+    const f64 *SDSGE_RESTRICT states_input, const i64 n_states,
+    const int states_batched,
+    f64 *SDSGE_RESTRICT states_output,
+    const f64 *SDSGE_RESTRICT observables_input, const i64 n_observables,
+    const int observables_batched, const i64 rep_idx,
+    f64 *SDSGE_RESTRICT observables_output) {
+  if (n_states > 0)
+    memcpy(states_output,
+           states_input + (states_batched ? rep_idx * n_states : 0),
+           (size_t)n_states * sizeof(f64));
+  if (n_observables > 0)
+    memcpy(observables_output,
+           observables_input +
+               (observables_batched ? rep_idx * n_observables : 0),
+           (size_t)n_observables * sizeof(f64));
+}
 
 i64 sdsge_simulate_order1_arena_size(const i64 n, const i64 k, const i64 T,
                                      const i64 n_par) {

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -35,3 +35,111 @@ void sdsge_simulate_order1_step(
     }
   }
 }
+
+void sdsge_simulate_order2_step(
+    const f64 *SDSGE_RESTRICT hx, const f64 *SDSGE_RESTRICT gx,
+    const f64 *SDSGE_RESTRICT bx, const f64 *SDSGE_RESTRICT hxx,
+    const f64 *SDSGE_RESTRICT gxx, const f64 *SDSGE_RESTRICT hss,
+    const f64 *SDSGE_RESTRICT gss, const f64 *SDSGE_RESTRICT steady_state,
+    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock,
+    sdsge_measurement_fn measurement, f64 *SDSGE_RESTRICT params, i64 T, i64 nx,
+    i64 ny, i64 n_exog, i64 m, f64 *SDSGE_RESTRICT simout,
+    f64 *SDSGE_RESTRICT scratch) {
+  const i64 n = nx + ny;
+  f64 *SDSGE_RESTRICT states = simout;
+  f64 *SDSGE_RESTRICT observables = simout + T * n;
+  f64 *SDSGE_RESTRICT x1_cur = scratch;
+  f64 *SDSGE_RESTRICT x1_next = scratch + nx;
+  f64 *SDSGE_RESTRICT x2_cur = scratch + 2 * nx;
+  f64 *SDSGE_RESTRICT x2_next = scratch + 3 * nx;
+  f64 *SDSGE_RESTRICT x1_outer = scratch + 4 * nx;
+
+  for (i64 i = 0; i < nx; ++i) {
+    x1_cur[i] = x0[i];
+    x2_cur[i] = 0.0;
+  }
+
+  for (i64 t = 0; t < T; ++t) {
+    for (i64 j = 0; j < nx; ++j) {
+      const f64 xj = x1_cur[j];
+      f64 *SDSGE_RESTRICT row = x1_outer + j * nx;
+      for (i64 k = 0; k < nx; ++k) {
+        row[k] = xj * x1_cur[k];
+      }
+    }
+
+    const f64 *SDSGE_RESTRICT shock_t = n_exog > 0 ? shock + t * n_exog : NULL;
+    for (i64 i = 0; i < nx; ++i) {
+      const f64 *SDSGE_RESTRICT hxi = hx + i * nx;
+      const f64 *SDSGE_RESTRICT bxi = n_exog > 0 ? bx + i * n_exog : NULL;
+      const f64 *SDSGE_RESTRICT hxxi = hxx + i * nx * nx;
+      f64 s1 = 0.0;
+      f64 s2 = 0.5 * hss[i];
+
+      for (i64 j = 0; j < nx; ++j) {
+        s1 += hxi[j] * x1_cur[j];
+        s2 += hxi[j] * x2_cur[j];
+      }
+      for (i64 j = 0; j < n_exog; ++j) {
+        s1 += bxi[j] * shock_t[j];
+      }
+      for (i64 j = 0; j < nx; ++j) {
+        const f64 *SDSGE_RESTRICT hxxij = hxxi + j * nx;
+        const f64 *SDSGE_RESTRICT outerj = x1_outer + j * nx;
+        for (i64 k = 0; k < nx; ++k) {
+          s2 += 0.5 * hxxij[k] * outerj[k];
+        }
+      }
+
+      x1_next[i] = s1;
+      x2_next[i] = s2;
+    }
+
+    f64 *tmp = x1_cur;
+    x1_cur = x1_next;
+    x1_next = tmp;
+    tmp = x2_cur;
+    x2_cur = x2_next;
+    x2_next = tmp;
+
+    f64 *SDSGE_RESTRICT state_t = states + t * n;
+    for (i64 i = 0; i < nx; ++i) {
+      state_t[i] = x1_cur[i] + x2_cur[i];
+    }
+
+    if (ny > 0) {
+      for (i64 j = 0; j < nx; ++j) {
+        const f64 xj = x1_cur[j];
+        f64 *SDSGE_RESTRICT row = x1_outer + j * nx;
+        for (i64 k = 0; k < nx; ++k) {
+          row[k] = xj * x1_cur[k];
+        }
+      }
+
+      for (i64 i = 0; i < ny; ++i) {
+        const f64 *SDSGE_RESTRICT gxi = gx + i * nx;
+        const f64 *SDSGE_RESTRICT gxxi = gxx + i * nx * nx;
+        f64 value = 0.5 * gss[i];
+
+        for (i64 j = 0; j < nx; ++j) {
+          value += gxi[j] * state_t[j];
+        }
+        for (i64 j = 0; j < nx; ++j) {
+          const f64 *SDSGE_RESTRICT gxxij = gxxi + j * nx;
+          const f64 *SDSGE_RESTRICT outerj = x1_outer + j * nx;
+          for (i64 k = 0; k < nx; ++k) {
+            value += 0.5 * gxxij[k] * outerj[k];
+          }
+        }
+        state_t[nx + i] = value;
+      }
+    }
+
+    for (i64 i = 0; i < n; ++i) {
+      state_t[i] += steady_state[i];
+    }
+    if (m > 0) {
+      measurement(state_t, params, observables + t * m);
+    }
+  }
+}

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -3,9 +3,11 @@
 #include <string.h>
 
 void sdsge_add_payload_step(const f64 *SDSGE_RESTRICT input, const i64 n,
+                            const int input_batched, const i64 rep_idx,
                             f64 *SDSGE_RESTRICT output) {
   if (n > 0)
-    memcpy(output, input, (size_t)n * sizeof(f64));
+    memcpy(output, input + (input_batched ? rep_idx * n : 0),
+           (size_t)n * sizeof(f64));
 }
 
 void sdsge_raw_model_data_step(

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -1,0 +1,8 @@
+#ifndef SDSGE_MC_CORE_STEPS
+#define SDSGE_MC_CORE_STEPS
+
+#include "../_common/sdsge_common.h"
+#include "../core/core.h"
+#include "../kalman/kalman.h"
+
+#endif /* SDSGE_MC_CORE_STEPS */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -11,4 +11,14 @@ void sdsge_simulate_order1_step(
     const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock, const i64 T,
     const i64 n, const i64 k, const i64 m, f64 *SDSGE_RESTRICT simout);
 
+void sdsge_simulate_order2_step(
+    const f64 *SDSGE_RESTRICT hx, const f64 *SDSGE_RESTRICT gx,
+    const f64 *SDSGE_RESTRICT bx, const f64 *SDSGE_RESTRICT hxx,
+    const f64 *SDSGE_RESTRICT gxx, const f64 *SDSGE_RESTRICT hss,
+    const f64 *SDSGE_RESTRICT gss, const f64 *SDSGE_RESTRICT steady_state,
+    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock,
+    sdsge_measurement_fn measurement, f64 *SDSGE_RESTRICT params, i64 T, i64 nx,
+    i64 ny, i64 n_exog, i64 m, f64 *SDSGE_RESTRICT simout,
+    f64 *SDSGE_RESTRICT scratch);
+
 #endif /* SDSGE_MC_CORE_STEPS */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -5,20 +5,23 @@
 #include "../core/core.h"
 #include "../kalman/kalman.h"
 
-void sdsge_simulate_order1_step(
-    const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
-    const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT d,
-    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock, const i64 T,
-    const i64 n, const i64 k, const i64 m, f64 *SDSGE_RESTRICT simout);
+/* ``input`` is [A(n,n), B(n,k), x0(n), shock(T,k), params(n_par)].
+ * ``simout`` is [states(T,n), observables(T,m)]. */
+i64 sdsge_simulate_order1_arena_size(i64 n, i64 k, i64 T, i64 n_par);
+void sdsge_simulate_order1_step(f64 *SDSGE_RESTRICT arena,
+                                sdsge_measurement_fn measurement, i64 T, i64 n,
+                                i64 k, i64 n_par, i64 m,
+                                f64 *SDSGE_RESTRICT simout);
 
-void sdsge_simulate_order2_step(
-    const f64 *SDSGE_RESTRICT hx, const f64 *SDSGE_RESTRICT gx,
-    const f64 *SDSGE_RESTRICT bx, const f64 *SDSGE_RESTRICT hxx,
-    const f64 *SDSGE_RESTRICT gxx, const f64 *SDSGE_RESTRICT hss,
-    const f64 *SDSGE_RESTRICT gss, const f64 *SDSGE_RESTRICT steady_state,
-    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock,
-    sdsge_measurement_fn measurement, f64 *SDSGE_RESTRICT params, i64 T, i64 nx,
-    i64 ny, i64 n_exog, i64 m, f64 *SDSGE_RESTRICT simout,
-    f64 *SDSGE_RESTRICT scratch);
+/* ``input`` is [hx(nx,nx), gx(ny,nx), bx(nx,n_exog), hxx(nx,nx,nx),
+ * gxx(ny,nx,nx), hss(nx), gss(ny), steady_state(nx+ny), x0(nx),
+ * shock(T,n_exog), params(n_par), scratch(4*nx + nx*nx)]. ``simout`` is
+ * [states(T,nx+ny), observables(T,m)]. */
+i64 sdsge_simulate_order2_arena_size(i64 n_state, i64 n_var, i64 n_exog, i64 T,
+                                     i64 n_par);
+void sdsge_simulate_order2_step(f64 *SDSGE_RESTRICT arena,
+                                sdsge_measurement_fn measurement, i64 T, i64 nx,
+                                i64 ny, i64 n_exog, i64 n_par, i64 m,
+                                f64 *SDSGE_RESTRICT simout);
 
 #endif /* SDSGE_MC_CORE_STEPS */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -24,4 +24,46 @@ void sdsge_simulate_order2_step(f64 *SDSGE_RESTRICT arena,
                                 i64 ny, i64 n_exog, i64 n_par, i64 m,
                                 f64 *SDSGE_RESTRICT simout);
 
+/* Linear filter input is [A(n,n), B(n,k), C(m,n), d(m), Q(k,k), R(m,m),
+ * y(T,m), x0(n), P0(n,n)]. Output follows FilterRawResult field order:
+ * [x_pred, x_filt, P_pred, P_filt, y_pred, y_filt, innov, std_innov, S,
+ * eps_hat (when return_shocks), loglik]. */
+i64 sdsge_filter_linear_input_arena_size(i64 n, i64 m, i64 k, i64 T);
+i64 sdsge_filter_linear_output_arena_size(i64 n, i64 m, i64 k, i64 T,
+                                           int return_shocks);
+int sdsge_filter_linear_step(const f64 *SDSGE_RESTRICT input_arena,
+                             f64 *SDSGE_RESTRICT scratch_arena, i64 T, i64 n,
+                             i64 m, i64 k, int symmetrize, f64 jitter,
+                             int return_shocks,
+                             f64 *SDSGE_RESTRICT output_arena);
+
+/* Extended filter input is [A(n,n), B(n,k), params(n_par), Q(k,k), R(m,m),
+ * y(T,m), x0(n), P0(n,n)]. Output has the linear filter layout. */
+i64 sdsge_filter_extended_input_arena_size(i64 n, i64 m, i64 k, i64 T,
+                                            i64 n_par);
+i64 sdsge_filter_extended_output_arena_size(i64 n, i64 m, i64 k, i64 T,
+                                             int return_shocks);
+int sdsge_filter_extended_step(const f64 *SDSGE_RESTRICT input_arena,
+                               f64 *SDSGE_RESTRICT scratch_arena, meas_fn meas,
+                               meas_fn jac, i64 T, i64 n, i64 m, i64 k,
+                               i64 n_par, int symmetrize, f64 jitter,
+                               int return_shocks,
+                               f64 *SDSGE_RESTRICT output_arena);
+
+/* Unscented input is [hx(ns,ns), gx(nc,ns), bx(ns,ne), hxx(ns,ns,ns),
+ * gxx(nc,ns,ns), hss(ns), gss(nc), steady_state(ns+nc), params(n_par),
+ * Q(ne,ne), R(no,no), obs(T,no), z0(2*ns), P0(2*ns,2*ns)]. Output follows
+ * UnscentedFilterRawResult field order, omitting eps_hat (always None). */
+i64 sdsge_filter_unscented_input_arena_size(i64 n_state, i64 n_ctrl,
+                                             i64 n_exog, i64 n_obs, i64 T,
+                                             i64 n_par);
+i64 sdsge_filter_unscented_output_arena_size(i64 n_state, i64 n_ctrl,
+                                              i64 n_obs, i64 T);
+i64 sdsge_filter_unscented_step(const f64 *SDSGE_RESTRICT input_arena,
+                                f64 *SDSGE_RESTRICT scratch_arena, meas_fn meas,
+                                i64 T, i64 n_state, i64 n_ctrl, i64 n_exog,
+                                i64 n_obs, i64 n_par, f64 alpha, f64 beta,
+                                f64 kappa, int symmetrize, f64 jitter,
+                                f64 *SDSGE_RESTRICT output_arena);
+
 #endif /* SDSGE_MC_CORE_STEPS */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -5,4 +5,10 @@
 #include "../core/core.h"
 #include "../kalman/kalman.h"
 
+void sdsge_simulate_order1_step(
+    const f64 *SDSGE_RESTRICT A, const f64 *SDSGE_RESTRICT B,
+    const f64 *SDSGE_RESTRICT C, const f64 *SDSGE_RESTRICT d,
+    const f64 *SDSGE_RESTRICT x0, const f64 *SDSGE_RESTRICT shock, const i64 T,
+    const i64 n, const i64 k, const i64 m, f64 *SDSGE_RESTRICT simout);
+
 #endif /* SDSGE_MC_CORE_STEPS */

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -5,8 +5,10 @@
 #include "../core/core.h"
 #include "../kalman/kalman.h"
 
-/* Static payload materialization: output[0:n] := input[0:n]. */
+/* Payload materialization. ``input_batched`` selects input[rep_idx] from a
+ * leading replication axis; otherwise the same input span is copied each time. */
 void sdsge_add_payload_step(const f64 *SDSGE_RESTRICT input, i64 n,
+                            int input_batched, i64 rep_idx,
                             f64 *SDSGE_RESTRICT output);
 
 /* Raw model-data materialization. ``*_batched`` selects input[rep_idx] from a

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -5,6 +5,21 @@
 #include "../core/core.h"
 #include "../kalman/kalman.h"
 
+/* Static payload materialization: output[0:n] := input[0:n]. */
+void sdsge_add_payload_step(const f64 *SDSGE_RESTRICT input, i64 n,
+                            f64 *SDSGE_RESTRICT output);
+
+/* Raw model-data materialization. ``*_batched`` selects input[rep_idx] from a
+ * leading replication axis; otherwise the same input span is copied each time.
+ * Either input/output pair may be NULL when its element count is zero. */
+void sdsge_raw_model_data_step(const f64 *SDSGE_RESTRICT states_input,
+                               i64 n_states, int states_batched,
+                               f64 *SDSGE_RESTRICT states_output,
+                               const f64 *SDSGE_RESTRICT observables_input,
+                               i64 n_observables, int observables_batched,
+                               i64 rep_idx,
+                               f64 *SDSGE_RESTRICT observables_output);
+
 /* ``input`` is [A(n,n), B(n,k), x0(n), shock(T,k), params(n_par)].
  * ``simout`` is [states(T,n), observables(T,m)]. */
 i64 sdsge_simulate_order1_arena_size(i64 n, i64 k, i64 T, i64 n_par);

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -213,7 +213,7 @@ class SolvedModel:
         if all(is_affine.values()):
             C, d = self._build_C_d_from_obs(y_names)
             Y = np.empty((states.shape[0] - start, len(y_names)), dtype=float64)
-            affine_observations_into(states, C, d, start, Y)
+            affine_observations_into(states, C, d, Y)
             return Y
 
         Y = self._non_affine_measurement(y_names, states)
@@ -319,7 +319,7 @@ class SolvedModel:
             int(fig_square), int(fig_square), figsize=(4 * fig_square, 3 * fig_square)
         )  # 4:3 aspect ratio
         ax = ax.flatten()
-        time = np.arange(T + 1)  # +1 for initial state
+        time = np.arange(T)
 
         # Remove unused axes
         nplots = len(transitions)
@@ -870,7 +870,7 @@ def _simulate_order1(
         shocks=shocks,
         shock_scale=shock_scale,
     )
-    X = np.empty((T + 1, model.A.shape[0]), dtype=float64)
+    X = np.empty((T, model.A.shape[0]), dtype=float64)
     simulate_linear_states_into(
         asarray(model.A, dtype=float64),
         asarray(model.B, dtype=float64),
@@ -925,7 +925,7 @@ def _simulate_order2(
         shock_mat,
     )
 
-    X = np.empty((T + 1, n), dtype=float64)
+    X = np.empty((T, n), dtype=float64)
     X[:, :n_state] = x_path + ss_state
     if ny > 0:
         X[:, n_state:] = y_path + ss[n_state:]

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -229,6 +229,7 @@ def _resolve_filter_specs(
         S=(T, n_obs, n_obs),
         innov=(T, n_obs),
         std_innov=(T, n_obs),
+        loglik=(),
     )
     match step.kwargs["filter_mode"]:
         case "linear" | "extended":

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -109,7 +109,9 @@ def _payload_shape(value: object) -> Shape:
         return array.shape[0], 1
     if array.ndim == 2:
         return tuple(int(size) for size in array.shape)
-    raise ValueError(f"Payload must be 1-D, or 2-D; got {array.ndim}-D.")
+    if array.ndim == 3:
+        return tuple(int(size) for size in array.shape[1:])
+    raise ValueError(f"Payload must be 1-D, 2-D, or 3-D; got {array.ndim}-D.")
 
 
 def _float_specs(shapes: Mapping[str, Shape]) -> dict[str, BufferSpec]:

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -177,9 +177,7 @@ def _resolve_datagen_specs(
                     "Simulation shape resolution requires its target model."
                 )
             T = int(step.kwargs["T"])
-            shapes: dict[str, Shape] = {
-                "states": (T + 1, len(model.compiled.var_names))
-            }
+            shapes: dict[str, Shape] = {"states": (T, len(model.compiled.var_names))}
             if step.kwargs["observables"]:
                 shapes["observables"] = (T, len(model.compiled.observable_names))
             return _float_specs(shapes)

--- a/SymbolicDSGE/monte_carlo/operations/core/builtins.py
+++ b/SymbolicDSGE/monte_carlo/operations/core/builtins.py
@@ -130,11 +130,17 @@ def reference_filter_step(
 
 def add_payload_step(
     name: str,
-    payload: NDF | Sequence[float] | Sequence[Sequence[float]],
+    payload: (
+        NDF
+        | Sequence[float]
+        | Sequence[Sequence[float]]
+        | Sequence[Sequence[Sequence[float]]]
+    ),
 ) -> MCStep:
-    """Add a replication-specific payload to the context.
+    """Add a payload to the context.
 
-    The ``payload`` is stored in ``context.payload[name]`` for that replication.
+    One- and two-dimensional payloads are reused across replications. A
+    three-dimensional payload is indexed on its leading replication axis.
     """
     return MCStep(
         name=name,

--- a/SymbolicDSGE/monte_carlo/operations/core/ops.py
+++ b/SymbolicDSGE/monte_carlo/operations/core/ops.py
@@ -151,11 +151,19 @@ def add_payload(
     reference: SolvedModel,
     dgp: SolvedModel | None,
     rep_idx: int,
-    value: NDF | Sequence[float] | Sequence[Sequence[float]],
+    value: (
+        NDF
+        | Sequence[float]
+        | Sequence[Sequence[float]]
+        | Sequence[Sequence[Sequence[float]]]
+    ),
 ) -> NDF:
-    del context, reference, dgp, rep_idx
+    del context, reference, dgp
 
     out = np.asarray(value, dtype=np.float64)
-    if not out.ndim in (1, 2):
-        raise ValueError(f"Payload must be 1-D, or 2-D; got {out.ndim}-D.")
+    if out.ndim not in (1, 2, 3):
+        raise ValueError(f"Payload must be 1-D, 2-D, or 3-D; got {out.ndim}-D.")
+    if out.ndim == 3:
+        rep_payload: NDF = out[rep_idx]
+        return rep_payload
     return out

--- a/SymbolicDSGE/monte_carlo/operations/core/ops.py
+++ b/SymbolicDSGE/monte_carlo/operations/core/ops.py
@@ -57,7 +57,7 @@ def simulate(
     raw["_X"] = states
     if obs_names:
         obs_full = model._simulate_observable_matrix(states, drop_initial=False)
-        obs_mat = np.ascontiguousarray(obs_full[1:], dtype=np.float64)
+        obs_mat = np.ascontiguousarray(obs_full, dtype=np.float64)
         for i, name in enumerate(obs_names):
             raw[name] = obs_full[:, i]
     return MCData(

--- a/SymbolicDSGE/utils/dhm.py
+++ b/SymbolicDSGE/utils/dhm.py
@@ -27,7 +27,7 @@ from ..core.solved_model import SolvedModel
 _DHMShock = Shock | Callable[[float | np.ndarray], np.ndarray] | np.ndarray
 _DHMShocks = Mapping[str, _DHMShock]
 
-from .._ckernels.core import residual_path
+from .._ckernels.core import residual_path, simulate_linear_states_into
 
 _GLOBAL_TRANSFORMATIONS = standard_transformations + (convert_xor,)
 _FOC_CACHE: dict[
@@ -123,7 +123,6 @@ class _PreparedMeasurementMoments:
     instrument_idx: np.ndarray
 
 
-@njit(cache=True)
 def _simulate_linear_states(
     A: np.ndarray,
     B: np.ndarray,
@@ -132,11 +131,9 @@ def _simulate_linear_states(
 ) -> np.ndarray:
     T = shock_mat.shape[0]
     n = A.shape[0]
-    X = np.zeros((T + 1, n), dtype=np.float64)
-    X[0] = x0
+    X = np.empty((T, n), dtype=np.float64)
 
-    for t in range(T):
-        X[t + 1] = A @ X[t] + B @ shock_mat[t]
+    simulate_linear_states_into(A, B, x0, shock_mat, X)
 
     return X
 
@@ -1276,7 +1273,7 @@ class DenHaanMarcet:
         return np.ascontiguousarray(moments, dtype=np.float64)
 
     def _aligned_testing_states(self, states: np.ndarray) -> np.ndarray:
-        return np.ascontiguousarray(states[1:], dtype=np.float64)
+        return np.ascontiguousarray(states, dtype=np.float64)
 
     def _validate_moment_controls(
         self,

--- a/scripts/bench_native_objective.py
+++ b/scripts/bench_native_objective.py
@@ -1,14 +1,11 @@
 """Benchmark the native estimation objective against the Python solve+filter path.
 
-Synthetic ``n_theta == 0`` case: base calibration, constant Q/R, no prior. For
-each filter mode the native ``obj_*_base`` composer runs the entire
-solve -> filter -> loglik in C behind a single Python call. The baseline is the
-equivalent Python per-evaluation work, ``solver.solve(...).kalman(...)``, which
-recomputes the solve every call just as the native objective does internally.
-Both therefore measure one full objective evaluation, so the ratio reflects the
-per-draw speedup an estimator would see (cfunc/LAPACK addresses and packed
-inputs are built once, outside the timed loop, exactly as an estimator amortizes
-them across draws).
+Each case prepares an ``Estimator`` with one calibrated parameter in theta,
+then constructs a persistent native ``NativeLogpost`` context. The benchmark
+therefore measures the repeated objective evaluation used by native estimation:
+solve -> filter -> loglik, with cfunc addresses, packed inputs, and filter
+scratch retained across evaluations. The Python baseline is the corresponding
+``Estimator.loglik(theta)`` call.
 
 The sample length T is swept on a log-grid (default 100 .. 1e6, 10 whole-number
 steps). The filter is O(T) while the solve is O(n^3) and T-independent, so the
@@ -53,14 +50,10 @@ POST82 = FIXTURES / "POST82.yaml"
 RBC = FIXTURES / "rbc_second_order.yaml"
 
 from SymbolicDSGE import DSGESolver, ModelParser  # noqa: E402
-from SymbolicDSGE.estimation import backend  # noqa: E402
+from SymbolicDSGE.estimation import Estimator, backend  # noqa: E402
 from SymbolicDSGE.kalman.config import KalmanConfig  # noqa: E402
 from SymbolicDSGE.kalman.interface import FilterMode, _resolve_P0  # noqa: E402
-from SymbolicDSGE._ckernels.estimation._estimation import (  # noqa: E402
-    obj_extended_base,
-    obj_linear_base,
-    obj_unscented_base,
-)
+from SymbolicDSGE._ckernels.estimation._estimation import NativeLogpost  # noqa: E402
 
 _cc = np.ascontiguousarray
 _POST82_MODES = ("linear", "extended")
@@ -140,55 +133,34 @@ def _post82_y(ctx: Post82Ctx, T: int) -> pd.DataFrame:
         )
         ctx.y_cache[T] = pd.DataFrame(
             {
-                "OutGap": sim["OutGap"][1:],
-                "Infl": sim["Infl"][1:],
-                "Rate": sim["Rate"][1:],
+                "OutGap": sim["OutGap"],
+                "Infl": sim["Infl"],
+                "Rate": sim["Rate"],
             }
         )
     return ctx.y_cache[T]
 
 
 def _post82_case(ctx: Post82Ctx, mode: str, T: int) -> Case:
-    composer = obj_linear_base if mode == "linear" else obj_extended_base
     y = _post82_y(ctx, T)
-    base = backend.extract_base_params(ctx.compiled)
-    prep = backend.prepare_filter_run(
+    estimator = Estimator(
+        solver=ctx.solver,
         compiled=ctx.compiled,
-        kalman=ctx.kalman,
         y=y,
         observables=ctx.obs,
         filter_mode=mode,
-        jitter=None,
-        symmetrize=None,
+        estimated_params=["beta"],
+        ss_seed=ctx.steady,
     )
-    R = _cc(
-        backend.build_R(ctx.compiled, ctx.kalman, prep.observables, base),
-        dtype=np.float64,
-    )
-    args = (
-        ctx.residual_addr,
-        prep.meas_addr,
-        prep.jac_addr,
-        ctx.compiled.n_state,
-        ctx.compiled.n_exog,
-        len(prep.observables),
-        0,
-        _cc(ctx.steady, dtype=np.float64),
-        ctx.calib,
-        ctx.Q,
-        R,
-        _cc(prep.y_reordered, dtype=np.float64),
-        _cc(prep.P0, dtype=np.float64),
-        float(prep.kf_jitter),
-        int(prep.kf_sym),
-    )
+    theta = estimator.resolve_theta0(None)
+    native_ctx, native_mode = estimator._build_native_context()
+    native_objective = NativeLogpost(native_ctx, native_mode)
 
-    def native(_c=composer, _a=args) -> float:
-        return _c(*_a)[0]
+    def native(_objective=native_objective, _theta=theta) -> float:
+        return _objective.loglik(_theta)
 
-    def python(_m=mode, _y=y) -> float:
-        solved_i = ctx.solver.solve(compiled=ctx.compiled, ss_seed=ctx.steady)
-        return float(solved_i.kalman(y=_y, filter_mode=_m, observables=ctx.obs).loglik)
+    def python(_estimator=estimator, _theta=theta) -> float:
+        return float(_estimator.loglik(_theta))
 
     return Case(mode, T, native, python, native(), python())
 
@@ -252,39 +224,29 @@ def _rbc_case(ctx: RbcCtx, T: int) -> Case:
         x0=np.asarray(ctx.solved.policy.steady_state, dtype=np.float64),
         observables=True,
     )
-    y = pd.DataFrame({"c_obs": sim["c_obs"][1:]})
-    y_c = np.array(y.to_numpy(), dtype=np.float64, copy=True)
-    args = (
-        ctx.residual_addr,
-        ctx.bc_addr,
-        ctx.meas_addr,
-        ctx.compiled.n_state,
-        ctx.compiled.n_exog,
-        len(ctx.obs),
-        _cc(ctx.seed, dtype=np.float64),
-        ctx.calib,
-        ctx.Q,
-        ctx.R,
-        y_c,
-        ctx.P0_ukf,
-        float(ctx.jitter),
-        int(ctx.sym),
+    y = pd.DataFrame({"c_obs": sim["c_obs"]})
+    estimator = Estimator(
+        solver=ctx.solver,
+        compiled=ctx.compiled,
+        y=y,
+        observables=ctx.obs,
+        filter_mode="unscented",
+        estimated_params=["beta"],
+        ss_seed=ctx.seed,
+        jitter=ctx.jitter,
+        symmetrize=bool(ctx.sym),
+        R=ctx.R,
+        P0=np.eye(ctx.compiled.n_state, dtype=np.float64) * 0.1,
     )
+    theta = estimator.resolve_theta0(None)
+    native_ctx, native_mode = estimator._build_native_context()
+    native_objective = NativeLogpost(native_ctx, native_mode)
 
-    def native(_a=args) -> float:
-        return obj_unscented_base(*_a)[0]
+    def native(_objective=native_objective, _theta=theta) -> float:
+        return _objective.loglik(_theta)
 
-    def python(_y=y) -> float:
-        solved_i = ctx.solver.solve(compiled=ctx.compiled, ss_seed=ctx.seed, order=2)
-        return float(
-            solved_i.kalman(
-                y=_y,
-                filter_mode="unscented",
-                observables=ctx.obs,
-                jitter=ctx.jitter,
-                symmetrize=bool(ctx.sym),
-            ).loglik
-        )
+    def python(_estimator=estimator, _theta=theta) -> float:
+        return float(_estimator.loglik(_theta))
 
     return Case("unscented", T, native, python, native(), python())
 

--- a/tests/_oracles/core.py
+++ b/tests/_oracles/core.py
@@ -33,17 +33,14 @@ def _simulate_linear_states_into_numba(
     n = A.shape[0]
     k = B.shape[1]
 
-    for i in range(n):
-        out[0, i] = x0[i]
-
     for t in range(T):
         for i in range(n):
             s = 0.0
             for j in range(n):
-                s += A[i, j] * out[t, j]
+                s += A[i, j] * (x0[j] if t == 0 else out[t - 1, j])
             for j in range(k):
                 s += B[i, j] * shock_mat[t, j]
-            out[t + 1, i] = s
+            out[t, i] = s
 
 
 @njit(cache=True)
@@ -51,7 +48,6 @@ def _affine_observations_into_numba(
     states: NDF,
     C: NDF,
     d: NDF,
-    state_start: int,
     out: NDF,
 ) -> None:
     T = out.shape[0]
@@ -59,11 +55,10 @@ def _affine_observations_into_numba(
     n = C.shape[1]
 
     for t in range(T):
-        state_row = state_start + t
         for i in range(m):
             s = d[i]
             for j in range(n):
-                s += C[i, j] * states[state_row, j]
+                s += C[i, j] * states[t, j]
             out[t, i] = s
 
 
@@ -84,8 +79,8 @@ def _simulate_second_order_pruned_numba(
     ny = gx.shape[0]
     n_exog = bx.shape[1]
 
-    x_out = np.empty((T + 1, nx), dtype=np.float64)
-    y_out = np.empty((T + 1, ny), dtype=np.float64)
+    x_out = np.empty((T, nx), dtype=np.float64)
+    y_out = np.empty((T, ny), dtype=np.float64)
     x1_cur = np.empty(nx, dtype=np.float64)
     x1_next = np.empty(nx, dtype=np.float64)
     x2_cur = np.empty(nx, dtype=np.float64)
@@ -96,25 +91,10 @@ def _simulate_second_order_pruned_numba(
         x1_cur[i] = x0[i]
         x2_cur[i] = 0.0
 
-    for t in range(T + 1):
-        for i in range(nx):
-            x_out[t, i] = x1_cur[i] + x2_cur[i]
-
+    for t in range(T):
         for j in range(nx):
             for k in range(nx):
                 x1_outer[j, k] = x1_cur[j] * x1_cur[k]
-
-        for i in range(ny):
-            s = 0.5 * gss[i]
-            for j in range(nx):
-                s += gx[i, j] * x_out[t, j]
-            for j in range(nx):
-                for k in range(nx):
-                    s += 0.5 * gxx[i, j, k] * x1_outer[j, k]
-            y_out[t, i] = s
-
-        if t == T:
-            break
 
         for i in range(nx):
             s1 = 0.0
@@ -133,6 +113,22 @@ def _simulate_second_order_pruned_numba(
         for i in range(nx):
             x1_cur[i] = x1_next[i]
             x2_cur[i] = x2_next[i]
+
+        for i in range(nx):
+            x_out[t, i] = x1_cur[i] + x2_cur[i]
+
+        for j in range(nx):
+            for k in range(nx):
+                x1_outer[j, k] = x1_cur[j] * x1_cur[k]
+
+        for i in range(ny):
+            s = 0.5 * gss[i]
+            for j in range(nx):
+                s += gx[i, j] * x_out[t, j]
+            for j in range(nx):
+                for k in range(nx):
+                    s += 0.5 * gxx[i, j, k] * x1_outer[j, k]
+            y_out[t, i] = s
 
     return x_out, y_out
 

--- a/tests/bundle/test_roundtrip.py
+++ b/tests/bundle/test_roundtrip.py
@@ -89,7 +89,7 @@ def test_full_bundle_round_trip(tmp_path: Path) -> None:
     assert isinstance(loaded.reference, SolvedModel)
     assert loaded.dgp is None
     sim = loaded.reference.sim(8)
-    assert sim["_X"].shape[0] == 9
+    assert sim["_X"].shape[0] == 8
 
     # estimation
     assert loaded.estimation is not None

--- a/tests/bundle/test_user_api.py
+++ b/tests/bundle/test_user_api.py
@@ -62,7 +62,7 @@ def test_save_sdsge_round_trips_via_load_bundle(tmp_path: Path) -> None:
     assert isinstance(loaded, LoadedBundle)
     assert loaded.reference is not None
     # Re-solved model is usable.
-    assert loaded.reference.sim(5)["_X"].shape[0] == 6
+    assert loaded.reference.sim(5)["_X"].shape[0] == 5
 
 
 def test_to_bundle_builder_returns_chainable_builder(tmp_path: Path) -> None:

--- a/tests/ckernels/test_core.py
+++ b/tests/ckernels/test_core.py
@@ -29,25 +29,25 @@ def test_simulate_matches_numba(n: int, k: int, T: int) -> None:
     x0 = np.ascontiguousarray(rng.standard_normal(n))
     shock = np.ascontiguousarray(rng.standard_normal((T, k)))
 
-    native = np.empty((T + 1, n))
-    ref = np.empty((T + 1, n))
+    native = np.empty((T, n))
+    ref = np.empty((T, n))
     core.simulate_linear_states_into(A, B, x0, shock, native)
     _simulate_linear_states_into_numba(A, B, x0, shock, ref)
 
     np.testing.assert_allclose(native, ref, rtol=_RTOL, atol=_ATOL)
 
 
-@pytest.mark.parametrize("m, n, T, start", [(1, 2, 1, 0), (3, 4, 20, 0), (2, 5, 12, 3)])
-def test_affine_matches_numba(m: int, n: int, T: int, start: int) -> None:
-    rng = np.random.default_rng(m * 1000 + n * 100 + T * 10 + start)
-    states = np.ascontiguousarray(rng.standard_normal((start + T, n)))
+@pytest.mark.parametrize("m, n, T", [(1, 2, 1), (3, 4, 20), (2, 5, 12)])
+def test_affine_matches_numba(m: int, n: int, T: int) -> None:
+    rng = np.random.default_rng(m * 1000 + n * 100 + T * 10)
+    states = np.ascontiguousarray(rng.standard_normal((T, n)))
     C = np.ascontiguousarray(rng.standard_normal((m, n)))
     d = np.ascontiguousarray(rng.standard_normal(m))
 
     native = np.empty((T, m))
     ref = np.empty((T, m))
-    core.affine_observations_into(states, C, d, start, native)
-    _affine_observations_into_numba(states, C, d, start, ref)
+    core.affine_observations_into(states, C, d, native)
+    _affine_observations_into_numba(states, C, d, ref)
 
     np.testing.assert_allclose(native, ref, rtol=_RTOL, atol=_ATOL)
 
@@ -82,14 +82,14 @@ def test_second_order_pruned_matches_numba(
 
 
 def test_simulate_known_answer() -> None:
-    # n=1, k=1: A=2, B=1, x0=1, shock=[0.5, 0.5] -> out = [1, 2.5, 5.5].
+    # n=1, k=1: A=2, B=1, x0=1, shock=[0.5, 0.5] -> out = [2.5, 5.5].
     A = np.array([[2.0]])
     B = np.array([[1.0]])
     x0 = np.array([1.0])
     shock = np.array([[0.5], [0.5]])
-    out = np.empty((3, 1))
+    out = np.empty((2, 1))
     core.simulate_linear_states_into(A, B, x0, shock, out)
-    np.testing.assert_allclose(out.ravel(), [1.0, 2.5, 5.5])
+    np.testing.assert_allclose(out.ravel(), [2.5, 5.5])
 
 
 def test_affine_known_answer() -> None:
@@ -98,5 +98,5 @@ def test_affine_known_answer() -> None:
     C = np.array([[1.0, 2.0]])
     d = np.array([3.0])
     out = np.empty((2, 1))
-    core.affine_observations_into(states, C, d, 0, out)
+    core.affine_observations_into(states, C, d, out)
     np.testing.assert_allclose(out.ravel(), [6.0, 9.0])

--- a/tests/core/test_second_order.py
+++ b/tests/core/test_second_order.py
@@ -313,7 +313,7 @@ def test_rbc_second_order_deterministic_sim_matches_dynare():
 
     np.testing.assert_allclose(
         out,
-        _DYNARE_DETERMINISTIC_SIM,
+        _DYNARE_DETERMINISTIC_SIM[1:],
         rtol=2e-6,
         atol=2e-6,
     )
@@ -330,7 +330,7 @@ def test_rbc_second_order_stochastic_sim_matches_dynare():
 
     np.testing.assert_allclose(
         out,
-        _DYNARE_STOCHASTIC_SIM,
+        _DYNARE_STOCHASTIC_SIM[1:],
         rtol=2e-6,
         atol=2e-6,
     )
@@ -341,4 +341,4 @@ def test_rbc_second_order_irf_matches_dynare():
 
     out = solved.irf(["z"], T=_DYNARE_IRF.shape[0] - 1)["_X"]
 
-    np.testing.assert_allclose(out, _DYNARE_IRF, rtol=2e-6, atol=2e-6)
+    np.testing.assert_allclose(out, _DYNARE_IRF[1:], rtol=2e-6, atol=2e-6)

--- a/tests/core/test_solved_model.py
+++ b/tests/core/test_solved_model.py
@@ -131,10 +131,18 @@ def _make_second_order_test_model() -> tuple[solved_model_module.SolvedModel, di
 
 def _manual_second_order_path(data, shock, x0_state) -> np.ndarray:
     T = shock.shape[0]
-    expected = np.empty((T + 1, 3), dtype=np.float64)
+    expected = np.empty((T, 3), dtype=np.float64)
     x1 = x0_state.copy()
     x2 = np.zeros(2, dtype=np.float64)
-    for t in range(T + 1):
+    for t in range(T):
+        outer = np.outer(x1, x1)
+        x1_next = data["hx"] @ x1 + data["bx"][:, 0] * shock[t]
+        x2_next = (
+            data["hx"] @ x2
+            + 0.5 * np.einsum("ijk,jk->i", data["hxx"], outer)
+            + 0.5 * data["hss"]
+        )
+        x1, x2 = x1_next, x2_next
         state = x1 + x2
         outer = np.outer(x1, x1)
         expected[t, :2] = state
@@ -143,15 +151,6 @@ def _manual_second_order_path(data, shock, x0_state) -> np.ndarray:
             + 0.5 * np.sum(data["gxx"][0] * outer)
             + 0.5 * data["gss"][0]
         )
-        if t == T:
-            break
-        x1_next = data["hx"] @ x1 + data["bx"][:, 0] * shock[t]
-        x2_next = (
-            data["hx"] @ x2
-            + 0.5 * np.einsum("ijk,jk->i", data["hxx"], outer)
-            + 0.5 * data["hss"]
-        )
-        x1, x2 = x1_next, x2_next
     return expected
 
 
@@ -160,10 +159,10 @@ def test_solved_model_sim_shapes_and_keys(solved_test):
     out = solved_test.sim(T)
 
     assert "_X" in out
-    assert out["_X"].shape == (T + 1, solved_test.A.shape[0])
+    assert out["_X"].shape == (T, solved_test.A.shape[0])
     for name in solved_test.compiled.var_names:
         assert name in out
-        assert out[name].shape == (T + 1,)
+        assert out[name].shape == (T,)
 
 
 def test_linear_simulation_kernel_writes_manual_recursion() -> None:
@@ -174,21 +173,22 @@ def test_linear_simulation_kernel_writes_manual_recursion() -> None:
         [[0.5, 1.0], [-1.0, 0.0], [0.25, -0.5]],
         dtype=np.float64,
     )
-    out = np.empty((shock_mat.shape[0] + 1, A.shape[0]), dtype=np.float64)
+    out = np.empty((shock_mat.shape[0], A.shape[0]), dtype=np.float64)
     py_out = np.empty_like(out)
 
     simulate_linear_states_into(A, B, x0, shock_mat, out)
     _simulate_linear_states_into_numba.py_func(A, B, x0, shock_mat, py_out)
 
     expected = np.empty_like(out)
-    expected[0] = x0
+    previous = x0
     for t in range(shock_mat.shape[0]):
-        expected[t + 1] = A @ expected[t] + B @ shock_mat[t]
+        expected[t] = A @ previous + B @ shock_mat[t]
+        previous = expected[t]
     np.testing.assert_allclose(out, expected)
     np.testing.assert_allclose(py_out, expected)
 
 
-def test_affine_observation_kernel_writes_with_state_offset() -> None:
+def test_affine_observation_kernel_writes_all_states() -> None:
     states = np.array(
         [
             [1.0, 2.0],
@@ -199,14 +199,14 @@ def test_affine_observation_kernel_writes_with_state_offset() -> None:
     )
     C = np.array([[2.0, -0.5], [0.0, 1.5]], dtype=np.float64)
     d = np.array([1.0, -2.0], dtype=np.float64)
-    out = np.empty((2, 2), dtype=np.float64)
+    out = np.empty((3, 2), dtype=np.float64)
     py_out = np.empty_like(out)
 
-    affine_observations_into(states, C, d, 1, out)
-    _affine_observations_into_numba.py_func(states, C, d, 1, py_out)
+    affine_observations_into(states, C, d, out)
+    _affine_observations_into_numba.py_func(states, C, d, py_out)
 
-    np.testing.assert_allclose(out, states[1:] @ C.T + d)
-    np.testing.assert_allclose(py_out, states[1:] @ C.T + d)
+    np.testing.assert_allclose(out, states @ C.T + d)
+    np.testing.assert_allclose(py_out, states @ C.T + d)
 
 
 def test_solved_model_sim_matches_manual_state_recursion(solved_test):
@@ -224,9 +224,10 @@ def test_solved_model_sim_matches_manual_state_recursion(solved_test):
         shock_scale=0.5,
     )
     expected = np.empty_like(out["_X"])
-    expected[0] = solved_test._simulation_initial_state(None)
+    previous = solved_test._simulation_initial_state(None)
     for t in range(T):
-        expected[t + 1] = solved_test.A @ expected[t] + solved_test.B @ shock_mat[t]
+        expected[t] = solved_test.A @ previous + solved_test.B @ shock_mat[t]
+        previous = expected[t]
     np.testing.assert_allclose(out["_X"], expected)
 
 
@@ -257,7 +258,7 @@ def test_solved_model_second_order_irf_subtracts_pruned_baseline() -> None:
     ) - _manual_second_order_path(data, zero, np.zeros(2, dtype=np.float64))
 
     np.testing.assert_allclose(out, expected)
-    np.testing.assert_allclose(out[0], np.zeros(3, dtype=np.float64))
+    assert out.shape == (T, 3)
 
 
 def test_solved_model_sim_rejects_wrong_shock_length(solved_test):
@@ -269,7 +270,7 @@ def test_solved_model_sim_with_observables_includes_measurements(solved_test):
     out = solved_test.sim(10, observables=True)
     for obs in solved_test.compiled.observable_names:
         assert obs in out
-        assert out[obs].shape == (11,)
+        assert out[obs].shape == (10,)
 
 
 def test_solved_model_affine_observables_can_drop_initial_row(solved_test):
@@ -311,7 +312,7 @@ def test_solved_model_sim_uses_non_affine_measurement_branch(monkeypatch):
 
     out = solved.sim(3, observables=True)
 
-    assert np.array_equal(out["Obs"], np.array([0.0, 1.0, 2.0, 3.0]))
+    assert np.array_equal(out["Obs"], np.array([0.0, 1.0, 2.0]))
 
 
 def test_solved_model_irf_validation_errors(solved_test):
@@ -323,7 +324,7 @@ def test_solved_model_irf_validation_errors(solved_test):
 
 def test_solved_model_irf_runs_for_exogenous_shock(solved_test):
     out = solved_test.irf(shocks=["u"], T=8, observables=True)
-    assert out["u"].shape == (9,)
+    assert out["u"].shape == (8,)
     assert "_X" in out
     assert "Infl" in out and "Rate" in out
 
@@ -333,10 +334,10 @@ def test_solved_model_transition_plot_renders_observables_and_shocks(
 ):
     def fake_irf(self, shocks, T, scale=1.0, observables=False):
         return {
-            "_X": np.zeros((T + 1, 3), dtype=np.float64),
-            "Infl": np.linspace(0.0, 1.0, T + 1),
-            "u": np.linspace(1.0, 0.0, T + 1),
-            "x": np.linspace(-1.0, 0.0, T + 1),
+            "_X": np.zeros((T, 3), dtype=np.float64),
+            "Infl": np.linspace(0.0, 1.0, T),
+            "u": np.linspace(1.0, 0.0, T),
+            "x": np.linspace(-1.0, 0.0, T),
         }
 
     monkeypatch.setattr(solved_model_module.SolvedModel, "irf", fake_irf)
@@ -460,7 +461,7 @@ def test_solved_model_shock_unpack_rejects_variable_in_two_entries(solved_test):
 
 def test_solved_model_kalman_smoke(solved_post82):
     sim = solved_post82.sim(20, observables=True)
-    y = pd.DataFrame({"Infl": sim["Infl"][1:], "Rate": sim["Rate"][1:]})
+    y = pd.DataFrame({"Infl": sim["Infl"], "Rate": sim["Rate"]})
 
     out = solved_post82.kalman(y, observables=["Infl", "Rate"])
     assert out is not None

--- a/tests/estimation/conftest.py
+++ b/tests/estimation/conftest.py
@@ -51,7 +51,7 @@ def post82(post82_test_model_path):
         observables=True,
     )
     y = pd.DataFrame(
-        {"OutGap": sim["OutGap"][1:], "Infl": sim["Infl"][1:], "Rate": sim["Rate"][1:]}
+        {"OutGap": sim["OutGap"], "Infl": sim["Infl"], "Rate": sim["Rate"]}
     )
     return {
         "solver": solver,

--- a/tests/estimation/test_estimator_lkj_integration.py
+++ b/tests/estimation/test_estimator_lkj_integration.py
@@ -39,9 +39,9 @@ def dense_lkj_bundle(dense_lkj_test_model_path):
     )
     y = pd.DataFrame(
         {
-            "OutGap": sim["OutGap"][1:],
-            "Infl": sim["Infl"][1:],
-            "Rate": sim["Rate"][1:],
+            "OutGap": sim["OutGap"],
+            "Infl": sim["Infl"],
+            "Rate": sim["Rate"],
         }
     )
     return {

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -107,7 +107,7 @@ class _FakeSolvedModel:
     ):
         del shock_scale, x0
         self._draw_shocks(shocks)
-        t = np.arange(T + 1, dtype=np.float64)
+        t = np.arange(1, T + 1, dtype=np.float64)
         return np.column_stack(
             [
                 t + self.offset,
@@ -1084,14 +1084,15 @@ def test_simulate_dgp_fast_path_for_real_solved_model() -> None:
         observables=True,
     )
 
-    expected_states = np.empty((T + 1, 2), dtype=np.float64)
-    expected_states[0] = 0.0
+    expected_states = np.empty((T, 2), dtype=np.float64)
+    previous = np.zeros(2, dtype=np.float64)
     for t in range(T):
-        expected_states[t + 1] = A @ expected_states[t] + B[:, 0] * shock[t]
+        expected_states[t] = A @ previous + B[:, 0] * shock[t]
+        previous = expected_states[t]
     expected_obs = expected_states @ C.T + d
 
     np.testing.assert_allclose(data.states, expected_states)
-    np.testing.assert_allclose(data.observables, expected_obs[1:])
+    np.testing.assert_allclose(data.observables, expected_obs)
     np.testing.assert_allclose(data.raw["_X"], expected_states)
     np.testing.assert_allclose(data.raw["u"], expected_states[:, 0])
     np.testing.assert_allclose(data.raw["obs"], expected_obs[:, 0])

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -552,16 +552,20 @@ def test_add_payload_step_registers_2d_payload_with_column_selection() -> None:
     )
 
 
-def test_add_payload_step_rejects_non_matrix_payloads() -> None:
+def test_add_payload_step_selects_batched_payload_by_replication() -> None:
+    payload = np.arange(12.0, dtype=np.float64).reshape(2, 3, 2)
     pipeline = MCPipeline(
         [
-            raw_model_data_step(observables=np.zeros((2, 1))),
-            add_payload_step("cube", np.zeros((1, 2, 3), dtype=np.float64)),
+            raw_model_data_step(observables=np.zeros((3, 1))),
+            add_payload_step("cube", payload),
         ]
     )
 
-    with pytest.raises(ValueError, match="Payload must be 1-D, or 2-D"):
-        pipeline.run(reference=_FakeSolvedModel(), n_rep=1)
+    out = pipeline.run(reference=_FakeSolvedModel(), n_rep=2)
+
+    assert out.payloads is not None
+    np.testing.assert_allclose(out.payloads[0]["cube"], payload[0])
+    np.testing.assert_allclose(out.payloads[1]["cube"], payload[1])
 
 
 def test_breusch_pagan_pipeline_validates_residual_and_regressor_inputs() -> None:

--- a/tests/monte_carlo/test_pipeline.py
+++ b/tests/monte_carlo/test_pipeline.py
@@ -1214,7 +1214,10 @@ def test_output_specs_for_non_ols_regressions(kind: str) -> None:
     }
 
 
-def test_output_shape_resolution_includes_linear_filter_fields() -> None:
+@pytest.mark.parametrize("filter_mode", ("linear", "extended"))
+def test_output_shape_resolution_includes_linear_filter_fields(
+    filter_mode: str,
+) -> None:
     reference = _FakeSolvedModel()
     reference.compiled.observable_names = ["a", "b", "c"]
     observables = np.zeros((2, 8, 3), dtype=np.float64)
@@ -1225,6 +1228,7 @@ def test_output_shape_resolution_includes_linear_filter_fields() -> None:
                 observable_names=("a", "b", "c"),
             ),
             reference_filter_step(
+                filter_mode=filter_mode,
                 observables=["a", "c"],
                 return_shocks=True,
             ),
@@ -1244,6 +1248,7 @@ def test_output_shape_resolution_includes_linear_filter_fields() -> None:
         "std_innov": BufferSpec((8, 2), np.float64),
         "S": BufferSpec((8, 2, 2), np.float64),
         "eps_hat": BufferSpec((8, 1), np.float64),
+        "loglik": BufferSpec((), np.float64),
     }
 
 
@@ -1327,6 +1332,7 @@ def test_output_shape_resolution_includes_unscented_filter_fields(
         "x1_filt": BufferSpec((T, n_state), np.float64),
         "x2_pred": BufferSpec((T, n_state), np.float64),
         "x2_filt": BufferSpec((T, n_state), np.float64),
+        "loglik": BufferSpec((), np.float64),
     }
 
 

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -87,7 +87,7 @@ def test_ui_backend_loads_solves_and_simulates_model() -> None:
 
     x_series = next(series for series in sim_body["series"] if series["name"] == "_X")
     x_arr = decode_array(ArrayEnvelope.model_validate(x_series["array"]))
-    assert x_arr.shape == (6, solved_body["A_shape"][0])
+    assert x_arr.shape == (5, solved_body["A_shape"][0])
 
     fetched = client.get(f"/api/run/{sim_body['run_id']}")
     assert fetched.status_code == 200
@@ -652,7 +652,7 @@ def test_ui_backend_runs_jarque_bera_monte_carlo_step() -> None:
     assert set(body["test_summaries"]) == {"normality"}
     summary = body["test_summaries"]["normality"]
     assert summary["distribution"] == "jb_lookup"
-    assert summary["df"] == 12
+    assert summary["df"] == 11
     assert summary["n"] == 2
 
 

--- a/tests/utils/test_dhm.py
+++ b/tests/utils/test_dhm.py
@@ -49,7 +49,7 @@ def test_den_haan_marcet_one_sample_matches_sim_state_path(solved_test):
         use_conditional_expectation=False,
     )
 
-    assert np.allclose(out.states, expected[1:])
+    assert np.allclose(out.states, expected)
     assert np.allclose(
         out.shock_matrix[:, solved_test.compiled.idx["u"]],
         np.full((T,), 0.50, dtype=np.float64),
@@ -58,9 +58,9 @@ def test_den_haan_marcet_one_sample_matches_sim_state_path(solved_test):
         out.shock_matrix[:, solved_test.compiled.idx["v"]],
         shocks["v"],
     )
-    assert out.moments.shape == (T - 1, 6)
-    assert out.residuals.shape == (T - 1, 2)
-    assert out.instruments.shape == (T - 1, 3)
+    assert out.moments.shape == (T - 2, 6)
+    assert out.residuals.shape == (T - 2, 2)
+    assert out.instruments.shape == (T - 2, 3)
     assert out.variables == list(solved_test.compiled.var_names)
     assert np.allclose(out.raw_residuals, out.residuals)
     assert np.isfinite(out.statistic)
@@ -109,7 +109,7 @@ def test_den_haan_marcet_one_sample_uses_canonical_multivar_covariance(solved_po
     )
 
     assert np.allclose(captured["cov"], expected_cov)
-    assert np.allclose(out.states, expected[1:])
+    assert np.allclose(out.states, expected)
     assert np.allclose(
         out.shock_matrix[:, solved_post82.compiled.idx["g"]],
         expected_cov[0, 0],
@@ -188,8 +188,8 @@ def test_den_haan_marcet_conditional_expectation_uses_projected_forward_states(
         dtype=np.complex128,
     )
     objective = solved_test.compiled.equations
-    manual = np.empty((T, 1), dtype=np.float64)
-    for t in range(T):
+    manual = np.empty((T - 1, 1), dtype=np.float64)
+    for t in range(T - 1):
         manual[t, 0] = objective(
             projected_forward[t].astype(np.complex128),
             current_states[t].astype(np.complex128),
@@ -213,8 +213,8 @@ def test_measurement_moment_test_single_observable_matches_manual_construction(
     dhm = DenHaanMarcet(solved_test)
     obs_name = solved_test.compiled.observable_names[0]
     sim = solved_test.sim(T, shocks=shocks, observables=True)
-    aligned_states = sim["_X"][1:]
-    predicted_full = sim[obs_name][1:]
+    aligned_states = sim["_X"]
+    predicted_full = sim[obs_name]
     offset = np.linspace(0.10, -0.05, T, dtype=np.float64)
     y = predicted_full + offset
 
@@ -278,7 +278,7 @@ def test_measurement_moment_test_list_returns_canonical_results(solved_test):
         )
         for idx, name in enumerate(requested)
     }
-    y = np.column_stack([sim[name][1:] + offsets[name] for name in requested])
+    y = np.column_stack([sim[name] + offsets[name] for name in requested])
 
     out = dhm.measurement_moment_test(
         y,
@@ -299,7 +299,7 @@ def test_measurement_moment_test_list_returns_canonical_results(solved_test):
         obs_name = result.observables[0]
         assert np.allclose(
             result.observed,
-            sim[obs_name][1:] + offsets[obs_name],
+            sim[obs_name] + offsets[obs_name],
         )
 
 
@@ -315,7 +315,7 @@ def test_joint_measurement_moment_test_stacks_moments_and_uses_all_observables(
     dhm = DenHaanMarcet(solved_test)
     sim = solved_test.sim(T, shocks=shocks, observables=True)
     y = {
-        obs: sim[obs][1:] + np.linspace(0.02 * (idx + 1), -0.01, T, dtype=np.float64)
+        obs: sim[obs] + np.linspace(0.02 * (idx + 1), -0.01, T, dtype=np.float64)
         for idx, obs in enumerate(solved_test.compiled.observable_names)
     }
 
@@ -356,7 +356,7 @@ def test_measurement_moment_test_from_state_path_matches_simulation_path(
     dhm = DenHaanMarcet(solved_test)
     obs_name = solved_test.compiled.observable_names[0]
     sim = solved_test.sim(T, shocks=shocks, observables=True)
-    y = sim[obs_name][1:] + np.linspace(0.03, -0.02, T, dtype=np.float64)
+    y = sim[obs_name] + np.linspace(0.03, -0.02, T, dtype=np.float64)
 
     sim_out = dhm.measurement_moment_test(
         y,
@@ -396,7 +396,7 @@ def test_measurement_moment_test_accepts_shock_specs(solved_test):
         "v": Shock(dist="norm", seed=4),
     }
     sim = solved_test.sim(T, shocks=shock_specs, observables=True)
-    y = sim[obs_name][1:] + np.linspace(0.03, -0.02, T, dtype=np.float64)
+    y = sim[obs_name] + np.linspace(0.03, -0.02, T, dtype=np.float64)
 
     direct = dhm.measurement_moment_test(
         y,
@@ -441,8 +441,8 @@ def test_measurement_moment_test_supports_lagged_instruments(solved_test):
     dhm = DenHaanMarcet(solved_test)
     obs_name = solved_test.compiled.observable_names[0]
     sim = solved_test.sim(T, shocks=shocks, observables=True)
-    aligned_states = sim["_X"][1:]
-    predicted = sim[obs_name][1:]
+    aligned_states = sim["_X"]
+    predicted = sim[obs_name]
     y = predicted + np.linspace(0.01, 0.09, T, dtype=np.float64)
 
     out = dhm.measurement_moment_test_from_state_path(
@@ -477,7 +477,7 @@ def test_measurement_moment_test_allows_measurement_override(solved_test):
     dhm = DenHaanMarcet(solved_test)
     obs_name = solved_test.compiled.observable_names[0]
     sim = solved_test.sim(T)
-    aligned_states = sim["_X"][1:]
+    aligned_states = sim["_X"]
     idx_pi = solved_test.compiled.idx["Pi"]
     beta = float(
         solved_test.compiled.config.calibration.parameters[
@@ -514,7 +514,7 @@ def test_measurement_moment_test_raises_when_adjusted_df_is_not_positive(
     dhm = DenHaanMarcet(solved_test)
     obs_name = solved_test.compiled.observable_names[0]
     sim = solved_test.sim(T, observables=True)
-    y = sim[obs_name][1:]
+    y = sim[obs_name]
 
     with pytest.raises(ValueError, match="requires more moment conditions"):
         dhm.measurement_moment_test(
@@ -527,7 +527,7 @@ def test_measurement_moment_test_raises_when_adjusted_df_is_not_positive(
 
     with pytest.raises(ValueError, match="requires more moment conditions"):
         dhm.joint_measurement_moment_test(
-            {obs: sim[obs][1:] for obs in solved_test.compiled.observable_names},
+            {obs: sim[obs] for obs in solved_test.compiled.observable_names},
             instrument_idx=["u"],
             include_constant=False,
             n_estimated_params=len(solved_test.compiled.observable_names),

--- a/tests/utils/test_dhm_internal.py
+++ b/tests/utils/test_dhm_internal.py
@@ -50,7 +50,6 @@ def test_low_level_state_and_moment_builders_match_manual_construction():
     states = dhm_module._simulate_linear_states(A, B, x0, shock_mat)
     expected_states = np.array(
         [
-            [1.0, 2.0],
             [1.0, 2.25],
             [-0.5, 1.75],
         ],


### PR DESCRIPTION
## Summary

- Normalize simulation output timing to return the T post-shock periods, `x1` through `xT`.
- Add caller-owned native Monte Carlo simulation steps for first- and second-order models, with inlined measurement evaluation.
- Refactor Kalman, extended Kalman, and unscented Kalman hot loops to use caller-owned scratch arenas and expose flat native Monte Carlo filter steps.
- Add native raw-data and payload materialization, including leading replication-axis selection for batched inputs.
- Update buffer planning, simulation consumers, tests, and estimation benchmarks for the normalized timing and arena-based interfaces.

## Validation

- Full test suite passes.
- Native objective and filter parity checks pass.

closes #364 