### PR TITLE
Native mc kernel arenas and structs

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -46,6 +46,16 @@ static inline i64 max_i64(i64 a, i64 b) { return (a > b) ? a : b; }
 static inline f64 min_f64(f64 a, f64 b) { return (a < b) ? a : b; }
 static inline f64 max_f64(f64 a, f64 b) { return (a > b) ? a : b; }
 
+/* float/int arena size descriptor and constructor. */
+typedef struct {
+  i64 n_float;
+  i64 n_int;
+} arena_size;
+
+static inline arena_size make_sizer(i64 n_float, i64 n_int) {
+  return (arena_size){.n_float = n_float, .n_int = n_int};
+}
+
 /* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
  * differently by MSVC). */
 #if defined(__GNUC__) || defined(__clang__)

--- a/SymbolicDSGE/_ckernels/diag/diag.c
+++ b/SymbolicDSGE/_ckernels/diag/diag.c
@@ -4,9 +4,9 @@
 
 /* Breusch-Godfrey: regress eps on [1 | X | lagged eps], statistic n * R^2 (no
  * intercept removal -- TSS is sum(eps^2), matching the numba kernel). */
-i64 sdsge_bg_arena_size(i64 n, i64 K, i64 lags) {
+arena_size sdsge_bg_arena_size(i64 n, i64 K, i64 lags) {
   i64 p = 1 + K + lags;
-  return n * p + 2 * p * p + 2 * p;
+  return make_sizer(n * p + 2 * p * p + 2 * p, 0);
 }
 int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
                   i64 n, i64 K, i64 lags, f64 *SDSGE_RESTRICT arena,
@@ -65,7 +65,9 @@ int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
 /* Breusch-Pagan auxiliary regression of the scaled squared residuals on X_aug.
  * Returns the fit's RSS and centered TSS; the caller shapes them into bp_stat /
  * robust_bp_stat. */
-i64 sdsge_bp_arena_size(i64 n, i64 p) { return n + 2 * p * p + 2 * p; }
+arena_size sdsge_bp_arena_size(i64 n, i64 p) {
+  return make_sizer(n + 2 * p * p + 2 * p, 0);
+}
 int sdsge_bp_aux(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X_aug,
                  i64 n, i64 p, f64 *SDSGE_RESTRICT arena,
                  f64 *SDSGE_RESTRICT rss_out, f64 *SDSGE_RESTRICT tss_out) {
@@ -175,7 +177,9 @@ static int chow_segment_rss(const f64 *SDSGE_RESTRICT y_seg,
   return SDSGE_OK;
 }
 
-i64 sdsge_chow_arena_size(i64 p) { return 2 * p * p + 2 * p; }
+arena_size sdsge_chow_arena_size(i64 p) {
+  return make_sizer(2 * p * p + 2 * p, 0);
+}
 int sdsge_chow_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                     i64 T, i64 p, i64 t_break, f64 *SDSGE_RESTRICT arena,
                     f64 *SDSGE_RESTRICT stat_out) {
@@ -281,8 +285,10 @@ int sdsge_cusum_series(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
   return DIAG_OK;
 }
 
-i64 sdsge_cusum_arena_size(i64 T, i64 p) {
-  return (T - p) + 2 * p * p + 2 * p + 3 * p * p + 3 * p + (T - p);
+arena_size sdsge_cusum_arena_size(i64 T, i64 p) {
+  return make_sizer((T - p) + 2 * p * p + 2 * p + 3 * p * p + 3 * p +
+                        (T - p),
+                    0);
 }
 int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                      i64 T, i64 p, f64 *SDSGE_RESTRICT arena,
@@ -313,8 +319,8 @@ int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
   return DIAG_OK;
 }
 
-i64 sdsge_cusumsq_arena_size(i64 T, i64 p) {
-  return 3 * p * p + 3 * p + (T - p);
+arena_size sdsge_cusumsq_arena_size(i64 T, i64 p) {
+  return make_sizer(3 * p * p + 3 * p + (T - p), 0);
 }
 int sdsge_cusumsq_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                        i64 T, i64 p, i64 *SDSGE_RESTRICT n_out,
@@ -481,10 +487,10 @@ int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
   return DIAG_OK;
 }
 
-i64 sdsge_lb_arena_size(const i64 n, const i64 L) {
+arena_size sdsge_lb_arena_size(const i64 n, const i64 L) {
   const i64 n_safe = max_i64(n, 0);
   const i64 l_safe = min_i64(max_i64(L, 0), max_i64(n_safe - 1, 0));
-  return n_safe + l_safe + 1;
+  return make_sizer(n_safe + l_safe + 1, 0);
 }
 
 /* Jarque-Bera normality statistic n * (skew^2/6 + (kurt-3)^2/24), mirroring the

--- a/SymbolicDSGE/_ckernels/diag/diag.h
+++ b/SymbolicDSGE/_ckernels/diag/diag.h
@@ -32,7 +32,7 @@
  * p = 1 + K + lags
  * arena:  n * p + 2 * p * p + 2 * p
  */
-i64 sdsge_bg_arena_size(i64 n, i64 K, i64 lags);
+arena_size sdsge_bg_arena_size(i64 n, i64 K, i64 lags);
 int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
                   i64 n, i64 K, i64 lags, f64 *SDSGE_RESTRICT arena,
                   f64 *SDSGE_RESTRICT stat_out);
@@ -43,7 +43,7 @@ int sdsge_bg_stat(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X,
  *
  * arena: n + 2 * p * p + 2 * p
  */
-i64 sdsge_bp_arena_size(i64 n, i64 p);
+arena_size sdsge_bp_arena_size(i64 n, i64 p);
 int sdsge_bp_aux(const f64 *SDSGE_RESTRICT eps, const f64 *SDSGE_RESTRICT X_aug,
                  i64 n, i64 p, f64 *SDSGE_RESTRICT arena,
                  f64 *SDSGE_RESTRICT rss_out, f64 *SDSGE_RESTRICT tss_out);
@@ -56,7 +56,7 @@ int sdsge_bp_stat(const f64 *SDSGE_RESTRICT eps,
  *
  * arena: 2 * p * p + 2 * p
  * */
-i64 sdsge_chow_arena_size(i64 p);
+arena_size sdsge_chow_arena_size(i64 p);
 int sdsge_chow_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                     i64 T, i64 p, i64 t_break, f64 *SDSGE_RESTRICT arena,
                     f64 *SDSGE_RESTRICT stat_out);
@@ -91,7 +91,7 @@ int sdsge_cusum_series(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
  * scratch arena: (T - p) + 2 * p * p + 2 * p    +    (3 * p * p + 3 * p)    +
  * (T - p);
  * */
-i64 sdsge_cusum_arena_size(i64 T, i64 p);
+arena_size sdsge_cusum_arena_size(i64 T, i64 p);
 int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                      i64 T, i64 p, f64 *SDSGE_RESTRICT arena,
                      f64 *SDSGE_RESTRICT stat_out);
@@ -103,7 +103,7 @@ int sdsge_cusum_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
  *        recursive residuals       weights
  * arena: 3 * p * p + 3 * p    +    (T - p)
  * */
-i64 sdsge_cusumsq_arena_size(i64 T, i64 p);
+arena_size sdsge_cusumsq_arena_size(i64 T, i64 p);
 int sdsge_cusumsq_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
                        i64 T, i64 p, i64 *SDSGE_RESTRICT n_out,
                        f64 *SDSGE_RESTRICT arena, f64 *SDSGE_RESTRICT stat_out);
@@ -111,7 +111,7 @@ int sdsge_cusumsq_stat(const f64 *SDSGE_RESTRICT y, const f64 *SDSGE_RESTRICT X,
 int sdsge_acorr(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 L,
                 f64 *SDSGE_RESTRICT z_scratch, f64 *SDSGE_RESTRICT out);
 
-i64 sdsge_lb_arena_size(i64 n, i64 L);
+arena_size sdsge_lb_arena_size(i64 n, i64 L);
 int sdsge_lb_stat(const f64 *SDSGE_RESTRICT x, const i64 n, i64 L,
                   f64 *SDSGE_RESTRICT z_scratch,
                   f64 *SDSGE_RESTRICT acorr_scratch, f64 *SDSGE_RESTRICT out);

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.c
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.c
@@ -321,18 +321,19 @@ static int wald_hac_from_moments(f64 *SDSGE_RESTRICT moments,
       mean, target, omega, n, p, dev, factor, pivot_scratch, solved, stat_out);
 }
 
-i64 sdsge_wald_mean_hac_arena_size(const i64 n, const i64 q) {
-  return n * q + 3 * q * q + 4 * q;
+arena_size sdsge_wald_mean_hac_arena_size(const i64 n, const i64 q) {
+  return make_sizer(n * q + 3 * q * q + 4 * q, q);
 }
 
-i64 sdsge_wald_covariance_hac_arena_size(const i64 n, const i64 q) {
+arena_size sdsge_wald_covariance_hac_arena_size(const i64 n, const i64 q) {
   const i64 v = q * (q + 1) / 2;
-  return n * q + n * v + 3 * v * v + 5 * v;
+  return make_sizer(n * q + n * v + 3 * v * v + 5 * v, v);
 }
 
-i64 sdsge_wald_second_moment_hac_arena_size(const i64 n, const i64 q) {
+arena_size sdsge_wald_second_moment_hac_arena_size(const i64 n,
+                                                     const i64 q) {
   const i64 v = q * (q + 1) / 2;
-  return n * v + 3 * v * v + 5 * v;
+  return make_sizer(n * v + 3 * v * v + 5 * v, v);
 }
 
 int sdsge_wald_mean_hac(const f64 *SDSGE_RESTRICT g,

--- a/SymbolicDSGE/_ckernels/diag/diag_wald.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_wald.h
@@ -68,9 +68,9 @@ int sdsge_wald_stat_from_mean_and_cov(const f64 *SDSGE_RESTRICT mean,
  * `manual_bandwidth` is used only for WALD_BW_MANUAL. All other modes resolve
  * bandwidth in C, then clamp it to n - 1. Each function returns a diagnostic
  * status and writes the Wald statistic to `stat_out` on success. */
-i64 sdsge_wald_mean_hac_arena_size(i64 n, i64 q);
-i64 sdsge_wald_covariance_hac_arena_size(i64 n, i64 q);
-i64 sdsge_wald_second_moment_hac_arena_size(i64 n, i64 q);
+arena_size sdsge_wald_mean_hac_arena_size(i64 n, i64 q);
+arena_size sdsge_wald_covariance_hac_arena_size(i64 n, i64 q);
+arena_size sdsge_wald_second_moment_hac_arena_size(i64 n, i64 q);
 
 int sdsge_wald_mean_hac(const f64 *SDSGE_RESTRICT g,
                         const f64 *SDSGE_RESTRICT target, i64 n, i64 q,

--- a/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
@@ -168,10 +168,16 @@ cdef extern from "estimation.h":
                                int has_priors) nogil
 
 
+cdef extern from "sdsge_common.h":
+    ctypedef struct arena_size:
+        int64_t n_float
+        int64_t n_int
+
+
 cdef extern from "../kalman/kalman.h":
-    int64_t kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
-    int64_t ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
-    int64_t ukf_arena_size(
+    arena_size kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    arena_size ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    arena_size ukf_arena_size(
         int64_t n_state, int64_t n_ctrl, int64_t n_exog, int64_t n_obs,
     ) nogil
 
@@ -367,7 +373,9 @@ def obj_linear_base(
     b.std_q = NULL
     b.std_r = NULL
     b.bk_violations = 0
-    filter_arena = np.empty(kf_arena_size(n_var, n_obs, n_exog), dtype=np.float64)
+    filter_arena = np.empty(
+        kf_arena_size(n_var, n_obs, n_exog).n_float, dtype=np.float64
+    )
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
 
@@ -502,7 +510,9 @@ def obj_extended_base(
     b.std_q = NULL
     b.std_r = NULL
     b.bk_violations = 0
-    filter_arena = np.empty(ekf_arena_size(n_var, n_obs, n_exog), dtype=np.float64)
+    filter_arena = np.empty(
+        ekf_arena_size(n_var, n_obs, n_exog).n_float, dtype=np.float64
+    )
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
 
@@ -672,7 +682,8 @@ def obj_unscented_base(
     b.std_r = NULL
     b.bk_violations = 0
     filter_arena = np.empty(
-        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs).n_float,
+        dtype=np.float64,
     )
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
@@ -1147,15 +1158,16 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
 
     if mode == "linear":
         filter_arena = np.empty(
-            kf_arena_size(n_var, n_obs, n_exog), dtype=np.float64
+            kf_arena_size(n_var, n_obs, n_exog).n_float, dtype=np.float64
         )
     elif mode == "extended":
         filter_arena = np.empty(
-            ekf_arena_size(n_var, n_obs, n_exog), dtype=np.float64
+            ekf_arena_size(n_var, n_obs, n_exog).n_float, dtype=np.float64
         )
     else:
         filter_arena = np.empty(
-            ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+            ukf_arena_size(n_state, n_ctrl, n_exog, n_obs).n_float,
+            dtype=np.float64,
         )
     nc.keep.append(filter_arena)
     filter_arena_v = filter_arena

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -12,6 +12,10 @@ import numpy as np
 
 from libc.stdint cimport int64_t
 
+cdef extern from "sdsge_common.h":
+    ctypedef struct arena_size:
+        int64_t n_float
+        int64_t n_int
 
 cdef extern from "kalman.h":
     int KF_OK
@@ -50,7 +54,7 @@ cdef extern from "kalman.h":
         double *eps_hat
         double *loglik
 
-    int64_t kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    arena_size kf_arena_size(int64_t n, int64_t m, int64_t k) nogil
     int kf_hot_loop(
         const kf_inputs *inp,
         double *arena,
@@ -98,7 +102,7 @@ cdef extern from "kalman.h":
         double *eps_hat
         double *loglik
 
-    int64_t ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
+    arena_size ekf_arena_size(int64_t n, int64_t m, int64_t k) nogil
     int c_ekf_hot_loop "ekf_hot_loop"(
         const ekf_inputs *inp,
         double *arena,
@@ -157,7 +161,7 @@ cdef extern from "kalman.h":
 
         double *loglik
 
-    int64_t ukf_arena_size(
+    arena_size ukf_arena_size(
         int64_t n_state,
         int64_t n_ctrl,
         int64_t n_exog,
@@ -219,7 +223,7 @@ def kalman_hot_loop(
     std_innov = np.zeros((hist_T, m), dtype=np.float64)
     S = np.zeros((hist_T, m, m), dtype=np.float64)
     eps_hat = np.zeros((shock_T, k), dtype=np.float64)
-    arena = np.empty(kf_arena_size(n, m, k), dtype=np.float64)
+    arena = np.empty(kf_arena_size(n, m, k).n_float, dtype=np.float64)
     cdef double loglik = 0.0
 
     cdef double[:, ::1] x_pred_mv = x_pred
@@ -350,7 +354,7 @@ def ekf_hot_loop(
     std_innov = np.zeros((hist_T, m), dtype=np.float64)
     S = np.zeros((hist_T, m, m), dtype=np.float64)
     eps_hat = np.zeros((shock_T, k), dtype=np.float64)
-    arena = np.empty(ekf_arena_size(n, m, k), dtype=np.float64)
+    arena = np.empty(ekf_arena_size(n, m, k).n_float, dtype=np.float64)
     cdef double loglik = 0.0
 
     cdef double[:, ::1] x_pred_mv = x_pred
@@ -525,7 +529,7 @@ def ukf_hot_loop(
     std_innov = np.zeros((hist_T, n_obs), dtype=np.float64)
     S = np.zeros((hist_T, n_obs, n_obs), dtype=np.float64)
     arena = np.empty(
-        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs), dtype=np.float64
+        ukf_arena_size(n_state, n_ctrl, n_exog, n_obs).n_float, dtype=np.float64
     )
     cdef double loglik = 0.0
 

--- a/SymbolicDSGE/_ckernels/kalman/kalman.c
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.c
@@ -142,14 +142,16 @@ void kf_build_shock_projection(const f64 *SDSGE_RESTRICT B,
   sdsge_matmul(Q, temp_km, out, k, k, m);
 }
 
-i64 kf_arena_size(const i64 n, const i64 m, const i64 k) {
-  return 2 * n + 7 * m /* vectors + triangular-solve scratch */
-         + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
-         + 2 * m * m   /* S_buf, L */
-         + 3 * n * m   /* PCt, K, temp_nm */
-         + m * n       /* temp_mn */
-         + n * k       /* temp_nk */
-         + 2 * k * m;  /* M, temp_km */
+arena_size kf_arena_size(const i64 n, const i64 m, const i64 k) {
+  return make_sizer(
+      2 * n + 7 * m    /* vectors + triangular-solve scratch */
+          + 6 * n * n  /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+          + 2 * m * m  /* S_buf, L */
+          + 3 * n * m  /* PCt, K, temp_nm */
+          + m * n      /* temp_mn */
+          + n * k      /* temp_nk */
+          + 2 * k * m, /* M, temp_km */
+      0);
 }
 int kf_hot_loop(const kf_inputs *in, f64 *SDSGE_RESTRICT arena,
                 kf_outputs *out) {
@@ -276,14 +278,16 @@ int kf_hot_loop(const kf_inputs *in, f64 *SDSGE_RESTRICT arena,
   return status;
 }
 
-i64 ekf_arena_size(const i64 n, const i64 m, const i64 k) {
-  return 2 * n + 6 * m /* vectors + triangular-solve scratch */
-         + 6 * n * n   /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
-         + 2 * m * m   /* S_buf, L */
-         + 4 * n * m   /* PCt, K, temp_nm, H_buf */
-         + m * n       /* temp_mn */
-         + n * k       /* temp_nk */
-         + 2 * k * m;  /* M, temp_km */
+arena_size ekf_arena_size(const i64 n, const i64 m, const i64 k) {
+  return make_sizer(
+      2 * n + 6 * m    /* vectors + triangular-solve scratch */
+          + 6 * n * n  /* P_pred, P_filt, KC, I_minus_KC, temp_nn, BQBT */
+          + 2 * m * m  /* S_buf, L */
+          + 4 * n * m  /* PCt, K, temp_nm, H_buf */
+          + m * n      /* temp_mn */
+          + n * k      /* temp_nk */
+          + 2 * k * m, /* M, temp_km */
+      0);
 }
 
 int ekf_hot_loop(const ekf_inputs *in, f64 *SDSGE_RESTRICT arena,
@@ -618,15 +622,16 @@ static int ukf_chol_auto(const f64 *SDSGE_RESTRICT P, f64 jitter,
   return sdsge_chol(P, jitter + scale * UKF_CHOL_FLOOR_REL, L, n);
 }
 
-i64 ukf_arena_size(const i64 n_state, const i64 n_ctrl, const i64 n_exog,
-                   const i64 n_obs) {
+arena_size ukf_arena_size(const i64 n_state, const i64 n_ctrl,
+                           const i64 n_exog, const i64 n_obs) {
   const i64 nz = 2 * n_state;
   const i64 n_sig = 2 * nz + 1;
   const i64 nv = n_state + n_ctrl;
 
-  return 3 * nz + 4 * nz * nz + 2 * n_sig * nz + n_sig * n_obs +
-         n_state * n_state + n_state * n_exog + 6 * n_obs + 2 * n_obs * n_obs +
-         2 * nz * n_obs + nv;
+  return make_sizer(3 * nz + 4 * nz * nz + 2 * n_sig * nz + n_sig * n_obs +
+                        n_state * n_state + n_state * n_exog + 6 * n_obs +
+                        2 * n_obs * n_obs + 2 * nz * n_obs + nv,
+                    0);
 }
 i64 ukf_hot_loop(const ukf_inputs *in, f64 *SDSGE_RESTRICT arena,
                  ukf_outputs *out) {

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -109,7 +109,7 @@ typedef struct {
 
 /* Run the linear Kalman filter. Returns KF_OK, KF_ERR_MATRIX_CONDITION (non-PD
  * innovation covariance) */
-i64 kf_arena_size(const i64 n, const i64 m, const i64 k);
+arena_size kf_arena_size(const i64 n, const i64 m, const i64 k);
 int kf_hot_loop(const kf_inputs *in, f64 *SDSGE_RESTRICT arena,
                 kf_outputs *out);
 
@@ -144,7 +144,7 @@ typedef struct {
 /* Run the extended Kalman filter: linear transition, nonlinear measurement via
  * the meas/jac cfunc pointers (relinearized each step). Returns KF_OK,
  * KF_ERR_MATRIX_CONDITION (non-PD innovation covariance) */
-i64 ekf_arena_size(const i64 n, const i64 m, const i64 k);
+arena_size ekf_arena_size(const i64 n, const i64 m, const i64 k);
 int ekf_hot_loop(const ekf_inputs *in, f64 *SDSGE_RESTRICT arena,
                  ekf_outputs *out);
 
@@ -204,8 +204,8 @@ typedef struct {
   f64 *loglik;
 } ukf_outputs;
 
-i64 ukf_arena_size(const i64 n_state, const i64 n_ctrl, const i64 n_exog,
-                   const i64 n_obs);
+arena_size ukf_arena_size(const i64 n_state, const i64 n_ctrl,
+                           const i64 n_exog, const i64 n_obs);
 i64 ukf_hot_loop(const ukf_inputs *in, f64 *SDSGE_RESTRICT arena,
                  ukf_outputs *out);
 

--- a/SymbolicDSGE/_ckernels/monte_carlo/_tests.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_tests.pyx
@@ -9,14 +9,18 @@ import numpy as np
 
 from libc.stdint cimport int64_t
 
+cdef extern from "sdsge_common.h":
+    ctypedef struct arena_size:
+        int64_t n_float
+        int64_t n_int
 
 cdef extern from "diag.h":
-    int64_t sdsge_bg_arena_size(int64_t n, int64_t k, int64_t lags) nogil
-    int64_t sdsge_bp_arena_size(int64_t n, int64_t p) nogil
-    int64_t sdsge_chow_arena_size(int64_t p) nogil
-    int64_t sdsge_cusum_arena_size(int64_t n, int64_t p) nogil
-    int64_t sdsge_cusumsq_arena_size(int64_t n, int64_t p) nogil
-    int64_t sdsge_lb_arena_size(int64_t n, int64_t lags) nogil
+    arena_size sdsge_bg_arena_size(int64_t n, int64_t k, int64_t lags) nogil
+    arena_size sdsge_bp_arena_size(int64_t n, int64_t p) nogil
+    arena_size sdsge_chow_arena_size(int64_t p) nogil
+    arena_size sdsge_cusum_arena_size(int64_t n, int64_t p) nogil
+    arena_size sdsge_cusumsq_arena_size(int64_t n, int64_t p) nogil
+    arena_size sdsge_lb_arena_size(int64_t n, int64_t lags) nogil
     int sdsge_bg_stat(
         const double *eps, const double *X, int64_t n, int64_t k,
         int64_t lags, double *arena, double *stat_out,
@@ -48,9 +52,9 @@ cdef extern from "diag.h":
     int sdsge_jb_stat(const double *x, int64_t n, double *stat_out) nogil
 
 cdef extern from "diag_wald.h":
-    int64_t sdsge_wald_mean_hac_arena_size(int64_t n, int64_t q) nogil
-    int64_t sdsge_wald_covariance_hac_arena_size(int64_t n, int64_t q) nogil
-    int64_t sdsge_wald_second_moment_hac_arena_size(int64_t n, int64_t q) nogil
+    arena_size sdsge_wald_mean_hac_arena_size(int64_t n, int64_t q) nogil
+    arena_size sdsge_wald_covariance_hac_arena_size(int64_t n, int64_t q) nogil
+    arena_size sdsge_wald_second_moment_hac_arena_size(int64_t n, int64_t q) nogil
     int sdsge_wald_stat_from_mean_and_cov(
         const double *mean, const double *target, const double *omega,
         int64_t n, int64_t p, double *dev_scratch, double *factor_scratch,
@@ -81,47 +85,47 @@ WALD_BW_AUTO = 3
 
 def breusch_godfrey_arena_size(int64_t n, int64_t k, int64_t lags):
     """Return the float64 arena length for Breusch-Godfrey."""
-    return sdsge_bg_arena_size(n, k, lags)
+    return sdsge_bg_arena_size(n, k, lags).n_float
 
 
 def breusch_pagan_arena_size(int64_t n, int64_t p):
     """Return the float64 arena length for Breusch-Pagan."""
-    return sdsge_bp_arena_size(n, p)
+    return sdsge_bp_arena_size(n, p).n_float
 
 
 def chow_arena_size(int64_t p):
     """Return the float64 arena length for Chow."""
-    return sdsge_chow_arena_size(p)
+    return sdsge_chow_arena_size(p).n_float
 
 
 def cusum_arena_size(int64_t n, int64_t p):
     """Return the float64 arena length for CUSUM."""
-    return sdsge_cusum_arena_size(n, p)
+    return sdsge_cusum_arena_size(n, p).n_float
 
 
 def cusumsq_arena_size(int64_t n, int64_t p):
     """Return the float64 arena length for CUSUMSQ."""
-    return sdsge_cusumsq_arena_size(n, p)
+    return sdsge_cusumsq_arena_size(n, p).n_float
 
 
 def ljung_box_arena_size(int64_t n, int64_t lags):
     """Return the float64 arena length for Ljung-Box."""
-    return sdsge_lb_arena_size(n, lags)
+    return sdsge_lb_arena_size(n, lags).n_float
 
 
 def wald_mean_hac_arena_size(int64_t n, int64_t q):
     """Return the float64 arena length for mean-Wald HAC."""
-    return sdsge_wald_mean_hac_arena_size(n, q)
+    return sdsge_wald_mean_hac_arena_size(n, q).n_float
 
 
 def wald_covariance_hac_arena_size(int64_t n, int64_t q):
     """Return the float64 arena length for covariance-Wald HAC."""
-    return sdsge_wald_covariance_hac_arena_size(n, q)
+    return sdsge_wald_covariance_hac_arena_size(n, q).n_float
 
 
 def wald_second_moment_hac_arena_size(int64_t n, int64_t q):
     """Return the float64 arena length for second-moment-Wald HAC."""
-    return sdsge_wald_second_moment_hac_arena_size(n, q)
+    return sdsge_wald_second_moment_hac_arena_size(n, q).n_float
 
 
 def ljung_box_runner(x, int64_t lags, arena):

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.c
@@ -2,6 +2,114 @@
 #include "../core/core.h"
 #include <string.h>
 
+static int sdsge_mc_finish_status(const int status,
+                                  i64 *SDSGE_RESTRICT int_out) {
+  if (int_out != NULL)
+    int_out[0] = (i64)status;
+  return status;
+}
+
+int sdsge_mc_payload_runner(const i64 rep_idx,
+                            f64 *SDSGE_RESTRICT float_in_work,
+                            f64 *SDSGE_RESTRICT float_out,
+                            i64 *SDSGE_RESTRICT int_work,
+                            i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_payload_step_ctx *ctx = ctx_ptr;
+  (void)float_in_work;
+  (void)int_work;
+  sdsge_add_payload_step(ctx->input, ctx->n, ctx->input_batched, rep_idx,
+                         float_out);
+  return sdsge_mc_finish_status(SDSGE_OK, int_out);
+}
+
+int sdsge_mc_raw_model_data_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_raw_model_data_step_ctx *ctx = ctx_ptr;
+  (void)float_in_work;
+  (void)int_work;
+  sdsge_raw_model_data_step(
+      ctx->states_input, ctx->n_states, ctx->states_batched, float_out,
+      ctx->observables_input, ctx->n_observables, ctx->observables_batched,
+      rep_idx, float_out + ctx->n_states);
+  return sdsge_mc_finish_status(SDSGE_OK, int_out);
+}
+
+int sdsge_mc_simulate_order1_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_simulate_order1_step_ctx *ctx = ctx_ptr;
+  (void)rep_idx;
+  (void)int_work;
+  sdsge_simulate_order1_step(float_in_work, ctx->measurement, ctx->T, ctx->n,
+                             ctx->k, ctx->n_par, ctx->m, float_out);
+  return sdsge_mc_finish_status(SDSGE_OK, int_out);
+}
+
+int sdsge_mc_simulate_order2_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_simulate_order2_step_ctx *ctx = ctx_ptr;
+  (void)rep_idx;
+  (void)int_work;
+  sdsge_simulate_order2_step(float_in_work, ctx->measurement, ctx->T,
+                             ctx->n_state, ctx->n_ctrl, ctx->n_exog,
+                             ctx->n_par, ctx->m, float_out);
+  return sdsge_mc_finish_status(SDSGE_OK, int_out);
+}
+
+int sdsge_mc_filter_linear_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_filter_linear_step_ctx *ctx = ctx_ptr;
+  const i64 input_size =
+      sdsge_filter_linear_input_arena_size(ctx->n, ctx->m, ctx->k, ctx->T);
+  (void)rep_idx;
+  (void)int_work;
+  const int status = sdsge_filter_linear_step(
+      float_in_work, float_in_work + input_size, ctx->T, ctx->n, ctx->m,
+      ctx->k, ctx->symmetrize, ctx->jitter, ctx->return_shocks, float_out);
+  return sdsge_mc_finish_status(status, int_out);
+}
+
+int sdsge_mc_filter_extended_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_filter_extended_step_ctx *ctx = ctx_ptr;
+  const i64 input_size = sdsge_filter_extended_input_arena_size(
+      ctx->n, ctx->m, ctx->k, ctx->T, ctx->n_par);
+  (void)rep_idx;
+  (void)int_work;
+  const int status = sdsge_filter_extended_step(
+      float_in_work, float_in_work + input_size, ctx->measurement,
+      ctx->jacobian, ctx->T, ctx->n, ctx->m, ctx->k, ctx->n_par,
+      ctx->symmetrize, ctx->jitter, ctx->return_shocks, float_out);
+  return sdsge_mc_finish_status(status, int_out);
+}
+
+int sdsge_mc_filter_unscented_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx_ptr) {
+  const sdsge_mc_filter_unscented_step_ctx *ctx = ctx_ptr;
+  const i64 input_size = sdsge_filter_unscented_input_arena_size(
+      ctx->n_state, ctx->n_ctrl, ctx->n_exog, ctx->n_obs, ctx->T,
+      ctx->n_par);
+  (void)rep_idx;
+  (void)int_work;
+  const int status = (int)sdsge_filter_unscented_step(
+      float_in_work, float_in_work + input_size, ctx->measurement, ctx->T,
+      ctx->n_state, ctx->n_ctrl, ctx->n_exog, ctx->n_obs, ctx->n_par,
+      ctx->alpha, ctx->beta, ctx->kappa, ctx->symmetrize, ctx->jitter,
+      float_out);
+  return sdsge_mc_finish_status(status, int_out);
+}
+
 void sdsge_add_payload_step(const f64 *SDSGE_RESTRICT input, const i64 n,
                             const int input_batched, const i64 rep_idx,
                             f64 *SDSGE_RESTRICT output) {

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -4,6 +4,113 @@
 #include "../_common/sdsge_common.h"
 #include "../core/core.h"
 #include "../kalman/kalman.h"
+#include "runner.h"
+
+/* Static configuration for future generic native MC step dispatch. Dynamic
+ * numeric inputs, scratch, and outputs remain in caller-owned arenas. */
+typedef struct {
+  const f64 *input;
+  i64 n;
+  int input_batched;
+} sdsge_mc_payload_step_ctx;
+
+typedef struct {
+  const f64 *states_input;
+  i64 n_states;
+  int states_batched;
+  const f64 *observables_input;
+  i64 n_observables;
+  int observables_batched;
+} sdsge_mc_raw_model_data_step_ctx;
+
+typedef struct {
+  sdsge_measurement_fn measurement;
+  i64 T;
+  i64 n;
+  i64 k;
+  i64 n_par;
+  i64 m;
+} sdsge_mc_simulate_order1_step_ctx;
+
+typedef struct {
+  sdsge_measurement_fn measurement;
+  i64 T;
+  i64 n_state;
+  i64 n_ctrl;
+  i64 n_exog;
+  i64 n_par;
+  i64 m;
+} sdsge_mc_simulate_order2_step_ctx;
+
+typedef struct {
+  i64 T;
+  i64 n;
+  i64 m;
+  i64 k;
+  int symmetrize;
+  f64 jitter;
+  int return_shocks;
+} sdsge_mc_filter_linear_step_ctx;
+
+typedef struct {
+  meas_fn measurement;
+  meas_fn jacobian;
+  i64 T;
+  i64 n;
+  i64 m;
+  i64 k;
+  i64 n_par;
+  int symmetrize;
+  f64 jitter;
+  int return_shocks;
+} sdsge_mc_filter_extended_step_ctx;
+
+typedef struct {
+  meas_fn measurement;
+  i64 T;
+  i64 n_state;
+  i64 n_ctrl;
+  i64 n_exog;
+  i64 n_obs;
+  i64 n_par;
+  f64 alpha;
+  f64 beta;
+  f64 kappa;
+  int symmetrize;
+  f64 jitter;
+} sdsge_mc_filter_unscented_step_ctx;
+
+/* Generic-runner adapters. They preserve the canonical arena layouts of the
+ * direct kernels below and write one status code when ``int_out`` is non-NULL.
+ */
+int sdsge_mc_payload_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                            f64 *SDSGE_RESTRICT float_out,
+                            i64 *SDSGE_RESTRICT int_work,
+                            i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_raw_model_data_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_simulate_order1_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_simulate_order2_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_filter_linear_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_filter_extended_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_filter_unscented_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
 
 /* Payload materialization. ``input_batched`` selects input[rep_idx] from a
  * leading replication axis; otherwise the same input span is copied each time. */

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.c
@@ -6,6 +6,47 @@
 #include <math.h>
 #include <stddef.h>
 
+arena_size sdsge_mc_ols_work_arena_size(const i64 n, const i64 p) {
+  return make_sizer(n * p + n + 2 * p * p + 2 * p, 0);
+}
+
+arena_size sdsge_mc_ridge_work_arena_size(const i64 n, const i64 p) {
+  return make_sizer(n * p + n + 3 * p * p + 2 * p, 0);
+}
+
+arena_size sdsge_mc_ridge_gs_work_arena_size(const i64 n, const i64 p) {
+  return make_sizer(n * p + n + 3 * p * p + 3 * p, 0);
+}
+
+arena_size sdsge_mc_lasso_work_arena_size(const i64 n, const i64 p) {
+  return make_sizer(n * p + n + 2 * p * p + 2 * p, 0);
+}
+
+arena_size sdsge_mc_lasso_gs_work_arena_size(const i64 n, const i64 p,
+                                              const int intercept,
+                                              const i64 n_alpha,
+                                              const i64 max_iter) {
+  const i64 k = p - (intercept ? 1 : 0);
+  const i64 staged = n * p + n;
+  const i64 gram = 2 * p * p + p;
+  const i64 path = max_iter + 1 + (max_iter + 1) * k + n_alpha * k;
+  const i64 solver_work = k * k + 8 * k;
+  return make_sizer(staged + gram + path + solver_work, 0);
+}
+
+arena_size sdsge_mc_elastic_net_work_arena_size(const i64 n, const i64 p) {
+  return make_sizer(n * p + n + 2 * p * p + 2 * p, 0);
+}
+
+arena_size sdsge_mc_elastic_net_gs_work_arena_size(const i64 n, const i64 p,
+                                                    const int intercept,
+                                                    const i64 n_alpha) {
+  const i64 k = p - (intercept ? 1 : 0);
+  const i64 staged = n * p + n;
+  return make_sizer(staged + 2 * p * p + 3 * p + n_alpha * k + 3 * k * k + k,
+                    n_alpha);
+}
+
 static void sdsge_mc_set_failure(sdsge_mc_regression_record *rec) {
   for (i64 i = 0; i < rec->p; ++i)
     rec->coef[i] = NAN;
@@ -301,4 +342,202 @@ void sdsge_mc_elastic_net_gs_fit(
   if (intercept)
     sdsge_mc_restore_intercept(rec, G_base, g[k]);
   sdsge_mc_compute_ssr_sst(X, y, rec);
+}
+
+static sdsge_mc_regression_record sdsge_mc_regression_output_record(
+    const i64 n, const i64 p, f64 *SDSGE_RESTRICT float_out, const int with_se) {
+  sdsge_mc_regression_record rec = {
+      .n = n,
+      .p = p,
+      .coef = float_out,
+      .se = with_se ? float_out + p + 2 : NULL,
+      .ssr = NAN,
+      .sst = NAN,
+      .status = REGRESSION_NON_CONVERGENT,
+  };
+  return rec;
+}
+
+static int sdsge_mc_regression_status(
+    const sdsge_mc_regression_record *rec, f64 *SDSGE_RESTRICT float_out,
+    i64 *SDSGE_RESTRICT int_out) {
+  float_out[rec->p] = rec->ssr;
+  float_out[rec->p + 1] = rec->sst;
+  if (int_out != NULL) {
+    int_out[0] = rec->status;
+  }
+  return (int)rec->status;
+}
+
+int sdsge_mc_ols_runner(const i64 rep_idx,
+                        f64 *SDSGE_RESTRICT float_in_work,
+                        f64 *SDSGE_RESTRICT float_out,
+                        i64 *SDSGE_RESTRICT int_work,
+                        i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_ols_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 1);
+  f64 *L = scratch;
+  f64 *G = L + config->p * config->p;
+  f64 *g = G + config->p * config->p;
+  f64 *work = g + config->p;
+  sdsge_mc_ols_fit(X, y, &rec, L, G, g, work);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_ridge_runner(const i64 rep_idx,
+                          f64 *SDSGE_RESTRICT float_in_work,
+                          f64 *SDSGE_RESTRICT float_out,
+                          i64 *SDSGE_RESTRICT int_work,
+                          i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_ridge_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *L = scratch;
+  f64 *G = L + config->p * config->p;
+  f64 *G_unpen = G + config->p * config->p;
+  f64 *g = G_unpen + config->p * config->p;
+  f64 *col = g + config->p;
+  sdsge_mc_ridge_fit(X, y, config->alpha, config->intercept, &rec, L, G,
+                      G_unpen, g, col);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_ridge_gs_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_ridge_gs_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *G_base = scratch;
+  f64 *G = G_base + config->p * config->p;
+  f64 *L = G + config->p * config->p;
+  f64 *g = L + config->p * config->p;
+  f64 *coef_work = g + config->p;
+  f64 *col = coef_work + config->p;
+  sdsge_mc_ridge_gs_fit(X, y, config->alphas, config->n_alpha,
+                         config->criterion, config->intercept, &rec, G_base,
+                         G, L, g, coef_work, col);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_lasso_runner(const i64 rep_idx,
+                          f64 *SDSGE_RESTRICT float_in_work,
+                          f64 *SDSGE_RESTRICT float_out,
+                          i64 *SDSGE_RESTRICT int_work,
+                          i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_lasso_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *G_base = scratch;
+  f64 *G = G_base + config->p * config->p;
+  f64 *g = G + config->p * config->p;
+  f64 *Gcoef = g + config->p;
+  sdsge_mc_lasso_fit(X, y, config->alpha, config->intercept, config->max_iter,
+                      config->tol, &rec, G_base, G, g, Gcoef);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_lasso_gs_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_lasso_gs_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 k = config->p - (config->intercept ? 1 : 0);
+  const i64 n_path = config->max_iter + 1;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *G_base = scratch;
+  f64 *G = G_base + config->p * config->p;
+  f64 *g = G + config->p * config->p;
+  f64 *lam_path = g + config->p;
+  f64 *beta_path = lam_path + n_path;
+  f64 *beta_grid = beta_path + n_path * k;
+  f64 *work = beta_grid + config->n_alpha * k;
+  sdsge_mc_lasso_gs_fit(X, y, config->alphas, config->n_alpha,
+                         config->intercept, config->max_iter, config->tol,
+                         &rec, G_base, G, g, lam_path, beta_path, beta_grid,
+                         work);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_elastic_net_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_elastic_net_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *G_base = scratch;
+  f64 *G = G_base + config->p * config->p;
+  f64 *g = G + config->p * config->p;
+  f64 *Gcoef = g + config->p;
+  sdsge_mc_elastic_net_fit(
+      X, y, config->alpha, config->l1_ratio, config->intercept,
+      config->max_iter, config->tol, &rec, G_base, G, g, Gcoef);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
+}
+
+int sdsge_mc_elastic_net_gs_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  const sdsge_mc_elastic_net_gs_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 k = config->p - (config->intercept ? 1 : 0);
+  const f64 *X = float_in_work;
+  const f64 *y = float_in_work + input_count;
+  f64 *scratch = float_in_work + input_count + config->n;
+  sdsge_mc_regression_record rec =
+      sdsge_mc_regression_output_record(config->n, config->p, float_out, 0);
+  f64 *G_base = scratch;
+  f64 *G = G_base + config->p * config->p;
+  f64 *g = G + config->p * config->p;
+  f64 *beta_grid = g + config->p;
+  f64 *Gcoef = beta_grid + config->n_alpha * k;
+  f64 *beta = Gcoef + config->p;
+  f64 *dof_work = beta + config->p;
+  sdsge_mc_elastic_net_gs_fit(
+      X, y, config->alphas, config->n_alpha, config->l1_ratio,
+      config->criterion, config->intercept, config->max_iter, config->tol,
+      &rec, G_base, G, g, beta_grid, int_work, Gcoef, beta, dof_work);
+  return sdsge_mc_regression_status(&rec, float_out, int_out);
 }

--- a/SymbolicDSGE/_ckernels/monte_carlo/regression.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/regression.h
@@ -2,6 +2,7 @@
 #define SDSGE_MC_REGRESSION_H
 
 #include "../_common/sdsge_common.h"
+#include "runner.h"
 
 typedef struct {
   i64 n; // number of samples
@@ -15,14 +16,94 @@ typedef struct {
   i64 status;
 } sdsge_mc_regression_record;
 
-/* Regression Wrappers for natve MC Steps */
+/* Static configuration for generic native MC regression dispatch.
+ * The dynamic response, design, solver workspace, and outputs remain in
+ * caller-owned float and integer arenas. */
+typedef struct {
+  i64 n;
+  i64 p;
+  int intercept;
+} sdsge_mc_ols_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  int intercept;
+  f64 alpha;
+} sdsge_mc_ridge_step_ctx;
+
+typedef struct {
+  const f64 *alphas;
+  i64 n;
+  i64 p;
+  i64 n_alpha;
+  i64 criterion;
+  int intercept;
+} sdsge_mc_ridge_gs_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  int intercept;
+  i64 max_iter;
+  f64 tol;
+  f64 alpha;
+} sdsge_mc_lasso_step_ctx;
+
+typedef struct {
+  const f64 *alphas;
+  i64 n;
+  i64 p;
+  i64 n_alpha;
+  int intercept;
+  i64 max_iter;
+  f64 tol;
+} sdsge_mc_lasso_gs_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  int intercept;
+  i64 max_iter;
+  f64 tol;
+  f64 alpha;
+  f64 l1_ratio;
+} sdsge_mc_elastic_net_step_ctx;
+
+typedef struct {
+  const f64 *alphas;
+  i64 n;
+  i64 p;
+  i64 n_alpha;
+  i64 criterion;
+  int intercept;
+  i64 max_iter;
+  f64 tol;
+  f64 l1_ratio;
+} sdsge_mc_elastic_net_gs_step_ctx;
+
+/* Shared input/work arena sizes. ``p`` is the design width after optional
+ * intercept augmentation. All float counts include staged X(n,p) and y(n).
+ */
+arena_size sdsge_mc_ols_work_arena_size(const i64 n, const i64 p);
+arena_size sdsge_mc_ridge_work_arena_size(i64 n, i64 p);
+arena_size sdsge_mc_ridge_gs_work_arena_size(i64 n, i64 p);
+arena_size sdsge_mc_lasso_work_arena_size(i64 n, i64 p);
+arena_size sdsge_mc_lasso_gs_work_arena_size(i64 n, i64 p, int intercept,
+                                              i64 n_alpha, i64 max_iter);
+arena_size sdsge_mc_elastic_net_work_arena_size(i64 n, i64 p);
+arena_size sdsge_mc_elastic_net_gs_work_arena_size(i64 n, i64 p,
+                                                    int intercept,
+                                                    i64 n_alpha);
+
+/* Regression kernels for native MC steps. */
 void sdsge_mc_ols_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
                       sdsge_mc_regression_record *SDSGE_RESTRICT rec,
                       f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
                       f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT work);
 
-void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-                        f64 alpha, i64 intercept,
+void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X,
+                        const f64 *SDSGE_RESTRICT y, f64 alpha, i64 intercept,
                         sdsge_mc_regression_record *SDSGE_RESTRICT rec,
                         f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT G,
                         f64 *SDSGE_RESTRICT G_unpen, f64 *SDSGE_RESTRICT g,
@@ -30,10 +111,9 @@ void sdsge_mc_ridge_fit(const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y
 
 void sdsge_mc_ridge_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion,
-    i64 intercept, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 criterion, i64 intercept,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec, f64 *SDSGE_RESTRICT G_base,
+    f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT L, f64 *SDSGE_RESTRICT g,
     f64 *SDSGE_RESTRICT coef_work, f64 *SDSGE_RESTRICT col);
 
 /* Sparse estimators receive a design with an explicit leading intercept column
@@ -46,37 +126,69 @@ void sdsge_mc_ridge_gs_fit(
  * elastic_net_fit: G_base(p*p), G(p*p), g(p), Gcoef(p).
  * elastic_net_gs_fit: beta_grid(n_alpha*k), statuses(n_alpha), Gcoef(p),
  * beta(p), and dof_work(3*k*k + k), in addition to G_base, G, and g. */
-void sdsge_mc_lasso_fit(
-    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
-    i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
+void sdsge_mc_lasso_fit(const f64 *SDSGE_RESTRICT X,
+                        const f64 *SDSGE_RESTRICT y, f64 alpha, i64 intercept,
+                        i64 max_iter, f64 tol,
+                        sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                        f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+                        f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
 
 void sdsge_mc_lasso_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept,
-    i64 max_iter, f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT lam_path,
-    f64 *SDSGE_RESTRICT beta_path, f64 *SDSGE_RESTRICT beta_grid,
-    f64 *SDSGE_RESTRICT work);
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, i64 intercept, i64 max_iter,
+    f64 tol, sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT g,
+    f64 *SDSGE_RESTRICT lam_path, f64 *SDSGE_RESTRICT beta_path,
+    f64 *SDSGE_RESTRICT beta_grid, f64 *SDSGE_RESTRICT work);
 
-void sdsge_mc_elastic_net_fit(
-    const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y, f64 alpha,
-    f64 l1_ratio, i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
+void sdsge_mc_elastic_net_fit(const f64 *SDSGE_RESTRICT X,
+                              const f64 *SDSGE_RESTRICT y, f64 alpha,
+                              f64 l1_ratio, i64 intercept, i64 max_iter,
+                              f64 tol,
+                              sdsge_mc_regression_record *SDSGE_RESTRICT rec,
+                              f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
+                              f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT Gcoef);
 
 void sdsge_mc_elastic_net_gs_fit(
     const f64 *SDSGE_RESTRICT X, const f64 *SDSGE_RESTRICT y,
-    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio,
-    i64 criterion, i64 intercept, i64 max_iter, f64 tol,
-    sdsge_mc_regression_record *SDSGE_RESTRICT rec,
-    f64 *SDSGE_RESTRICT G_base, f64 *SDSGE_RESTRICT G,
-    f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
+    const f64 *SDSGE_RESTRICT alphas, i64 n_alpha, f64 l1_ratio, i64 criterion,
+    i64 intercept, i64 max_iter, f64 tol,
+    sdsge_mc_regression_record *SDSGE_RESTRICT rec, f64 *SDSGE_RESTRICT G_base,
+    f64 *SDSGE_RESTRICT G, f64 *SDSGE_RESTRICT g, f64 *SDSGE_RESTRICT beta_grid,
     i64 *SDSGE_RESTRICT statuses, f64 *SDSGE_RESTRICT Gcoef,
     f64 *SDSGE_RESTRICT beta, f64 *SDSGE_RESTRICT dof_work);
+
+/* Generic-runner adapters. ``float_in_work`` begins with staged X(n,p) and
+ * y(n), followed by the fit kernel's scratch layout. ``float_out`` is
+ * [coef(p), ssr, sst, se(p) for OLS], and ``int_out[0]`` receives status when
+ * supplied. */
+int sdsge_mc_ols_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                        f64 *SDSGE_RESTRICT float_out,
+                        i64 *SDSGE_RESTRICT int_work,
+                        i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_ridge_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                          f64 *SDSGE_RESTRICT float_out,
+                          i64 *SDSGE_RESTRICT int_work,
+                          i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_ridge_gs_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                             f64 *SDSGE_RESTRICT float_out,
+                             i64 *SDSGE_RESTRICT int_work,
+                             i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_lasso_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                          f64 *SDSGE_RESTRICT float_out,
+                          i64 *SDSGE_RESTRICT int_work,
+                          i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_lasso_gs_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                             f64 *SDSGE_RESTRICT float_out,
+                             i64 *SDSGE_RESTRICT int_work,
+                             i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_elastic_net_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_elastic_net_gs_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
 
 #endif /* SDSGE_MC_REGRESSION_H */

--- a/SymbolicDSGE/_ckernels/monte_carlo/runner.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/runner.h
@@ -1,0 +1,37 @@
+#ifndef SDSGE_MC_RUNNER_H
+#define SDSGE_MC_RUNNER_H
+
+#include "../_common/sdsge_common.h"
+
+/* Generic native Monte Carlo step ABI. The caller supplies one reusable
+ * per-replication input/work arena and writes each replication to its own
+ * output arena slice. ``ctx`` points to immutable, step-specific static
+ * configuration owned by the compiled pipeline plan. */
+typedef int (*sdsge_mc_step_fn)(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                                f64 *SDSGE_RESTRICT float_out,
+                                i64 *SDSGE_RESTRICT int_work,
+                                i64 *SDSGE_RESTRICT int_out, const void *ctx);
+
+/* One compiled pipeline step. Output offsets are element offsets from the
+ * per-replication output bases. Input and workspace arenas are temporary and
+ * reused by every sequential step within a replication. */
+typedef struct {
+  sdsge_mc_step_fn fn;
+  i64 float_out_offset;
+  i64 int_out_offset;
+  const void *ctx;
+} sdsge_mc_step_desc;
+
+/* Immutable native execution plan. The compiler owns the descriptor array and
+ * all step contexts, retaining every backing array referenced by a context for
+ * at least as long as this plan remains live. Output strides advance the
+ * runner from one replication's persistent outputs to the next. */
+
+typedef struct {
+  const sdsge_mc_step_desc *steps;
+  i64 n_steps;
+  i64 float_out_stride;
+  i64 int_out_stride;
+} sdsge_mc_runner_ctx;
+
+#endif /* SDSGE_MC_RUNNER_H */

--- a/SymbolicDSGE/_ckernels/monte_carlo/tests.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/tests.c
@@ -1,0 +1,153 @@
+#include "tests.h"
+
+static int sdsge_mc_test_status(const int status,
+                                i64 *SDSGE_RESTRICT int_out) {
+  if (int_out != NULL) {
+    int_out[0] = status;
+  }
+  return status;
+}
+
+int sdsge_mc_wald_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  const sdsge_mc_wald_test_ctx *config = ctx;
+  const f64 *sample = float_in_work;
+  f64 *arena = float_in_work + config->n * config->q;
+  int status;
+
+  if (config->kind == SDSGE_MC_WALD_MEAN) {
+    status = sdsge_wald_mean_hac(
+        sample, config->target, config->n, config->q, config->kernel_id,
+        config->bandwidth_mode, config->manual_bandwidth, arena, int_work,
+        float_out);
+  } else if (config->kind == SDSGE_MC_WALD_COVARIANCE) {
+    status = sdsge_wald_covariance_hac(
+        sample, config->target, config->n, config->q, config->kernel_id,
+        config->bandwidth_mode, config->manual_bandwidth, arena, int_work,
+        float_out);
+  } else {
+    status = sdsge_wald_second_moment_hac(
+        sample, config->target, config->n, config->q, config->kernel_id,
+        config->bandwidth_mode, config->manual_bandwidth, arena, int_work,
+        float_out);
+  }
+  return sdsge_mc_test_status(status, int_out);
+}
+
+int sdsge_mc_ljung_box_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_ljung_box_test_ctx *config = ctx;
+  const f64 *x = float_in_work;
+  f64 *arena = float_in_work + config->n;
+  const int status = sdsge_lb_stat(x, config->n, config->lags, arena,
+                                   arena + config->n, float_out);
+  return sdsge_mc_test_status(status, int_out);
+}
+
+int sdsge_mc_jarque_bera_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_jarque_bera_test_ctx *config = ctx;
+  return sdsge_mc_test_status(
+      sdsge_jb_stat(float_in_work, config->n, float_out), int_out);
+}
+
+int sdsge_mc_breusch_pagan_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_breusch_pagan_test_ctx *config = ctx;
+  const f64 *eps = float_in_work;
+  f64 *X = float_in_work + config->n;
+  const i64 p = config->k + 1;
+  f64 *X_aug = X + config->n * config->k;
+  f64 *arena = X_aug + config->n * p;
+
+  for (i64 i = 0; i < config->n; ++i) {
+    X_aug[i * p] = 1.0;
+    for (i64 j = 0; j < config->k; ++j) {
+      X_aug[i * p + 1 + j] = X[i * config->k + j];
+    }
+  }
+
+  return sdsge_mc_test_status(
+      sdsge_bp_stat(eps, X_aug, config->n, p, config->robust, arena,
+                    float_out),
+      int_out);
+}
+
+int sdsge_mc_breusch_godfrey_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_breusch_godfrey_test_ctx *config = ctx;
+  const f64 *eps = float_in_work;
+  f64 *X = float_in_work + config->n;
+  f64 *arena = X + config->n * config->k;
+  return sdsge_mc_test_status(
+      sdsge_bg_stat(eps, X, config->n, config->k, config->lags, arena,
+                    float_out),
+      int_out);
+}
+
+int sdsge_mc_cusum_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_cusum_test_ctx *config = ctx;
+  const f64 *y = float_in_work;
+  f64 *X = float_in_work + config->n;
+  f64 *arena = X + config->n * config->p;
+  return sdsge_mc_test_status(
+      sdsge_cusum_stat(y, X, config->n, config->p, arena, float_out),
+      int_out);
+}
+
+int sdsge_mc_cusumsq_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_cusumsq_test_ctx *config = ctx;
+  const f64 *y = float_in_work;
+  f64 *X = float_in_work + config->n;
+  f64 *arena = X + config->n * config->p;
+  i64 n_out;
+  return sdsge_mc_test_status(
+      sdsge_cusumsq_stat(y, X, config->n, config->p, &n_out, arena,
+                          float_out),
+      int_out);
+}
+
+int sdsge_mc_chow_test_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_chow_test_ctx *config = ctx;
+  const f64 *y = float_in_work;
+  f64 *X = float_in_work + config->n;
+  f64 *arena = X + config->n * config->p;
+  return sdsge_mc_test_status(
+      sdsge_chow_stat(y, X, config->n, config->p, config->t_break, arena,
+                      float_out),
+      int_out);
+}

--- a/SymbolicDSGE/_ckernels/monte_carlo/tests.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/tests.h
@@ -1,0 +1,96 @@
+#ifndef SDSGE_MC_TESTS_H
+#define SDSGE_MC_TESTS_H
+
+#include "../diag/diag.h"
+#include "../diag/diag_wald.h"
+#include "runner.h"
+
+typedef enum {
+  SDSGE_MC_WALD_MEAN = 0,
+  SDSGE_MC_WALD_COVARIANCE = 1,
+  SDSGE_MC_WALD_SECOND_MOMENT = 2,
+} sdsge_mc_wald_kind;
+
+typedef struct {
+  const f64 *target;
+  i64 n;
+  i64 q;
+  i64 manual_bandwidth;
+  KernelID kernel_id;
+  WaldBandwidthMode bandwidth_mode;
+  sdsge_mc_wald_kind kind;
+} sdsge_mc_wald_test_ctx;
+
+typedef struct {
+  i64 n;
+  i64 lags;
+} sdsge_mc_ljung_box_test_ctx;
+
+typedef struct {
+  i64 n;
+} sdsge_mc_jarque_bera_test_ctx;
+
+typedef struct {
+  i64 n;
+  i64 k;
+  int robust;
+} sdsge_mc_breusch_pagan_test_ctx;
+
+typedef struct {
+  i64 n;
+  i64 k;
+  i64 lags;
+} sdsge_mc_breusch_godfrey_test_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+} sdsge_mc_cusum_test_ctx;
+
+typedef sdsge_mc_cusum_test_ctx sdsge_mc_cusumsq_test_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  i64 t_break;
+} sdsge_mc_chow_test_ctx;
+
+/* Generic native Monte Carlo test adapters. Every adapter writes a scalar
+ * statistic to ``float_out[0]`` and its status code to ``int_out[0]`` when the
+ * latter is supplied. ``float_in_work`` starts with the operation inputs and
+ * continues with all temporary float storage required by the underlying
+ * diagnostic kernel. */
+int sdsge_mc_wald_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_ljung_box_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_jarque_bera_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_breusch_pagan_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_breusch_godfrey_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_cusum_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_cusumsq_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_chow_test_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+
+#endif /* SDSGE_MC_TESTS_H */

--- a/SymbolicDSGE/_ckernels/monte_carlo/transforms.c
+++ b/SymbolicDSGE/_ckernels/monte_carlo/transforms.c
@@ -27,6 +27,9 @@ static void welford_ax0(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
   }
 }
 
+arena_size sdsge_standardize_ax0_arena_size(i64 n, i64 p) {
+  return make_sizer(n * p + 2 * p, 0);
+}
 i64 sdsge_standardize_ax0(const f64 *SDSGE_RESTRICT x, const i64 ddof,
                           const i64 n, const i64 p, f64 *SDSGE_RESTRICT scratch,
                           f64 *SDSGE_RESTRICT out) {
@@ -62,6 +65,7 @@ i64 sdsge_standardize_ax0(const f64 *SDSGE_RESTRICT x, const i64 ddof,
   return SDSGE_TRANSFORM_SUCCESS;
 }
 
+arena_size sdsge_log_arena_size(i64 n, i64 p) { return make_sizer(n * p, 0); }
 i64 sdsge_log(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
               const i64 p, f64 *SDSGE_RESTRICT out) {
   if (n <= 0 || p <= 0) {
@@ -77,6 +81,9 @@ i64 sdsge_log(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
   return SDSGE_TRANSFORM_SUCCESS;
 }
 
+arena_size sdsge_log_diff_arena_size(i64 n, i64 p) {
+  return make_sizer(n * p + p, 0);
+}
 i64 sdsge_log_diff(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
                    const i64 p, f64 *SDSGE_RESTRICT scratch,
                    f64 *SDSGE_RESTRICT out) {
@@ -107,6 +114,9 @@ i64 sdsge_log_diff(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
   return SDSGE_TRANSFORM_SUCCESS;
 }
 
+arena_size sdsge_diff_arena_size(i64 n, i64 p, i64 order) {
+  return make_sizer(n * p + order * p, 0);
+}
 i64 sdsge_diff(const f64 *SDSGE_RESTRICT x, const i64 order, const i64 n,
                const i64 p, f64 *SDSGE_RESTRICT scratch,
                f64 *SDSGE_RESTRICT out) {
@@ -157,6 +167,10 @@ i64 sdsge_diff(const f64 *SDSGE_RESTRICT x, const i64 order, const i64 n,
   return SDSGE_TRANSFORM_SUCCESS;
 }
 
+arena_size sdsge_rolling_mean_arena_size(i64 n, i64 p, i64 window) {
+  (void)window;
+  return make_sizer(n * p + p, 0);
+}
 i64 sdsge_rolling_mean(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                        const i64 window, f64 *SDSGE_RESTRICT scratch,
                        f64 *SDSGE_RESTRICT out) {
@@ -213,6 +227,7 @@ i64 sdsge_rolling_mean(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
  * Welford avoids, so m2 drifts on a long window over a large mean; it is
  * clamped at zero, and callers comparing against a per-window recomputation
  * should expect agreement to a tolerance rather than to the bit. */
+
 static i64 rolling_moment_ax0(const f64 *SDSGE_RESTRICT x, const i64 n,
                               const i64 p, const i64 window, const i64 ddof,
                               const int take_sqrt, f64 *SDSGE_RESTRICT scratch,
@@ -279,15 +294,128 @@ static i64 rolling_moment_ax0(const f64 *SDSGE_RESTRICT x, const i64 n,
 
   return SDSGE_TRANSFORM_SUCCESS;
 }
-
+arena_size sdsge_rolling_var_arena_size(i64 n, i64 p, i64 window) {
+  (void)window;
+  return make_sizer(n * p + 2 * p, 0);
+}
 i64 sdsge_rolling_var(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                       const i64 window, const i64 ddof,
                       f64 *SDSGE_RESTRICT scratch, f64 *SDSGE_RESTRICT out) {
   return rolling_moment_ax0(x, n, p, window, ddof, 0, scratch, out);
 }
 
+arena_size sdsge_rolling_std_arena_size(i64 n, i64 p, i64 window) {
+  (void)window;
+  return make_sizer(n * p + 2 * p, 0);
+}
 i64 sdsge_rolling_std(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                       const i64 window, const i64 ddof,
                       f64 *SDSGE_RESTRICT scratch, f64 *SDSGE_RESTRICT out) {
   return rolling_moment_ax0(x, n, p, window, ddof, 1, scratch, out);
+}
+
+static int sdsge_mc_transform_status(const i64 status,
+                                     i64 *SDSGE_RESTRICT int_out) {
+  if (int_out != NULL) {
+    int_out[0] = status;
+  }
+  return (int)status;
+}
+
+int sdsge_mc_standardize_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_standardize_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_standardize_ax0(
+      float_in_work, config->ddof, config->n, config->p,
+      float_in_work + input_count, float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_log_runner(const i64 rep_idx,
+                        f64 *SDSGE_RESTRICT float_in_work,
+                        f64 *SDSGE_RESTRICT float_out,
+                        i64 *SDSGE_RESTRICT int_work,
+                        i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_log_step_ctx *config = ctx;
+  const i64 status = sdsge_log(float_in_work, config->offset, config->n,
+                               config->p, float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_log_diff_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_log_diff_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_log_diff(float_in_work, config->offset, config->n,
+                                    config->p, float_in_work + input_count,
+                                    float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_diff_runner(const i64 rep_idx,
+                         f64 *SDSGE_RESTRICT float_in_work,
+                         f64 *SDSGE_RESTRICT float_out,
+                         i64 *SDSGE_RESTRICT int_work,
+                         i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_diff_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_diff(float_in_work, config->order, config->n,
+                                config->p, float_in_work + input_count,
+                                float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_rolling_mean_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_rolling_mean_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_rolling_mean(
+      float_in_work, config->n, config->p, config->window,
+      float_in_work + input_count, float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_rolling_var_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_rolling_var_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_rolling_var(
+      float_in_work, config->n, config->p, config->window, config->ddof,
+      float_in_work + input_count, float_out);
+  return sdsge_mc_transform_status(status, int_out);
+}
+
+int sdsge_mc_rolling_std_runner(
+    const i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx) {
+  (void)rep_idx;
+  (void)int_work;
+  const sdsge_mc_rolling_std_step_ctx *config = ctx;
+  const i64 input_count = config->n * config->p;
+  const i64 status = sdsge_rolling_std(
+      float_in_work, config->n, config->p, config->window, config->ddof,
+      float_in_work + input_count, float_out);
+  return sdsge_mc_transform_status(status, int_out);
 }

--- a/SymbolicDSGE/_ckernels/monte_carlo/transforms.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/transforms.h
@@ -2,6 +2,7 @@
 #define SDSGE_MC_TRANSFORMS_H
 
 #include "../_common/sdsge_common.h"
+#include "runner.h"
 
 /* Per-replication sample transforms, mirroring
  * `monte_carlo.operations.transforms.ops`. Every kernel is allocation-free:
@@ -19,44 +20,124 @@
  */
 #define SDSGE_TRANSFORM_BAD_ARG -6
 
+/* Static configuration for future generic native MC transform dispatch.
+ * Dynamic sample data, scratch, and output remain in caller-owned arenas. */
+typedef struct {
+  i64 n;
+  i64 p;
+  i64 ddof;
+} sdsge_mc_standardize_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  f64 offset;
+} sdsge_mc_log_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  f64 offset;
+} sdsge_mc_log_diff_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  i64 order;
+} sdsge_mc_diff_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  i64 window;
+} sdsge_mc_rolling_mean_step_ctx;
+
+typedef struct {
+  i64 n;
+  i64 p;
+  i64 window;
+  i64 ddof;
+} sdsge_mc_rolling_var_step_ctx;
+
+typedef sdsge_mc_rolling_var_step_ctx sdsge_mc_rolling_std_step_ctx;
+
 /* Per-column z-score over axis 0; writes out(n, p). `scratch` is 2*p.
  * Columns whose standard deviation is zero are written as zeros rather than
  * dividing through, matching `run_standardize`. */
+arena_size sdsge_standardize_ax0_arena_size(i64 n, i64 p);
 i64 sdsge_standardize_ax0(const f64 *SDSGE_RESTRICT x, const i64 ddof,
                           const i64 n, const i64 p, f64 *SDSGE_RESTRICT scratch,
                           f64 *SDSGE_RESTRICT out);
 
 /* log(x + offset) elementwise; writes out(n, p). */
+arena_size sdsge_log_arena_size(i64 n, i64 p);
 i64 sdsge_log(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
               const i64 p, f64 *SDSGE_RESTRICT out);
 
 /* One-period log differences down the time axis; writes out(n - 1, p).
  * `scratch` is p. */
+arena_size sdsge_log_diff_arena_size(i64 n, i64 p);
 i64 sdsge_log_diff(const f64 *SDSGE_RESTRICT x, const f64 offset, const i64 n,
                    const i64 p, f64 *SDSGE_RESTRICT scratch,
                    f64 *SDSGE_RESTRICT out);
 
 /* `order`-th difference down the time axis; writes out(n - order, p).
  * `scratch` is order*p. `order` must be at least 1. */
+arena_size sdsge_diff_arena_size(i64 n, i64 p, i64 order);
 i64 sdsge_diff(const f64 *SDSGE_RESTRICT x, const i64 order, const i64 n,
                const i64 p, f64 *SDSGE_RESTRICT scratch,
                f64 *SDSGE_RESTRICT out);
 
 /* Trailing rolling mean; writes out(n - window + 1, p). `scratch` is p. */
+arena_size sdsge_rolling_mean_arena_size(i64 n, i64 p, i64 window);
 i64 sdsge_rolling_mean(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                        const i64 window, f64 *SDSGE_RESTRICT scratch,
                        f64 *SDSGE_RESTRICT out);
 
 /* Trailing rolling variance; writes out(n - window + 1, p). `scratch` is 2*p.
  */
+arena_size sdsge_rolling_var_arena_size(i64 n, i64 p, i64 window);
 i64 sdsge_rolling_var(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                       const i64 window, const i64 ddof,
                       f64 *SDSGE_RESTRICT scratch, f64 *SDSGE_RESTRICT out);
 
 /* Trailing rolling standard deviation; writes out(n - window + 1, p).
  * `scratch` is 2*p. */
+arena_size sdsge_rolling_std_arena_size(i64 n, i64 p, i64 window);
 i64 sdsge_rolling_std(const f64 *SDSGE_RESTRICT x, const i64 n, const i64 p,
                       const i64 window, const i64 ddof,
                       f64 *SDSGE_RESTRICT scratch, f64 *SDSGE_RESTRICT out);
+
+/* Generic-runner adapters. ``float_in_work`` begins with x(n, p), followed by
+ * the transform's scratch span. Each adapter writes its status to ``int_out``
+ * when supplied. */
+int sdsge_mc_standardize_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_log_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                        f64 *SDSGE_RESTRICT float_out,
+                        i64 *SDSGE_RESTRICT int_work,
+                        i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_log_diff_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_diff_runner(i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+                         f64 *SDSGE_RESTRICT float_out,
+                         i64 *SDSGE_RESTRICT int_work,
+                         i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_rolling_mean_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_rolling_var_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
+int sdsge_mc_rolling_std_runner(
+    i64 rep_idx, f64 *SDSGE_RESTRICT float_in_work,
+    f64 *SDSGE_RESTRICT float_out, i64 *SDSGE_RESTRICT int_work,
+    i64 *SDSGE_RESTRICT int_out, const void *ctx);
 
 #endif /* SDSGE_MC_TRANSFORMS_H */


### PR DESCRIPTION
## Summary

- Add the shared `arena_size` contract for caller-owned float and integer workspaces.
- Refactor Kalman and diagnostic kernels to accept caller-owned arenas, and update their Cython callers and estimation contexts.
- Add generic native Monte Carlo step descriptors and immutable context structs.
- Add runner adapters for data generation, payloads, filters, transforms, diagnostics, and regressions.
- Define flat per-replication output layouts and status channels for native Monte Carlo steps.

closes #367