### PR TITLE
Refine documentation and enhance native lowering tests and coverage

### DIFF
--- a/.github/workflows/tests-and-badges.yml
+++ b/.github/workflows/tests-and-badges.yml
@@ -115,7 +115,7 @@ jobs:
           if [ "$SR_CHANGED" != "true" ]; then
             PYTEST_MARKERS=(-m "not sr")
           fi
-          uv run pytest -q ./tests "${PYTEST_MARKERS[@]}" -n auto --dist loadgroup --cov --cov-report=term-missing --cov-report=xml:coverage/coverage.xml
+          uv run pytest -q ./tests "${PYTEST_MARKERS[@]}" -n auto --dist loadgroup --cov --cov-report=
           EXIT=$?
           set -e
           # juliacall's C-extension finalizers can segfault during interpreter
@@ -128,6 +128,27 @@ jobs:
             exit 0
           fi
           exit "$EXIT"
+
+      - name: Report coverage
+        if: always()
+        shell: bash
+        env:
+          SR_CHANGED: ${{ steps.sr_diff.outputs.sr_changed }}
+        run: |
+          if [ ! -f .coverage ]; then
+            echo "No coverage data written; skipping report."
+            exit 0
+          fi
+          mkdir -p coverage
+          # Deselected sr tests leave the sr package at 0%, so drop it from the
+          # figure rather than counting statements this run never measured.
+          COV_OMIT=()
+          if [ "$SR_CHANGED" != "true" ]; then
+            COV_OMIT=(--omit 'SymbolicDSGE/regression/sr/*')
+            echo "::notice::SR tests deselected; sr excluded from the coverage figure."
+          fi
+          uv run coverage report --show-missing "${COV_OMIT[@]}"
+          uv run coverage xml -o coverage/coverage.xml "${COV_OMIT[@]}"
 
       - name: Compute coverage percent
         id: cov

--- a/SymbolicDSGE/_ckernels/_common/sdsge_bicomplex.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_bicomplex.h
@@ -126,13 +126,9 @@ static inline bc256 bc256_cpow(const bc256 x, const bc256 y) {
   return bc256_reconst(c128_cpow(px1, py1), c128_cpow(px2, py2));
 }
 
-/* Principal square root via the direct in-slot solve of w^2 = x (x = z1 + z2 j):
+/* Principal square root of x = z1 + z2 j, solved in slot:
  *   w1 = sqrt((z1 + sqrt(z1^2 + z2^2)) / 2),   w2 = z2 / (2 w1).
- * Unlike the idempotent transcendentals this is cancellation-free on a
- * perturbation (the ij component comes out of a division, not a subtraction of
- * near-equal O(1) values). Assumes a positive-real-dominant base -- i.e. the
- * only place a real sqrt is meaningful; w1 = 0 (sqrt of a negative real) is
- * outside that domain. */
+ * Requires a positive-real-dominant base; w1 = 0 is outside the domain. */
 static inline bc256 bc256_sqrt(const bc256 x) {
   const c128 s =
       c128_sqrt(c128_add(c128_mul(x.a, x.a), c128_mul(x.b, x.b)));

--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -4,17 +4,12 @@
 #include <math.h>
 #include <stdint.h>
 
-/* Shared low-level definitions for SymbolicDSGE native kernels.
- *
- * Numeric primitives reused across subsystems (matmul, cholesky, triangular
- * solves, dot products) will live alongside this header in sdsge_linalg.{c,h}
- * once the kalman port lands. Everything here is plain C operating on f64*
+/* Shared low-level definitions for SymbolicDSGE native kernels. Plain C on f64*
  * buffers; no CPython or NumPy API. */
 
-/* Architecture-agnostic numeric types. Use these everywhere instead of bare
- * `long`/`int`/`double` so width and indexing semantics are identical across
- * the whole wheel matrix; notably `long` is 32-bit on Windows (LLP64) but
- * 64-bit on Linux/macOS (LP64). All counts and indices are i64. */
+/* Architecture-agnostic numeric types. Use these instead of bare
+ * `long`/`int`/`double`: `long` is 32-bit on Windows (LLP64) and 64-bit
+ * elsewhere (LP64). All counts and indices are i64. */
 typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;
@@ -26,17 +21,12 @@ typedef uint64_t u64;
 typedef float f32;
 typedef double f64;
 
-/* 2*pi as the nearest IEEE-754 double (== 2.0 * numpy's pi, exactly); shared by
- * the kalman / distribution / transform kernels. */
+/* Nearest IEEE-754 doubles; TWO_PI is exactly 2.0 * numpy's pi. */
 #define TWO_PI 6.283185307179586
 #define PI 3.141592653589793
 #define SQRT2 1.4142135623730951
 
-/* Shared status codes for the dense linear-algebra primitives in sdsge_linalg.
- * Subsystems map these onto their own error conventions (e.g. the kalman hot
- * loop translates SDSGE_NOT_PD -> KF_ERR_MATRIX_CONDITION; the diag kernels
- * turn it into a DIAG_FALLBACK request). SDSGE_OK is 0 so it coincides with
- * KF_OK. */
+/* Status codes for the sdsge_linalg primitives. */
 #define SDSGE_OK 0
 #define SDSGE_NOT_PD -1
 
@@ -56,8 +46,7 @@ static inline arena_size make_sizer(i64 n_float, i64 n_int) {
   return (arena_size){.n_float = n_float, .n_int = n_int};
 }
 
-/* Portable `restrict` qualifier (C99 `restrict` is not in C++ and is spelled
- * differently by MSVC). */
+/* Portable `restrict`. */
 #if defined(__GNUC__) || defined(__clang__)
 #define SDSGE_RESTRICT __restrict__
 #elif defined(_MSC_VER)

--- a/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_linalg.h
@@ -3,13 +3,9 @@
 
 #include "sdsge_common.h"
 
-/* Dense linear-algebra primitives shared across the native subsystems. These
- * were first written for the kalman hot loop (as the `kf_*` kernels) and are
- * now promoted here so the regression / diagnostic kernels reuse them.
- * Everything is plain C on C-contiguous, row-major f64 buffers; no CPython, no
- * NumPy, no BLAS (matrices are small and we keep bit-parity with the numba
- * reference). Buffers are caller-allocated and never alias unless a function
- * documents otherwise. */
+/* Dense linear-algebra primitives shared across the native subsystems. Plain C
+ * on C-contiguous, row-major f64 buffers; no CPython, NumPy, or BLAS. Buffers
+ * are caller-allocated and never alias unless a function documents otherwise. */
 
 /* out(r,c) := 0 */
 void sdsge_zero_mat(f64 *out, i64 r, i64 c);
@@ -20,12 +16,8 @@ void sdsge_sym_inplace(f64 *P, i64 n);
 /* out(n,m) := A(n,p) @ B(p,m) */
 void sdsge_matmul(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p, i64 m);
 
-/* out(p,m) := A(n,p)^T @ B(n,m). The transpose is folded into the indexing (no
- * materialized A^T); contraction is over the row axis, accumulated row-by-row
- * like sdsge_gram (of which this is the asymmetric generalization: matmul_atb
- * of X with itself equals the full gram of X). `out` must not alias A or B, but
- * A and B may overlap each other -- both are read-only, so e.g. lagged views of
- * one buffer (A = M, B = M + j*cols) are fine. */
+/* out(p,m) := A(n,p)^T @ B(n,m). `out` must not alias A or B; A and B may
+ * overlap each other (e.g. lagged views of one buffer). */
 void sdsge_matmul_atb(const f64 *A, const f64 *B, f64 *out, i64 n, i64 p,
                       i64 m);
 
@@ -77,7 +69,7 @@ void sdsge_gram_rhs(const f64 *X, const f64 *y, f64 *g, i64 n, i64 p);
 
 /* Solve the SPD system G(p,p) coef = g(p) via Cholesky. coef(p) is the output
  * (may alias g); scratch_L(p,p) holds the factor. Returns SDSGE_OK or
- * SDSGE_NOT_PD (G not positive definite -- caller falls back to lstsq). */
+ * SDSGE_NOT_PD. */
 int sdsge_chol_solve(const f64 *G, const f64 *g, f64 *coef, f64 *scratch_L,
                      i64 p);
 

--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -1,9 +1,9 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Cython shim mapping NumPy buffers to the pure-C core kernels.
 
-No numeric logic here -- only the buffer->pointer marshalling and the GIL
-release. The algorithms live in core.c. At the ABI level the kernels' f64/i64
-are exactly double/int64_t, so the extern is declared with those.
+Buffer to pointer marshalling and the GIL release only; the algorithms live in
+core.c. The kernels' f64/i64 are exactly double/int64_t, so the externs are
+declared with those.
 """
 
 from libc.stdint cimport int64_t
@@ -458,7 +458,7 @@ def steady_state_newton(
 
 
 def second_order(a, b, f_xx, gx, hx, int64_t n_state):
-    """SGU second-order tensors ``(gxx, hxx)`` -- native transcription of
+    """SGU second-order tensors ``(gxx, hxx)``. Parity oracle:
     ``core.second_order.solve_second_order``. ``a``/``b`` are the first-order
     pencil ``(n, n)``, ``f_xx`` the residual Hessian ``(n, 2n, 2n)``, ``gx``
     ``(ny, nx)``, ``hx`` ``(nx, nx)``. Returns ``gxx (ny, nx, nx)``,
@@ -497,7 +497,7 @@ def second_order(a, b, f_xx, gx, hx, int64_t n_state):
 
 
 def second_order_risk(a, b, f_xx, gx, gxx, eta, int64_t n_state):
-    """Sigma^2 risk correction ``(gss, hss)`` -- native transcription of
+    """Sigma^2 risk correction ``(gss, hss)``. Parity oracle:
     ``core.second_order.solve_second_order_risk``. ``gxx`` is the second-order
     controls ``(ny, nx, nx)``; ``eta`` the shock loading ``(nx, ne)``. Returns
     ``gss (ny,)``, ``hss (nx,)``. Inputs coerced to C-contiguous f64.
@@ -538,7 +538,7 @@ def second_order_risk(a, b, f_xx, gx, gxx, eta, int64_t n_state):
 def residual_path(size_t residual_addr, cur_states, fwd_states, params, int64_t n_eq):
     """Real residual matrix ``(n_steps, n_eq)`` from a residual @cfunc
     (``build_cfunc``) evaluated over a simulated path. Native backend for the
-    Den Haan-Marcet moment builder -- reuses the solve's cfunc, so it never
+    Den Haan-Marcet moment builder, reusing the solve's cfunc so it never
     triggers the numba residual compile. Inputs are coerced to contiguous
     complex128 here.
     """
@@ -628,7 +628,7 @@ def measurement_path(size_t meas_addr, states, par, int64_t n_obs):
 def residual_eval(size_t residual_addr, fwd, cur, params, int64_t n_eq):
     """Complex residual vector ``F(fwd, cur, par)`` of length ``n_eq`` from a
     residual @cfunc (``build_cfunc``) given its ``.address``. Single-point native
-    evaluation -- the path ``CompiledModel.equations`` takes instead of the numba
+    evaluation, the path ``CompiledModel.equations`` takes instead of the numba
     vector kernel. Inputs are coerced to contiguous complex128 here.
     """
     cdef double complex[::1] fwdv = np.ascontiguousarray(

--- a/SymbolicDSGE/_ckernels/core/bicomplex_hessian.h
+++ b/SymbolicDSGE/_ckernels/core/bicomplex_hessian.h
@@ -9,10 +9,9 @@
  * over bc256 buffers (each bc256 == complex128[2], the cfunc's per-element view).
  *
  * z = (fwd, cur) stacked, 2*n_var wide. Perturbing z_i on the i-unit (a.im) and
- * z_j on the j-unit (b.re) -- both units on the same variable when i == j -- the
- * residual's ij component (b.im) / h^2 is d^2 F / dz_i dz_j. The driver only
- * constructs perturbations and extracts the ij component; the bicomplex
- * arithmetic lives in the numba cfunc.
+ * z_j on the j-unit (b.re), both units landing on one variable when i == j, the
+ * residual's ij component (b.im) / h^2 is d^2 F / dz_i dz_j. The bicomplex
+ * arithmetic itself lives in the numba cfunc.
  *
  * `hessian` is (n_eq, 2*n_var, 2*n_var) row-major f64, symmetric in the last
  * two. Levels only (no log-linear wrapping at order > 1). */

--- a/SymbolicDSGE/_ckernels/core/klein_postproc.h
+++ b/SymbolicDSGE/_ckernels/core/klein_postproc.h
@@ -13,10 +13,6 @@ i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
 #define SDSGE_KLEIN_POSTPROC_SINGULAR -2
 #define SDSGE_KLEIN_POSTPROC_INVALID -3
 
-/* stab sentinel: klein_postproc stamps this into *stab up front, so any
- * early-return failure path (singular z11, alloc failure, no states) leaves a
- * non-zero (= undetermined / not-stable) value rather than a stale one, for a
- * caller that reads stab without inspecting the return code. It is overwritten
- * with the real 0 / -1 / +1 result only on the successful path. */
+/* Stamped into *stab up front; 2 is not a stability status the solve returns. */
 #define SDSGE_KLEIN_STAB_UNSET 2
 #endif /* SDSGE_KLEIN_POSTPROC_H */

--- a/SymbolicDSGE/_ckernels/core/residual_path.h
+++ b/SymbolicDSGE/_ckernels/core/residual_path.h
@@ -4,9 +4,7 @@
 
 /* Evaluate the model residual @cfunc over a simulated path. For each step t,
  * calls resid(&fwd[t], &cur[t], par, out) and stores Re(out[k]) into
- * residuals[t*n_eq + k]. Lets the Den Haan-Marcet diagnostic build its moment
- * conditions from the same native residual the solve uses, instead of the numba
- * vector residual. States/params are complex128 (real values, zero imaginary). */
+ * residuals[t*n_eq + k]. States/params are complex128 (real, zero imaginary). */
 i64 sdsge_residual_path(sdsge_residual_fn resid, const c128 *SDSGE_RESTRICT cur,
                         const c128 *SDSGE_RESTRICT fwd,
                         const c128 *SDSGE_RESTRICT par, i64 n_steps, i64 n_var,

--- a/SymbolicDSGE/_ckernels/core/second_order.h
+++ b/SymbolicDSGE/_ckernels/core/second_order.h
@@ -4,10 +4,7 @@
 #include "../_common/sdsge_common.h"
 
 /* Second-order (SGU) policy tensors from the first-order solution and the
- * residual Hessian. Native transcription of
- * core.second_order.solve_second_order (row-major, allocation-free inner loop):
- * builds the symmetry-reduced linear system big_q @ sym, solves it with the f64
- * LU, and expands via sym.
+ * residual Hessian. Parity oracle: core.second_order.solve_second_order.
  *
  * Inputs (all C-contiguous, row-major, f64), with n = n_var = n_eq (square) and
  * ny = n - nx:
@@ -27,17 +24,17 @@ i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
                        const f64 *SDSGE_RESTRICT hx, const i64 n, const i64 nx,
                        f64 *SDSGE_RESTRICT gxx, f64 *SDSGE_RESTRICT hxx);
 
-/* Sigma^2 risk correction (g_ss, h_ss). Native transcription of
- * core.second_order.solve_second_order_risk. Only the forward-forward Hessian
- * blocks enter. Inputs as above plus:
+/* Sigma^2 risk correction (g_ss, h_ss). Parity oracle:
+ * core.second_order.solve_second_order_risk. Inputs as above plus:
  *   gxx  (ny, nx, nx)  second-order controls (from sdsge_second_order)
  *   eta  (nx, ne)      shock loading (eta @ eta^T = state innovation
  * covariance)
  *
  * Outputs:
  * gss (ny,) controls risk correction
- * hss  (nx,) states risk correction Solves the (n, n) system [Qg Qh] [gss; hss]
- * = -q. Same return codes. */
+ * hss (nx,) states risk correction
+ *
+ * Same return codes. */
 i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
                             const f64 *SDSGE_RESTRICT b,
                             const f64 *SDSGE_RESTRICT f_xx,

--- a/SymbolicDSGE/_ckernels/core/spike.h
+++ b/SymbolicDSGE/_ckernels/core/spike.h
@@ -10,10 +10,10 @@
  *   - a numba @cfunc is callable from native code by pointer,
  *   - with the GIL released,
  *   - without numba's runtime (NRT) being reachable inside the call.
- * The whole preproc design depends on this holding, so tests/ckernels/test_spike.py
- * exercises it across the wheel platform matrix -- on demand via the "cfunc ABI"
- * workflow (.github/workflows/cfunc-abi.yml) and again on each wheel build via
- * cibuildwheel's per-platform test-command. Keep it. */
+ * The whole preproc design depends on this holding. tests/ckernels/test_spike.py
+ * exercises it across the wheel platform matrix, via
+ * .github/workflows/cfunc-abi.yml and cibuildwheel's per-platform
+ * test-command. Keep it. */
 
 typedef void (*spike_residual_fn)(const c128 *a, const c128 *b, c128 *out, i64 n);
 

--- a/SymbolicDSGE/_ckernels/diag/_diag.pyx
+++ b/SymbolicDSGE/_ckernels/diag/_diag.pyx
@@ -1,11 +1,10 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Cython shim mapping NumPy buffers to the pure-C diagnostic-test kernels.
 
-No numeric logic here -- only buffer->pointer marshalling and the GIL release.
-The algorithms live in diag.c. Each ``def`` mirrors the matching numba kernel in
-SymbolicDSGE/_diag_tests/ and returns the same (status, ...) tuple shape. A
-status of ``DIAG_FALLBACK`` means the design was rank-deficient and the caller
-must re-run the whole statistic via numba (which has the lstsq/SVD fallback).
+Buffer to pointer marshalling and the GIL release only; the algorithms live in
+diag.c. Each ``def`` returns the same (status, ...) tuple shape as its parity
+oracle in SymbolicDSGE/_diag_tests/. A ``DIAG_FALLBACK`` status means the design
+was rank-deficient and the caller must re-run the statistic via numba.
 """
 
 import numpy as np
@@ -314,9 +313,8 @@ def lb_stat(x, int64_t L):
 def hac_estimator_matmul(r, int kernel_id, int64_t L):
     """HAC long-run covariance (Gamma_0 + sum_j w_j(Gamma_j + Gamma_j')) / n.
 
-    Full-estimator parity with the numba ``jit_hac_estimator_matmul``: same
-    inputs (centered moment array, integer kernel id, bandwidth) and the same
-    (p, p) output -- no separate Gamma_0/scaling codepath on the caller side.
+    Parity oracle: the numba ``jit_hac_estimator_matmul``, same inputs (centered
+    moment array, integer kernel id, bandwidth) and the same (p, p) output.
     """
     cdef double[:, ::1] r_mv = np.ascontiguousarray(r, dtype=np.float64)
     cdef int64_t n = r_mv.shape[0]

--- a/SymbolicDSGE/_ckernels/diag/diag.h
+++ b/SymbolicDSGE/_ckernels/diag/diag.h
@@ -8,13 +8,10 @@
  * Chow, Brown-Durbin-Evans recursive residuals). Each mirrors the numba kernel
  * in SymbolicDSGE/_diag_tests/. All matrices are C-contiguous, row-major, f64.
  *
- * Error/status convention: the full-rank fast path (Cholesky on the normal
- * equations) runs entirely here. The negative codes below mirror the Python
- * TestStatus IntEnum exactly, so the Cython shim returns them verbatim.
- * DIAG_FALLBACK is the one extra value: it means "the design is rank-deficient,
- * the Cholesky path can't proceed -- re-run the whole statistic via the numba
- * kernel (which has the SVD-based lstsq fallback)". There is deliberately no
- * lstsq/SVD in C; this keeps the native side LAPACK-free. */
+ * The negative codes below mirror the Python TestStatus IntEnum, so the Cython
+ * shim returns them verbatim. DIAG_FALLBACK is the extra value: the design is
+ * rank-deficient and the caller must re-run the statistic via the numba kernel,
+ * which has the SVD-based lstsq path this side does not. */
 
 #define DIAG_OK 0
 #define DIAG_BAD_SHAPE -1

--- a/SymbolicDSGE/_ckernels/diag/diag_cusum.h
+++ b/SymbolicDSGE/_ckernels/diag/diag_cusum.h
@@ -4,19 +4,12 @@
 #include "../_common/sdsge_common.h"
 
 /* Durbin (1969) reference distribution for the recursive-residual CUSUM
- * statistic. The test is parameter-free: the boundary-crossing probability is a
- * closed form of the statistic itself, so the survival function is a closed form
- * of the statistic. Mirrors the numba CusumDist kernels in
- * SymbolicDSGE/_diag_tests/cusum.py.
+ * statistic, a parameter-free closed form. Parity oracle: the numba CusumDist
+ * kernels in SymbolicDSGE/_diag_tests/cusum.py. The recursion/series/stat
+ * kernels live in diag.c; this file is the p-value layer only.
  *
- * The recursion/series/stat kernels for CUSUM live in diag.c; this file holds
- * only the reference-distribution (p-value) layer.
- *
- * The raw Durbin form (2*(Phi_sf(2a) + exp(-4 a^2) Phi_cdf(a))) can exceed 1 for
- * small statistics, so the survival function is clamped to <= 1 here in C -- the
- * clamp is the whole reason CusumDist.sf existed as a Python wrapper, and it
- * belongs on the native side. The isf Newton solve (once ported) will re-expose
- * the unclamped monotone form it needs. */
+ * The raw Durbin form (2*(Phi_sf(2a) + exp(-4 a^2) Phi_cdf(a))) exceeds 1 for
+ * small statistics, so the survival function is clamped to <= 1. */
 
 /* Clamped Durbin survival function of the CUSUM statistic ``a`` (a >= 0). */
 f64 sdsge_cusum_sf(f64 a);

--- a/SymbolicDSGE/_ckernels/diag/jb_lookup.h
+++ b/SymbolicDSGE/_ckernels/diag/jb_lookup.h
@@ -5,19 +5,8 @@
 
 /* Small-N Jarque-Bera reference distribution: table lookup + bilinear
  * interpolation over the Wuertz-Keller (2004) finite-sample critical-value
- * grid. Mirrors the numba kernels that used to live in
- * SymbolicDSGE/_diag_tests/jb_lookup.py.
- *
- * The (constant) N grid, p-value grid, and critical-value matrix are compiled
- * in as static const tables in jb_lookup.c; the Python module keeps its own
- * numpy copies purely for the distribution's small-N boundary check and the
- * parity tests. There is no rank-deficiency / fallback path here: the kernels
- * are pure interpolation, so the Python side is hard-native (no numba mirror).
- *
- * ``isf`` maps (n, p) -> critical value; ``pval`` maps (n, x) -> p-value. Each
- * has a scalar and an ``_into`` array form. The ``find_hilo`` helpers are the
- * bracketing primitives (ascending grid / descending critical-value column),
- * exposed so the parity tests can pin them directly. */
+ * grid, whose N grid, p-value grid, and critical-value matrix are static const
+ * tables in jb_lookup.c. Parity oracle: SymbolicDSGE/_diag_tests/jb_lookup.py. */
 
 /* Bracket ``val`` in the ascending array ``arr`` (length n). Writes the pair of
  * indices (lo, hi): (0,0) below the grid, (n-1,n-1) above it, (idx,idx) on an

--- a/SymbolicDSGE/_ckernels/distributions/_distributions.pyx
+++ b/SymbolicDSGE/_ckernels/distributions/_distributions.pyx
@@ -1,15 +1,13 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Cython shim for the native distribution kernels.
 
-No numeric logic here -- only argument marshalling and the C call. The numba
-references now live in the test oracles (tests/_oracles/distributions.py), so
-this is the sole production path and the parity tests pin them together.
+Argument marshalling and the C call only. Parity oracle:
+tests/_oracles/distributions.py.
 
 ``ndtri_as241`` / ``erfinv_from_as241`` are the Wichura AS 241 inverse-normal
-primitives from ``_common/as241.c``. The vectorized ``ndtri_as241_into`` owns its
-own casting: it takes an untyped array, forces a C-contiguous float64 copy, and
-returns a new array shaped like the input. The precise NumPy types live in the
-``.pyi`` stub, not the signature.
+primitives from ``_common/as241.c``. The vectorized ``ndtri_as241_into`` takes
+an untyped array, forces a C-contiguous float64 copy, and returns a new array
+shaped like the input; its precise NumPy types are in the ``.pyi`` stub.
 """
 
 import numpy as np

--- a/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
@@ -1469,12 +1469,12 @@ cdef class NativeLogpost:
     """Single-eval handle over a built native objective context.
 
     ``logpost(theta)`` / ``loglik(theta)`` return the native objective at
-    ``theta`` -- the exact value run_mcmc / run_estimation evaluate per step
+    ``theta``, the exact value run_mcmc / run_estimation evaluate per step
     (``+logpost`` / ``+loglik`` form; ``-inf`` on a BK or non-finite solve). The
-    ctx is marshalled once at construction; each call re-solves at ``theta``. This
-    is the seam parity tests use to drive a Python reference chain through the
-    SAME objective the native loop uses, isolating loop mechanics from the
-    objective; it is not the estimation hot path."""
+    ctx is marshalled once at construction and each call re-solves at ``theta``.
+
+    This is the seam parity tests drive a Python reference chain through, not
+    the estimation hot path."""
     cdef _NativeCtx nc
     cdef str mode
 

--- a/SymbolicDSGE/_ckernels/estimation/_prior_program.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_prior_program.pyx
@@ -1,12 +1,11 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Cython shim for the native packed log-prior kernels.
 
-No numeric logic here -- only buffer->pointer marshalling and the GIL release.
-The algorithms live in prior_program.c; each ``def`` mirrors the matching numba
-helper in SymbolicDSGE/estimation/prior_program.py. The leaves are exposed so the
-parity tests can hit them directly; ``logprior_program`` is the per-replication
-hot path the estimator dispatches to. A NaN result means "fall back to the numba
-path" (out-of-support / unknown code), matching the numba kernel.
+Buffer to pointer marshalling and the GIL release only; the algorithms live in
+prior_program.c. Parity oracle: SymbolicDSGE/estimation/prior_program.py.
+``logprior_program`` is the per-replication hot path; the leaves are exposed for
+the parity tests. A NaN result means out-of-support or an unknown code, and the
+caller falls back to the numba path.
 """
 
 from libc.stdint cimport int64_t

--- a/SymbolicDSGE/_ckernels/estimation/prior_program.h
+++ b/SymbolicDSGE/_ckernels/estimation/prior_program.h
@@ -4,14 +4,10 @@
 #include "../_common/sdsge_common.h"
 #include "../_common/sdsge_linalg.h"
 
-/* Integer dispatch codes for the packed log-prior kernel.
- *
- * These MUST stay in lockstep with the DistCode / TransformCode IntEnums in
- * prior_program.py (same names, same values): the Python side packs every prior
- * into int64 code arrays keyed by these values, and the native kernel switches
- * on them. SDSGE_N_*_PARAMS are the packed-row strides (N_DIST_PARAMS /
- * N_TRANSFORM_PARAMS in that module). Plain integer enums -- no CPython, no
- * NumPy -- so the kernel can include this header directly. */
+/* Integer dispatch codes for the packed log-prior kernel. These MUST stay in
+ * lockstep with the DistCode / TransformCode IntEnums in prior_program.py (same
+ * names, same values), which is what the Python side packs its int64 code
+ * arrays with. */
 
 typedef enum {
   SDSGE_DIST_NORMAL = 1,

--- a/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
+++ b/SymbolicDSGE/_ckernels/kalman/_kalman.pyx
@@ -310,7 +310,7 @@ def ekf_hot_loop(
     measurement via the ``meas``/``jac`` @cfunc addresses).
 
     ``meas_addr``/``jac_addr`` are real-valued @cfunc addresses with signature
-    ``void(double* x, double* params, double* out)`` -- ``meas`` writes
+    ``void(double* x, double* params, double* out)``: ``meas`` writes
     ``out[m]``, ``jac`` writes the (m, n) row-major jacobian. Array inputs are
     coerced to contiguous float64 here. Returns ``(status, out)`` with the
     history tuple + loglik; the caller maps a nonzero status to the matching

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -13,14 +13,13 @@
 #define KF_ERR_SINGULAR_MATRIX -4
 #define KF_ERR_ALLOC -5
 
-/* Kalman hot-loop helpers ported from the numba `*_into` kernels in
+/* Kalman hot-loop helpers. Parity oracle: the numba `*_into` kernels in
  * SymbolicDSGE/kalman/filter.py. All matrices are C-contiguous, row-major, f64.
  * Buffers are caller-allocated; nothing here aliases (inputs and outputs are
- * always distinct). The dense linear-algebra primitives these build on
- * (sdsge_matmul, sdsge_chol, sdsge_*subst, sdsge_dot, ...) now live in
- * _common/sdsge_linalg so the regression / diagnostic kernels share them. */
+ * always distinct). The dense primitives these build on are in
+ * _common/sdsge_linalg. */
 
-/* -- Kalman-specific dense helpers (not general enough for sdsge_linalg) -- */
+/* Kalman-specific dense helpers. */
 
 /* out(m) := A[row, :] - x(m), where A has m columns */
 void kf_row_minus_vec(const f64 *A, i64 row, const f64 *x, f64 *out, i64 m);

--- a/SymbolicDSGE/_ckernels/monte_carlo/_arena.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_arena.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Native Monte Carlo arena-size boundary.
 
-Python's pipeline compiler owns shape resolution.  This module exposes the C
+Python's pipeline compiler owns shape resolution. This module exposes the C
 arena sizers so its allocation plan always follows the native kernel contract.
 """
 

--- a/SymbolicDSGE/_ckernels/monte_carlo/_arenas.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_arenas.pyx
@@ -1,9 +1,9 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Dynamic arena allocation for compiled Monte Carlo buffer plans.
 
-The Python planner resolves lane sizes and output layouts.  This module turns
-that plan and a run's ``n_rep`` into the contiguous NumPy arrays owned by a
-future native runner.  Step-context lowering supplies static data separately.
+The Python planner resolves lane sizes and output layouts. This module turns
+that plan and a run's ``n_rep`` into the contiguous NumPy arrays the native
+runner executes over. Step-context lowering supplies static data separately.
 """
 
 import os

--- a/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_regression.pyx
@@ -1,11 +1,7 @@
-
-
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Python shim for native Monte Carlo regression kernels.
 
-The caller owns result and solver-work buffers. The eventual native MC
-executor can use the same ABI with its preallocated trace rows and scratch
-space.
+The caller owns the result and solver-work buffers.
 """
 
 from libc.stdint cimport int64_t

--- a/SymbolicDSGE/_ckernels/monte_carlo/_transforms.pyx
+++ b/SymbolicDSGE/_ckernels/monte_carlo/_transforms.pyx
@@ -2,20 +2,18 @@
 """Thin Cython shim mapping NumPy buffers to the pure-C Monte Carlo transform
 kernels.
 
-No numeric logic here -- only buffer->pointer marshalling, scratch allocation,
-and the GIL release. The algorithms live in transforms.c. Each ``def`` mirrors
-the matching Python op in
-``SymbolicDSGE/monte_carlo/step_factories.py`` and returns the same
-array shape, including the row counts that shrink with ``order`` or ``window``.
+Buffer to pointer marshalling, scratch allocation, and the GIL release only;
+the algorithms live in transforms.c. Each ``def`` returns the same array shape
+as its counterpart in ``SymbolicDSGE/monte_carlo/step_factories.py``, including
+the row counts that shrink with ``order`` or ``window``.
 
 Arguments a kernel is not defined on (a window wider than the sample, a
-non-positive order, a ddof that empties the denominator) are screened here and
-raised as ``ValueError`` naming the offending pair, so the messages match the
-ones the pure-Python ops raised. ``SDSGE_TRANSFORM_BAD_ARG`` coming back from a
-kernel anyway is a backstop, not the usual path.
+non-positive order, a ddof that empties the denominator) raise ``ValueError``
+here, naming the offending pair. ``SDSGE_TRANSFORM_BAD_ARG`` coming back from a
+kernel is a backstop, not the usual path.
 
-Scratch is allocated per call here: the native replication loop calls the C
-entry points directly and owns its buffers.
+Scratch is allocated per call. The native replication loop bypasses this module
+and owns its own buffers.
 """
 
 import numpy as np

--- a/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/core_steps.h
@@ -7,8 +7,8 @@
 #include "runner.h"
 #include "shocks.h"
 
-/* Static configuration for future generic native MC step dispatch. Dynamic
- * numeric inputs, scratch, and outputs remain in caller-owned arenas. */
+/* Static configuration for generic native MC step dispatch. Dynamic numeric
+ * inputs, scratch, and outputs live in caller-owned arenas. */
 typedef struct {
   const f64 *input;
   i64 n;

--- a/SymbolicDSGE/_ckernels/monte_carlo/runner.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/runner.h
@@ -67,9 +67,7 @@ typedef struct {
 
 /* ``SDSGE_MC_NOT_RUN`` marks failure-lane entries and integer retained
  * outputs for replications that failed or were skipped by a fail-fast halt.
- * Float retained outputs for the same rows are set to NAN. This prevents
- * NumPy's uninitialized ``empty`` allocations from being observable after the
- * run returns. */
+ * Float retained outputs for the same rows are set to NAN. */
 #define SDSGE_MC_NOT_RUN INT64_MIN
 #define SDSGE_MC_RUN_OK 0
 #define SDSGE_MC_RUN_HALTED 1
@@ -84,8 +82,7 @@ typedef struct {
  * Before returning, the runner sets every retained row belonging to a failed
  * or unfinished replication to defined sentinels. When ``profile_steps`` is
  * nonzero, each profiling array has ``n_workers * n_steps`` entries in
- * worker-major order. The runner clears and writes only the executing
- * worker's row, so profiling adds no synchronization to the hot loop. */
+ * worker-major order, and only the executing worker's row is written. */
 
 typedef struct {
   const sdsge_mc_step_desc *steps;

--- a/SymbolicDSGE/_ckernels/monte_carlo/shocks.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/shocks.h
@@ -4,40 +4,22 @@
 #include "../_common/sdsge_common.h"
 
 /* Per-replication shock draw, executed inside the MC hot loop (issue #374).
+ * Draws into a (T, n_exog) block in the step's own arena, via the Philox engine
+ * in ../rng/philox.h, keyed so a replication's draw depends only on `rep_idx`.
  *
- * Shocks used to be materialized in Python before the loop: one numpy
- * Generator constructed per replication per entry, drawn into a
- * (n_rep, T, n_exog) slab that the runner then streamed row by row. At 100k
- * replications that Python prep cost as much as the entire native loop, and
- * the slab alone ran to hundreds of megabytes.
- *
- * Drawing here instead makes the cost O(1) in Python and replaces the slab
- * with a (T, n_exog) block in the step's own arena. The engine is the
- * counter-based Philox in ../rng/philox.h, keyed so that a replication's draw
- * depends only on `rep_idx`: identical no matter which worker runs it, how
- * many workers there are, or in what order they are scheduled.
- *
- * Not every spec can be drawn natively. Student-t, arbitrary scipy
- * distribution objects, user callables, and literal arrays stay on the Python
- * prematerialization route, which the lowering selects when any entry is not
- * representable here. */
+ * Student-t, scipy distribution objects, user callables, and literal arrays are
+ * not representable here; lowering routes such specs to Python
+ * prematerialization instead. */
 
 #define SDSGE_MC_SHOCK_NORMAL 0
 #define SDSGE_MC_SHOCK_UNIFORM 1
 
-/* One resolved entry of a shock spec.
- *
- * `columns` names the exogenous columns this entry drives, in the canonical
- * order its factor was built in. A univariate entry is just the width-1 case:
- * its `factor` is the 1x1 matrix holding the standard deviation, so normal
- * draws take one code path regardless of width.
- *
- * `key` is the spec's own seed and `entry_idx` its position in the spec. The
- * latter is what keeps two entries that happen to share a seed on independent
- * streams. */
+/* One resolved entry of a shock spec. A univariate entry is the width-1 case,
+ * its `factor` the 1x1 standard deviation. */
 typedef struct {
   int family;
   i64 width;
+  /* width-long, the exogenous columns this entry drives, in factor order. */
   const i64 *columns;
   /* width x width, row-major, with factor @ factor.T == cov. Normal only. */
   const f64 *factor;
@@ -46,12 +28,12 @@ typedef struct {
   /* Uniform only: draws land in [low, low + span). */
   f64 low;
   f64 span;
-  u64 key;
+  u64 key; /* the spec's seed; entry_idx separates entries sharing one. */
   u64 entry_idx;
 } sdsge_mc_shock_entry;
 
 /* A whole spec, resolved once at lowering and shared read-only by every
- * worker. `max_width` sizes the scratch the draw needs. */
+ * worker. */
 typedef struct {
   const sdsge_mc_shock_entry *entries;
   i64 n_entries;
@@ -65,11 +47,9 @@ typedef struct {
 i64 sdsge_mc_shock_scratch_size(const sdsge_mc_shock_plan *plan);
 
 /* Draw replication `rep_idx` into `out`, a (T, n_exog) row-major block.
- *
- * Columns no entry targets are zeroed, so `out` needs no preparation by the
- * caller. `scratch` must hold at least `sdsge_mc_shock_scratch_size(plan)`
- * elements and is caller-owned, which keeps this function allocation-free and
- * therefore safe to call from every worker concurrently. */
+ * Untargeted columns are zeroed, so `out` needs no preparation. `scratch` is
+ * caller-owned and holds at least `sdsge_mc_shock_scratch_size(plan)` elements;
+ * this allocates nothing and is safe to call from every worker concurrently. */
 void sdsge_mc_shock_draw(const sdsge_mc_shock_plan *plan, i64 rep_idx,
                          f64 *SDSGE_RESTRICT scratch, f64 *SDSGE_RESTRICT out);
 

--- a/SymbolicDSGE/_ckernels/monte_carlo/transforms.h
+++ b/SymbolicDSGE/_ckernels/monte_carlo/transforms.h
@@ -20,7 +20,7 @@
  */
 #define SDSGE_TRANSFORM_BAD_ARG -6
 
-/* Static configuration for future generic native MC transform dispatch.
+/* Static configuration for generic native MC transform dispatch.
  * Dynamic sample data, scratch, and output remain in caller-owned arenas. */
 typedef struct {
   i64 n;

--- a/SymbolicDSGE/_ckernels/optim/nelder_mead.h
+++ b/SymbolicDSGE/_ckernels/optim/nelder_mead.h
@@ -6,18 +6,12 @@
 
 /* Native Nelder-Mead simplex driver (issue #335): a faithful transpilation of
  * scipy's BSD-3 `_minimize_neldermead` (scipy/optimize/_optimize.py). Gradient
- * free by construction: no FD gradient, no Hessian, no standard errors (the
- * contrast with #329's L-BFGS-B). It shares the objective-cfunc ABI
- * (`sdsge_objective_fn`) and the lean result-struct shape with that driver.
+ * free: no FD gradient, no Hessian, no standard errors.
  *
  * Standard (non-adaptive) coefficients only: rho=1, chi=2, psi=0.5, sigma=0.5.
- * Bounds use scipy's clipping scheme, not a transform: the initial simplex is
- * reflected-then-clipped into the box and every trial point is clipped, so a
- * BK-violation region never yields an out-of-box vertex. Non-finite objective
- * returns (+INFINITY) rank worst in the simplex ordering and do not derail the
- * search. Parity against scipy is asserted within tolerance on x/fun, never on
- * the per-iteration trajectory: scipy re-sorts with a non-stable argsort, so
- * tie ordering is not reproducible across implementations. */
+ * Bounds clip rather than transform: the initial simplex is reflected-then-
+ * clipped into the box and every trial point is clipped. Non-finite objective
+ * returns (+INFINITY) rank worst in the simplex ordering. */
 
 typedef struct {
   i64 maxiter; /* iteration cap; <= 0 -> N*200 (scipy default) */

--- a/SymbolicDSGE/_ckernels/optim/optim.h
+++ b/SymbolicDSGE/_ckernels/optim/optim.h
@@ -4,16 +4,13 @@
 #include "../_common/sdsge_common.h"
 
 /* Native optimizer drivers (issue #329). Shared subsystem: any consumer links
- * optim via _EXTRA_DEPS. The estimation-specific objective trampoline lives in
- * the estimation module and wires in at #330; nothing here depends on it. The
- * linear-algebra primitives the L-BFGS-B kernel needs are served by
- * self-contained shims (shim.c), so the driver takes no backend argument. */
+ * optim via _EXTRA_DEPS. Linear algebra comes from self-contained shims
+ * (shim.c), so the driver takes no backend argument. */
 
 /* Objective ABI: minimize f(x). Returns the scalar objective at x (length n).
  * A non-finite return (+INFINITY) marks an infeasible point; the driver's FD
- * gradient and line search treat it as "no decrease" and backtrack. `ctx` is the
- * caller's closure: benchmark params in tests, or the estimation trampoline over
- * the native sdsge_obj_* objective at wiring time. */
+ * gradient and line search treat it as "no decrease" and backtrack. `ctx` is
+ * the caller's closure. */
 typedef f64 (*sdsge_objective_fn)(const f64 *SDSGE_RESTRICT x, void *ctx);
 
 typedef struct {

--- a/SymbolicDSGE/_ckernels/regression/_regression.pyx
+++ b/SymbolicDSGE/_ckernels/regression/_regression.pyx
@@ -1,12 +1,11 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Thin Cython shim for the native regression kernels.
 
-No numeric logic here -- only buffer->pointer marshalling, scratch allocation,
-and the GIL release. The algorithms live in regression.c; each ``def`` mirrors
-the matching numba helper in SymbolicDSGE/regression so the parity tests can hit
-them directly. ``chol_solve_L2`` is the single ridge solve; ``ridge_grid_search``
-runs the whole alpha grid in one native call (the Gram is formed once). A
-RANK_DEFICIENT status mirrors the numba contract (NaN coef, empty L).
+Buffer to pointer marshalling, scratch allocation, and the GIL release only;
+the algorithms live in regression.c. Parity oracles: the numba helpers in
+SymbolicDSGE/regression. ``chol_solve_L2`` is the single ridge solve,
+``ridge_grid_search`` the whole alpha grid in one native call. A RANK_DEFICIENT
+status returns NaN coef and an empty L, matching numba.
 """
 
 import numpy as np

--- a/SymbolicDSGE/_ckernels/regression/lasso.h
+++ b/SymbolicDSGE/_ckernels/regression/lasso.h
@@ -4,10 +4,10 @@
 #include "../_common/sdsge_common.h"
 #include "regression.h" /* RegressionStatus codes */
 
-/* Lasso kernels, mirroring the numba helpers in SymbolicDSGE/regression/lasso.
- * The numba reference is compiled with fastmath=True; this C is strict IEEE, so
- * the two are NOT bit-identical -- they converge to the same (unique) lasso
- * minimizer, and the parity tests compare at the solver tolerance, not ULP. */
+/* Lasso kernels. Parity oracle: the numba helpers in
+ * SymbolicDSGE/regression/lasso, which are compiled with fastmath=True while
+ * this C is strict IEEE. The two are NOT bit-identical, so compare them at the
+ * solver tolerance rather than in ULP. */
 
 /* Coordinate descent on the Gram. coef(k) is the output, Gcoef(k) is caller
  * scratch. Returns REGRESSION_OK on convergence, else REGRESSION_NON_CONVERGENT.

--- a/SymbolicDSGE/_ckernels/regression/regression.h
+++ b/SymbolicDSGE/_ckernels/regression/regression.h
@@ -20,39 +20,36 @@ typedef enum {
   REGRESSION_NON_CONVERGENT = -2,
 } RegressionStatus;
 
-/* Grid-search information criteria. Mirror the numba objective functions in
- * SymbolicDSGE/regression/utils.py (aic / bic / l2_loss); the Python dispatcher
- * maps the "aic"/"bic"/"loss" literal onto these codes. */
+/* Grid-search information criteria. Parity oracles: aic / bic / l2_loss in
+ * SymbolicDSGE/regression/utils.py. */
 typedef enum {
   REGRESSION_CRIT_AIC = 1,
   REGRESSION_CRIT_BIC = 2,
   REGRESSION_CRIT_LOSS = 3,
 } RegressionCriterion;
 
-/* Ridge (L2) normal-equation solve. Mirrors the numba ``chol_solve_L2``;
- * writes coef(p), the Cholesky factor L(p,p) of the penalized Gram, the
+/* Ridge (L2) normal-equation solve. Parity oracle: the numba ``chol_solve_L2``.
+ * Writes coef(p), the Cholesky factor L(p,p) of the penalized Gram, the
  * effective dof, and a RegressionStatus into *status. G/G_unpen/g/col are
- * caller-allocated scratch of sizes (p,p)/(p,p)/(p)/(p). See regression.c. */
+ * caller-allocated scratch of sizes (p,p)/(p,p)/(p)/(p). */
 void sdsge_chol_solve_L2(const f64 *X, const f64 *y, i64 n, i64 p, f64 alpha,
                          i64 intercept, f64 *coef, f64 *L, f64 *dof,
                          i64 *status, f64 *G, f64 *G_unpen, f64 *g, f64 *col);
 
-/* Ridge grid search over a precomputed alpha grid. Mirrors the numba
- * ``l2_grid_search``: forms the Gram ONCE (it is alpha-invariant), then per
- * alpha re-applies the diagonal penalty, factors, solves, scores via the
- * selected criterion, and keeps the argmin. Writes the winning alpha, coef(p),
- * objective value, and RegressionStatus. alphas(num) is caller-supplied (built
- * by the numba log_grid). Scratch: G_base/G/L (p,p), g/coef/col (p). */
+/* Ridge grid search over the caller-supplied alphas(num), scored by the
+ * selected criterion. Parity oracle: the numba ``l2_grid_search``. Writes the
+ * winning alpha, coef(p), objective value, and RegressionStatus. Scratch:
+ * G_base/G/L (p,p), g/coef/col (p). */
 void sdsge_ridge_grid_search(const f64 *X, const f64 *y, i64 n, i64 p,
                              const f64 *alphas, i64 num, i64 criterion,
                              i64 intercept, f64 *out_alpha, f64 *out_coef,
                              f64 *out_obj, i64 *out_status, f64 *G_base, f64 *G,
                              f64 *g, f64 *L, f64 *coef, f64 *col);
 
-/* OLS via the Cholesky normal equations. Mirrors the numba ``chol_solve``;
- * writes coef(p), the Cholesky factor L(p,p), and a RegressionStatus. G/g are
- * caller-allocated scratch of sizes (p,p)/(p). On REGRESSION_RANK_DEFICIENT the
- * caller falls back to lstsq (and L is undefined). */
+/* OLS via the Cholesky normal equations. Parity oracle: the numba
+ * ``chol_solve``. Writes coef(p), the Cholesky factor L(p,p), and a
+ * RegressionStatus. G/g are caller-allocated scratch of sizes (p,p)/(p). L is
+ * undefined on REGRESSION_RANK_DEFICIENT. */
 void sdsge_ols_chol_solve(const f64 *X, const f64 *y, i64 n, i64 p, f64 *coef,
                           f64 *L, i64 *status, f64 *G, f64 *g);
 

--- a/SymbolicDSGE/_ckernels/rng/philox.h
+++ b/SymbolicDSGE/_ckernels/rng/philox.h
@@ -3,33 +3,13 @@
 
 #include "../_common/sdsge_common.h"
 
-/* Counter-based engine for the Monte Carlo shock draw (issue #374).
+/* Counter-based engine for the Monte Carlo shock draw (issue #374). Seeking to
+ * a replication is an assignment, so each worker holds its own state on the
+ * stack and nothing here allocates or coordinates. The fills wrap this state in
+ * a `bitgen_t`, keeping numpy's compiled transforms.
  *
- * The MC runner parallelizes over replications and hands each step only its
- * `rep_idx`, so a shock stream has to be derivable from that index alone:
- * seekable, allocation-free, and identical regardless of which worker runs the
- * replication or how many workers exist. A borrowed numpy PCG64 cannot do
- * this. The `bitgen_t` ABI exposes only the `next_*` function pointers, with
- * no reseed and no jump, so C could only ever share one stream across workers,
- * which is both a data race and order-dependent.
- *
- * Philox is counter-based: the state IS a key plus a counter, so seeking to
- * replication `i` is an assignment rather than a seeding pass. Reseeding costs
- * nothing, distinct `(key, stream)` pairs give independent streams by
- * construction, and no coordination between workers is needed.
- *
- * This preserves the engine/transform split rng.h describes, with the engine
- * swapped: the fills below wrap this state in a `bitgen_t` and hand it to
- * npyrandom, so the uniform and ziggurat-normal transforms are still numpy's
- * compiled implementations. Only the bit source changes.
- *
- * Note that this is a SECOND engine, deliberately separate from the borrowed
- * PCG64 bridge in rng.h. That bridge exists to be bit-identical to numpy and
- * is pinned by tests/ckernels/test_rng_parity.py; nothing here touches it.
- *
- * The state is small and fully public so callers can hold it on the stack
- * inside an OpenMP loop body. Nothing here allocates, and numpy's headers stay
- * out of this header (philox.c alone includes them), matching rng.h. */
+ * A SECOND engine, separate from the borrowed PCG64 bridge in rng.h, which is
+ * bit-pinned by tests/ckernels/test_rng_parity.py. Nothing here touches it. */
 
 /* Philox4x64-10, the standard round count. */
 #define SDSGE_PHILOX_ROUNDS 10
@@ -43,10 +23,8 @@ typedef struct {
   i64 buffer_pos; /* 4 means exhausted; the next draw refills. */
 } sdsge_philox_state;
 
-/* Seed a stream. `key0`/`key1` and `stream0`/`stream1` jointly select it; any
- * distinct combination yields an independent sequence, with no restriction on
- * the values (zero is fine). The block counter starts fresh, so seeding the
- * same four words always replays the same draws. */
+/* Seed a stream. Any distinct combination of the four words yields an
+ * independent sequence (zero is fine) and always replays the same draws. */
 void sdsge_philox_seed(sdsge_philox_state *st, u64 key0, u64 key1, u64 stream0,
                        u64 stream1);
 

--- a/SymbolicDSGE/monte_carlo/allocation.py
+++ b/SymbolicDSGE/monte_carlo/allocation.py
@@ -8,7 +8,7 @@ named logical arrays.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, NamedTuple, Sequence, TypeAlias
+from typing import Any, Mapping, NamedTuple, Sequence, TypeAlias, cast
 
 import numpy as np
 
@@ -208,14 +208,9 @@ def _resolve_datagen_input_asize(
 ) -> ArenaSize:
     if step.step_type == "raw_model_data":
         return ArenaSize()
-    if step.step_type != "simulation":
-        raise NotImplementedError(
-            f"Input arena resolution is not implemented for datagen step type "
-            f"{step.step_type!r}."
-        )
-    model = reference if step.kwargs["target"] == "reference" else dgp
-    if model is None:
-        raise ValueError("Simulation input planning requires its target model.")
+    model = cast(
+        SolvedModel, reference if step.kwargs["target"] == "reference" else dgp
+    )
     T = int(step.kwargs["T"])
     size = _asize(
         _arena.simulation_arena_size(
@@ -241,10 +236,7 @@ def _resolve_filter_input_asize(
     datagen_plan: StepBufferPlan,
     reference: SolvedModel,
 ) -> ArenaSize:
-    try:
-        T, datagen_n_obs = datagen_plan.out_fields["observables"].shape
-    except KeyError as exc:
-        raise ValueError("Filter input planning requires datagen observables.") from exc
+    T, datagen_n_obs = datagen_plan.out_fields["observables"].shape
     selected_observables = step.kwargs["observables"]
     if selected_observables is not None:
         n_obs = len(selected_observables)
@@ -276,17 +268,12 @@ def _resolve_regression_input_asize(
     plans: BufferPlan,
     steps: Sequence[MCStep],
 ) -> ArenaSize:
-    y_rows, y_columns = _selected_source_shape(
+    y_rows, _ = _selected_source_shape(
         plans, steps, source_indices[0], step.source_args[0]
     )
-    X_rows, X_columns = _selected_source_shape(
+    _, X_columns = _selected_source_shape(
         plans, steps, source_indices[1], step.source_args[1]
     )
-    if y_columns != 1 or y_rows != X_rows:
-        raise ValueError(
-            f"Regression step {step.name!r} must resolve one response column and "
-            "matching response and design row counts."
-        )
     intercept = bool(step.kwargs["intercept"])
     p = X_columns + int(intercept)
     return _asize(

--- a/SymbolicDSGE/monte_carlo/memory.py
+++ b/SymbolicDSGE/monte_carlo/memory.py
@@ -1,11 +1,7 @@
 """Preflight memory profiling for a resolved Monte Carlo buffer plan.
 
-A run commits every retained arena before the first replication executes, and
-the default retains all replications of every step. Nothing reports that
-commitment, so an oversized plan allocates successfully and then degrades under
-paging rather than failing. This module walks a resolved plan, adds the terms
-that live outside it, and compares the total against what the machine has
-available right now.
+Sizes every retained arena a run commits before its first replication, adds the
+terms outside the plan, and compares the total against the machine.
 """
 
 from __future__ import annotations
@@ -30,35 +26,20 @@ if TYPE_CHECKING:
 #: Every native arena lane is float64 or int64, so a count converts directly.
 BYTES_PER_ELEMENT = 8
 
-#: Flat part of the reserve held back for the process around the run: the
-#: interpreter growing as results are read back, a notebook kernel holding its
-#: own copy, and the allocator's transient peaks. None of that scales with the
-#: size of the run, so neither does this term.
+#: Reserve held for the host process, independent of the size of the run.
 RESERVE_FLOOR_BYTES = 1024**3
 
-#: Part of the reserve that does scale, covering allocator overhead proportional
-#: to the arenas themselves. Deliberately small: a reserve expressed as a
-#: fraction of the machine rather than of the run withholds hundreds of
-#: gigabytes on a large host to protect against a fixed-size risk.
+#: Reserve proportional to the arenas, for allocator overhead.
 RESERVE_FRACTION = 0.025
 
 
-#: The package directory, against which a frame is judged library or caller.
 _PACKAGE_ROOT = os.path.normcase(os.path.dirname(os.path.dirname(__file__)))
 
 
 def _caller_stacklevel() -> int:
     """The ``stacklevel`` that blames the first frame outside this package.
 
-    Four call chains reach :meth:`MCMemoryProfiler.validate`, at four depths:
-    ``validate_memory_requirements`` is one hop from its caller, while a run
-    entered through :func:`~.builder.run_pipeline` is four. A constant is wrong
-    for three of them, and threading the depth through every signature between
-    here and the caller prices a warning header at four public arguments.
-    Counting the frames instead gets all four right and adds none.
-
-    This is what ``warnings.warn(skip_file_prefixes=...)`` does, which is 3.12
-    and later while this package supports 3.11.
+    Callers reach :meth:`MCMemoryProfiler.validate` at four different depths.
     """
     level = 1
     frame: FrameType | None = sys._getframe(1)
@@ -71,12 +52,7 @@ def _caller_stacklevel() -> int:
 
 
 def _print_flushed(message: str) -> None:
-    """Write to stdout and flush it.
-
-    Ordering against the traceback is the whole point of printing the report, and
-    a buffered stdout is drained after the interpreter has already written the
-    traceback to stderr.
-    """
+    """Write to stdout and flush, so the report lands before any traceback."""
     print(message, flush=True)
 
 
@@ -102,10 +78,8 @@ class StepMemory(NamedTuple):
 class MCMemoryReport:
     """What a run will allocate, against what the machine has available.
 
-    The report names no steps as targets for reduction. Retention intent is not
-    recoverable from the step graph: a value having downstream consumers does
-    not make it disposable, and a step feeding nothing may be the one its author
-    wants back. It reports the cost and leaves the choice.
+    Reports the cost per step and names none of them as the one to shrink, which
+    the step graph cannot tell.
     """
 
     steps: tuple[StepMemory, ...]
@@ -159,10 +133,7 @@ class MCMemoryReport:
     def ceiling_bytes(self) -> int:
         """The most the machine could hold, physical plus unused swap.
 
-        Past this an allocation does not get slower, it fails. On Windows the
-        commit limit is physical plus pagefile and a commit beyond it is refused
-        outright. Elsewhere the arenas allocate lazily and the process is killed
-        partway through the loop instead, which is the same loss arriving later.
+        Past this a run fails rather than slows, at allocation or partway through.
         """
         return self.available_bytes + self.swap_free_bytes
 
@@ -237,8 +208,7 @@ class MCMemoryReport:
             f"{label:<{label_width}}  {_format_bytes(value):>{widths[2]}}"
             for label, value in trailer
         ]
-        # The totals are whole-run figures, not a continuation of the per-step
-        # rows they align under. A rule keeps the two from reading as one table.
+        # Whole-run figures, not more step rows: keep them visually separate.
         rule = "-" * max(len(line) for line in (*lines, *totals))
         return "\n".join((*lines, rule, *totals))
 
@@ -246,11 +216,8 @@ class MCMemoryReport:
 class MCMemoryProfiler:
     """Sizes one native Monte Carlo run before its arenas are allocated.
 
-    Constructed from a resolved :data:`~.allocation.BufferPlan` and the run
-    arguments that plan was resolved under. It is not part of the public API:
-    a plan cannot be built without the run arguments in the first place, so the
-    profile is reached through :meth:`~.core.MCPipeline.validate_memory_requirements`
-    or raised automatically by a run.
+    Internal: reach a profile through
+    :meth:`~.core.MCPipeline.validate_memory_requirements`.
     """
 
     def __init__(
@@ -318,19 +285,11 @@ class MCMemoryProfiler:
     ) -> MCMemoryReport:
         """Profile the plan, warning when it is large and raising when it is too large.
 
-        Both paths print the breakdown rather than carrying it in the message
-        they raise or warn with, for the same reason on each. An exception
-        message long enough to hold the table is rendered after the traceback,
-        which puts the numbers below several screens of frames. A warning
-        message ending in the table is followed by the source line
-        :mod:`warnings` echoes for the frame it blames, which reads like a
-        stray frame under the totals. Printing leaves both with one line to
-        read.
+        Both paths print the breakdown and keep their message to one line, so the
+        table is not buried under a traceback or a warning's source-line echo.
         """
         report = self.report()
         if report.exceeds_limit:
-            # Titled here rather than in the report itself, which the warning
-            # path renders too and which is not an error there.
             print_func(f"Memory Availability Error:\n{report}")
             raise MemoryError(
                 f"This run requires {_format_bytes(report.total_bytes_w_margin)}, "
@@ -353,12 +312,9 @@ class MCMemoryProfiler:
     def _shock_bytes(self) -> int:
         """Bytes the fallback shock route materializes outside the arenas.
 
-        The native draw runs in C off a per-replication counter and allocates
-        nothing. One entry the kernel cannot reproduce sends the whole spec back
-        to the Python route, which materializes an ``(n_rep, T, n_exog)`` slab
-        while the step is lowered. Eligibility is read off the raw spec, the same
-        way the arena planner sizes its draw scratch and lowering picks its
-        branch, so the three cannot disagree.
+        A spec the native draw cannot reproduce is built in Python instead, as one
+        ``(n_rep, T, n_exog)`` slab. Eligibility is read off the raw spec, the same
+        way the arena planner and lowering read it.
         """
         step = self._steps[0]
         if step.op_type is not OpType.DATAGEN or step.step_type != "simulation":

--- a/SymbolicDSGE/monte_carlo/native_lowering/diagnostics.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/diagnostics.py
@@ -40,8 +40,6 @@ def lower_test_step(
     if kind == "wald":
         return _lower_wald_step(step, source_indices[0], steps, plan, n, first_columns)
     if kind in {"ljung_box", "jarque_bera"}:
-        if first_columns != 1:
-            raise ValueError(f"Native {kind} lowering requires one column.")
         native_step = (
             ljung_box_step(step.name, n, int(step.kwargs["lags"]))
             if kind == "ljung_box"
@@ -57,16 +55,7 @@ def lower_test_step(
                 target_row_stride=1,
             ),
         )
-    supported = {"breusch_pagan", "breusch_godfrey", "cusum", "cusumsq", "chow"}
-    if kind not in supported:
-        raise ValueError(f"Unsupported native diagnostic kind: {kind!r}.")
-    if first_columns != 1:
-        raise ValueError(f"Native {kind} lowering requires a one-column response.")
-    x_rows, x_columns = _selected_shape(
-        source_indices[1], step.source_args[1], steps, plan
-    )
-    if x_rows != n:
-        raise ValueError("Native diagnostic sources must have matching row counts.")
+    _, x_columns = _selected_shape(source_indices[1], step.source_args[1], steps, plan)
     if kind == "breusch_pagan":
         native_step = breusch_pagan_step(
             step.name, n, x_columns, bool(step.kwargs["robust"])

--- a/SymbolicDSGE/monte_carlo/native_lowering/filters.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/filters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 from numpy.typing import ArrayLike
 
@@ -137,7 +139,8 @@ def lower_filter_step(
             ),
             _filter_bindings(before_y, binding, (x0, interface.P0)),
         )
-    if mode == "unscented":
+
+    else:  # mode == "unscented"
         if interface.return_shocks:
             raise ValueError("Unscented filtering does not support return_shocks.")
         policy = reference.policy
@@ -183,7 +186,6 @@ def lower_filter_step(
             ),
             _filter_bindings(before_y, binding, (z0, interface.P0)),
         )
-    raise ValueError(f"Unsupported native filter mode: {mode!r}.")
 
 
 def _filter_observable_names(
@@ -199,14 +201,12 @@ def _filter_observable_names(
             raw_names or tuple(reference.compiled.observable_names),
             tuple(requested) if requested is not None else (raw_names or None),
         )
-    if datagen_step.step_type == "simulation":
-        target = datagen_step.kwargs["target"]
-        model = reference if target == "reference" else dgp
-        if model is None:
-            raise ValueError("Filter DATAGEN simulation requires its target model.")
-        names = tuple(model.compiled.observable_names)
-        return names, tuple(requested) if requested is not None else names
-    raise NotImplementedError("Native filters require raw data or simulation DATAGEN.")
+
+    # simulation
+    target = datagen_step.kwargs["target"]
+    model = reference if target == "reference" else cast(SolvedModel, dgp)
+    names = tuple(model.compiled.observable_names)
+    return names, tuple(requested) if requested is not None else names
 
 
 def _canonical_observables(

--- a/SymbolicDSGE/utils/dhm.py
+++ b/SymbolicDSGE/utils/dhm.py
@@ -139,9 +139,7 @@ def _simulate_linear_states(
 
 
 # The residual is evaluated up front into `residuals_full` (n_steps x n_eq_all,
-# real); this builder just assembles moment conditions from it. It no longer
-# takes a higher-order njit residual, which also removes the disk-cache
-# serialization of a CPUDispatcher argument.
+# real); this builder just assembles moment conditions from it.
 @njit
 def _build_forward_moments(
     current_states: np.ndarray,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ markers = [
     "sr: tests that require the optional symbolic-regression dependency",
 ]
 
+[tool.coverage.run]
+source = ["SymbolicDSGE"]
+
 [tool.coverage.report]
 # numba compiles @njit / @cfunc bodies to machine code, so coverage.py cannot
 # trace lines inside them while JIT is active (which the runtime requires for
@@ -119,7 +122,7 @@ exclude_also = [
 build = "cp311-* cp312-* cp313-* cp314-*"
 # 64-bit only (drop 32-bit i686/win32). Skip musllinux: numba/llvmlite ship no
 # musl wheels, so the dep chain builds llvmlite from source there and fails
-# (needs LLVM) -- the package can't run on Alpine regardless, so don't ship
+# (needs LLVM); the package can't run on Alpine regardless, so don't ship
 # unusable musl wheels. No -march=native anywhere (baseline ISA).
 skip = "*_i686 *-win32 *-musllinux*"
 # Validate each platform: confirm the wheel loads and the native kernels match
@@ -127,5 +130,5 @@ skip = "*_i686 *-win32 *-musllinux*"
 # (the C is Python-version-agnostic, only the generated Cython glue differs) to
 # bound the per-wheel dependency install.
 test-requires = "pytest"
-test-command = "python -m pytest {project}/tests/ckernels -q"
+test-command = "python -m pytest -n auto -q {project}/tests/ckernels"
 test-skip = "cp311-* cp312-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,6 @@ skip = "*_i686 *-win32 *-musllinux*"
 # the numba reference. All CPythons are built; runtime-test one per platform
 # (the C is Python-version-agnostic, only the generated Cython glue differs) to
 # bound the per-wheel dependency install.
-test-requires = "pytest"
+test-requires = "pytest pytest-xdist"
 test-command = "python -m pytest -n auto -q {project}/tests/ckernels"
 test-skip = "cp311-* cp312-*"

--- a/tests/monte_carlo/test_allocation_layouts.py
+++ b/tests/monte_carlo/test_allocation_layouts.py
@@ -1,0 +1,360 @@
+"""Output-layout planning: field shapes, arena sizes, and layout rejections."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE import DSGESolver, ModelParser
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.monte_carlo import MCPipeline
+from SymbolicDSGE.monte_carlo.allocation import (
+    ArenaSize,
+    _compile_field_layout,
+    _FieldSpec,
+    _resolve_input_asize,
+    resolve_output_specs,
+)
+from SymbolicDSGE.monte_carlo.mc_constructs import MCStep
+from SymbolicDSGE.monte_carlo.step_factories import (
+    add_payload_step,
+    diff_step,
+    log_diff_step,
+    postproc_step,
+    raw_model_data_step,
+    reference_filter_step,
+    regression_step,
+    rolling_mean_step,
+    rolling_std_step,
+    rolling_var_step,
+    simulation_step,
+    standardize_step,
+)
+
+T = 12
+N_REP = 2
+
+
+@pytest.fixture(scope="module")
+def solved() -> SolvedModel:
+    model, kalman = ModelParser("MODELS/POST82.yaml").get_all()
+    solver = DSGESolver(model, kalman)
+    return solver.solve(solver.compile())
+
+
+def _plan(steps: list[MCStep], reference: object = None) -> Any:
+    """Resolve output layouts without lowering or allocating."""
+    pipeline = MCPipeline(steps)
+    return pipeline._resolve_output_specs(
+        cast(SolvedModel, reference if reference is not None else object()), None
+    )
+
+
+def _data(*, rows: int = T, columns: int = 2) -> np.ndarray:
+    rng = np.random.default_rng(20260801)
+    return rng.normal(size=(N_REP, rows, columns))
+
+
+def _with_datagen(*steps: MCStep) -> list[MCStep]:
+    """Prepend the DATAGEN step MCPipeline requires at the head of a pipeline."""
+    return [raw_model_data_step("data", observables=_data()), *steps]
+
+
+# --------------------------------------------------------------------------
+# add_payload_step
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ([1.0, 2.0, 3.0], (3, 1)),
+        ([[1.0, 2.0], [3.0, 4.0]], (2, 2)),
+        (np.zeros((N_REP, 5, 3)), (5, 3)),
+    ],
+    ids=["1d", "2d", "3d-batched"],
+)
+def test_a_payload_carries_its_own_shape(
+    payload: object, expected: tuple[int, int]
+) -> None:
+    """A payload has no source, so its value alone fixes the layout."""
+    plans = _plan(_with_datagen(add_payload_step("const", payload=cast(Any, payload))))
+
+    assert plans["const"].out_fields["payload"].shape == expected
+
+
+def test_a_payload_needs_no_input_arena() -> None:
+    """Nothing is staged for a payload: the value is static backing."""
+    plans = _plan(_with_datagen(add_payload_step("const", payload=[1.0, 2.0])))
+
+    assert plans["const"].input_size == ArenaSize(0, 0)
+    assert plans["const"].output_size == ArenaSize(n_float=2, n_int=0)
+
+
+def test_a_payload_offsets_land_in_the_float_lane() -> None:
+    plans = _plan(_with_datagen(add_payload_step("const", payload=[[1.0, 2.0]])))
+    payload = plans["const"].out_fields["payload"]
+
+    assert payload.dtype == np.dtype(np.float64)
+    assert payload.offset == 0
+    assert payload.flat_count == 2
+
+
+def test_a_payload_feeds_a_downstream_transform() -> None:
+    """The payload's resolved shape is what the consumer plans against."""
+    plans = _plan(
+        _with_datagen(
+            add_payload_step("const", payload=np.zeros((6, 2))),
+            log_diff_step("growth", source="const", field="payload"),
+        )
+    )
+
+    assert plans["growth"].out_fields["payload"].shape == (5, 2)
+
+
+@pytest.mark.parametrize("ndim", [0, 4])
+def test_a_payload_must_be_1d_2d_or_3d(ndim: int) -> None:
+    payload = np.zeros((2,) * ndim)
+
+    with pytest.raises(ValueError, match="Payload must be 1D, 2D, or 3D"):
+        _plan(_with_datagen(add_payload_step("const", payload=cast(Any, payload))))
+
+
+# --------------------------------------------------------------------------
+# transform output shapes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("factory", "kwargs", "expected_rows"),
+    [
+        (standardize_step, {}, T),
+        (log_diff_step, {}, T - 1),
+        (diff_step, {"order": 1}, T - 1),
+        (diff_step, {"order": 3}, T - 3),
+        (rolling_mean_step, {"window": 4}, T - 3),
+        (rolling_std_step, {"window": 4}, T - 3),
+        (rolling_var_step, {"window": 1}, T),
+    ],
+)
+def test_row_shrinking_transforms_resolve_their_row_count(
+    factory: Any, kwargs: dict[str, Any], expected_rows: int
+) -> None:
+    plans = _plan(
+        [
+            raw_model_data_step("data", observables=np.exp(_data())),
+            factory("out", source="data", field="observables", **kwargs),
+        ]
+    )
+
+    assert plans["out"].out_fields["payload"].shape == (expected_rows, 2)
+
+
+@pytest.mark.parametrize(
+    ("factory", "kwargs"),
+    [(diff_step, {"order": T + 5}), (rolling_mean_step, {"window": T + 5})],
+)
+def test_a_transform_wider_than_its_source_clamps_to_zero_rows(
+    factory: Any, kwargs: dict[str, Any]
+) -> None:
+    """The layout stays non-negative; the kernel rejects the run later."""
+    plans = _plan(
+        [
+            raw_model_data_step("data", observables=np.exp(_data())),
+            factory("out", source="data", field="observables", **kwargs),
+        ]
+    )
+
+    assert plans["out"].out_fields["payload"].shape == (0, 2)
+
+
+def test_an_unknown_transform_type_has_no_output_shape() -> None:
+    step = standardize_step("out", source="data", field="observables")
+    steps = [
+        raw_model_data_step("data", observables=_data()),
+        dataclasses.replace(step, step_type="fourier"),
+    ]
+
+    with pytest.raises(NotImplementedError, match="transform step type"):
+        _plan(steps)
+
+
+def test_a_transform_takes_exactly_one_source() -> None:
+    step = standardize_step("out", source="data", field="observables")
+    steps = [
+        raw_model_data_step("data", observables=_data()),
+        dataclasses.replace(step, source_args=step.source_args * 2),
+    ]
+
+    with pytest.raises(ValueError, match="must have one source argument"):
+        _plan(steps)
+
+
+# --------------------------------------------------------------------------
+# datagen shapes
+# --------------------------------------------------------------------------
+
+
+def test_one_dimensional_raw_data_gains_a_column_axis() -> None:
+    plans = _plan([raw_model_data_step("data", observables=np.zeros(T))])
+
+    assert plans["data"].out_fields["observables"].shape == (T, 1)
+
+
+def test_raw_data_beyond_three_dimensions_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must be 1D, 2D, or 3D"):
+        _plan([raw_model_data_step("data", observables=np.zeros((2, 2, 2, 2)))])
+
+
+def test_an_unknown_datagen_type_has_no_output_layout() -> None:
+    step = raw_model_data_step("data", observables=_data())
+
+    with pytest.raises(NotImplementedError, match="datagen step type"):
+        _plan([dataclasses.replace(step, step_type="bootstrap")])
+
+
+# --------------------------------------------------------------------------
+# source selection
+# --------------------------------------------------------------------------
+
+
+def test_selecting_a_field_the_producer_does_not_emit_is_rejected() -> None:
+    steps = [
+        raw_model_data_step("data", observables=_data()),
+        standardize_step("out", source="data", field="states"),
+    ]
+
+    with pytest.raises(ValueError, match="does not produce source field"):
+        _plan(steps)
+
+
+def test_a_non_two_dimensional_source_field_cannot_be_selected(
+    solved: SolvedModel,
+) -> None:
+    """Filters emit rank-3 covariance fields that no transform can consume."""
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        reference_filter_step("filter"),
+        standardize_step("out", source="filter", field="P_pred"),
+    ]
+
+    with pytest.raises(ValueError, match="must be 2D"):
+        _plan(steps, reference=solved)
+
+
+def test_a_filter_needs_datagen_observables(solved: SolvedModel) -> None:
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=False),
+        reference_filter_step("filter"),
+    ]
+
+    with pytest.raises(ValueError, match="Filter output planning requires"):
+        _plan(steps, reference=solved)
+
+
+# --------------------------------------------------------------------------
+# defensive paths, reached by calling the planner directly
+# --------------------------------------------------------------------------
+
+
+def test_a_postproc_step_has_no_per_replication_layout() -> None:
+    """MCPipeline rejects these upstream, so the planner is called directly."""
+    step = postproc_step("summary", func=lambda **_: None)
+
+    with pytest.raises(NotImplementedError, match="Output-layout resolution"):
+        resolve_output_specs([step], [[]], cast(SolvedModel, object()), None)
+
+
+def test_a_negative_field_dimension_is_rejected() -> None:
+    """No producer emits one; the check guards the shared layout compiler."""
+    fields = {"payload": _FieldSpec(shape=(4, -1), dtype=np.float64)}
+
+    with pytest.raises(ValueError, match="has a negative dimension"):
+        _compile_field_layout(fields)
+
+
+def test_a_postproc_step_has_no_input_arena() -> None:
+    """Output resolution rejects it first, so the arena sizer is called direct."""
+    step = postproc_step("summary", func=lambda **_: None)
+
+    with pytest.raises(NotImplementedError, match="Input arena resolution"):
+        _resolve_input_asize(step, [], {}, [step], cast(SolvedModel, object()), None)
+
+
+# --------------------------------------------------------------------------
+# regression layouts
+# --------------------------------------------------------------------------
+
+
+def _regression(**overrides: Any) -> MCStep:
+    kwargs: dict[str, Any] = {
+        "y_source": "data",
+        "y_field": "observables",
+        "y_column": [0],
+        "X_source": "data",
+        "X_field": "observables",
+        "X_columns": [1],
+    }
+    kwargs.update(overrides)
+    return regression_step("fit", **kwargs)
+
+
+def test_a_regression_lays_out_one_coefficient_per_regressor() -> None:
+    plans = _plan(_with_datagen(_regression(intercept=True)))
+    fields = plans["fit"].out_fields
+
+    assert fields["coef"].shape == (2,)
+    assert fields["se"].shape == (2,)
+    assert fields["status"].dtype == np.dtype(np.int64)
+
+
+def test_a_non_ols_regression_reports_no_standard_errors() -> None:
+    plans = _plan(_with_datagen(_regression(kind="ridge", intercept=True)))
+
+    assert "se" not in plans["fit"].out_fields
+
+
+def test_a_regression_needs_both_a_response_and_a_design() -> None:
+    step = _regression()
+    steps = _with_datagen(dataclasses.replace(step, source_args=step.source_args[:1]))
+
+    with pytest.raises(ValueError, match="must have response and design sources"):
+        _plan(steps)
+
+
+def test_a_regression_response_must_be_one_column() -> None:
+    with pytest.raises(ValueError, match="response must resolve to one column"):
+        _plan(_with_datagen(_regression(y_column=[0, 1])))
+
+
+def test_a_regression_response_and_design_must_share_row_counts() -> None:
+    steps = [
+        raw_model_data_step("data", observables=np.exp(_data())),
+        log_diff_step("growth", source="data", field="observables", columns=[1]),
+        _regression(X_source="growth", X_field="payload", X_columns=None),
+    ]
+
+    with pytest.raises(ValueError, match="must have the same number of rows"):
+        _plan(steps)
+
+
+def test_a_regression_with_no_regressor_and_no_intercept_is_rejected() -> None:
+    with pytest.raises(ValueError, match="requires a regressor or an intercept"):
+        _plan(_with_datagen(_regression(X_columns=[], intercept=False)))
+
+
+def test_a_custom_transform_output_shape_must_be_two_non_negative_dimensions() -> None:
+    step = standardize_step("out", source="data", field="observables")
+    steps = _with_datagen(
+        dataclasses.replace(
+            step,
+            step_type="transform:custom",
+            kwargs={**step.kwargs, "output_shape": (T, -1)},
+        )
+    )
+
+    with pytest.raises(ValueError, match="two non-negative dimensions"):
+        _plan(steps)

--- a/tests/monte_carlo/test_memory_profiler.py
+++ b/tests/monte_carlo/test_memory_profiler.py
@@ -31,11 +31,42 @@ ARENA_NAMES = (
 )
 
 
+#: More memory than any plan here sizes to.
+ABUNDANT_BYTES = 1 << 50
+
+
 @pytest.fixture(scope="module")
 def solved() -> SolvedModel:
     model, kalman = ModelParser("MODELS/test.yaml").get_all()
     solver = DSGESolver(model, kalman)
     return solver.solve(solver.compile())
+
+
+def _pin_memory(
+    monkeypatch: pytest.MonkeyPatch,
+    available: int,
+    swap_free: int = 0,
+) -> None:
+    """Fix what the profiler reads for physical memory and for swap."""
+    import SymbolicDSGE.monte_carlo.memory as memory
+
+    class _Reading:
+        def __init__(self, **fields: int) -> None:
+            self.__dict__.update(fields)
+
+    monkeypatch.setattr(
+        memory.psutil, "virtual_memory", lambda: _Reading(available=available)
+    )
+    monkeypatch.setattr(memory.psutil, "swap_memory", lambda: _Reading(free=swap_free))
+
+
+@pytest.fixture(autouse=True)
+def abundant_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the machine's own free memory out of every test in this file.
+
+    Tests that care about scarcity call :func:`_pin_memory` again.
+    """
+    _pin_memory(monkeypatch, available=ABUNDANT_BYTES, swap_free=ABUNDANT_BYTES)
 
 
 def _allocated_bytes(allocation: Any) -> int:
@@ -154,24 +185,6 @@ def test_fallback_shocks_are_counted_outside_the_arenas(solved: SolvedModel) -> 
     )
 
 
-def _pin_memory(
-    monkeypatch: pytest.MonkeyPatch,
-    available: int,
-    swap_free: int = 0,
-) -> None:
-    """Fix what the profiler reads for physical memory and for swap."""
-    import SymbolicDSGE.monte_carlo.memory as memory
-
-    class _Reading:
-        def __init__(self, **fields: int) -> None:
-            self.__dict__.update(fields)
-
-    monkeypatch.setattr(
-        memory.psutil, "virtual_memory", lambda: _Reading(available=available)
-    )
-    monkeypatch.setattr(memory.psutil, "swap_memory", lambda: _Reading(free=swap_free))
-
-
 def test_the_reserve_is_a_floor_plus_a_fraction_not_a_multiple(
     solved: SolvedModel,
 ) -> None:
@@ -225,15 +238,21 @@ def test_validate_raises_only_once_swap_cannot_absorb_it_either(
         pipeline.validate_memory_requirements(reference=solved, n_rep=64, n_jobs=1)
 
 
-def test_the_ceiling_counts_swap_on_top_of_physical(solved: SolvedModel) -> None:
+def test_the_ceiling_counts_swap_on_top_of_physical(
+    solved: SolvedModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     pipeline = MCPipeline(
         [simulation_step("sim", target="reference", T=6, observables=True)]
     )
+    # Distinct readings, so summing them cannot be confused with doubling one.
+    _pin_memory(monkeypatch, available=ABUNDANT_BYTES, swap_free=ABUNDANT_BYTES // 4)
 
     report = pipeline.validate_memory_requirements(reference=solved, n_rep=8, n_jobs=1)
 
-    assert report.ceiling_bytes == report.available_bytes + report.swap_free_bytes
-    assert report.swap_free_bytes >= 0
+    assert report.available_bytes == ABUNDANT_BYTES
+    assert report.swap_free_bytes == ABUNDANT_BYTES // 4
+    assert report.ceiling_bytes == ABUNDANT_BYTES + ABUNDANT_BYTES // 4
 
 
 def test_the_raised_message_is_one_line_and_the_table_is_printed(

--- a/tests/monte_carlo/test_native_lowering_guards.py
+++ b/tests/monte_carlo/test_native_lowering_guards.py
@@ -1,0 +1,342 @@
+"""Rejection paths a pipeline the native runner cannot execute takes."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import cast
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE import DSGESolver, ModelParser
+from SymbolicDSGE.core.solved_model import SolvedModel
+from SymbolicDSGE.monte_carlo import MCPipeline
+from SymbolicDSGE.monte_carlo.allocation import FieldLayout
+from SymbolicDSGE.monte_carlo.mc_constructs import MCStep
+from SymbolicDSGE.monte_carlo.native_lowering.filters import (
+    _filter_bindings,
+    _filter_y_binding,
+)
+from SymbolicDSGE.monte_carlo.native_lowering.utils import FloatInputBinding
+from SymbolicDSGE.monte_carlo.step_factories import (
+    breusch_pagan_test_step,
+    jarque_bera_test_step,
+    ljung_box_test_step,
+    log_diff_step,
+    raw_model_data_step,
+    reference_filter_step,
+    simulation_step,
+    wald_test_step,
+)
+
+T = 12
+N_REP = 2
+
+
+@pytest.fixture(scope="module")
+def solved() -> SolvedModel:
+    model, kalman = ModelParser("MODELS/POST82.yaml").get_all()
+    solver = DSGESolver(model, kalman)
+    return solver.solve(solver.compile())
+
+
+def _two_column_data() -> np.ndarray:
+    rng = np.random.default_rng(20260801)
+    return rng.normal(size=(N_REP, T, 2))
+
+
+def _lower(steps: list[MCStep], reference: object = None) -> None:
+    """Lower a pipeline far enough to reach the step compilers."""
+    MCPipeline(steps).lower_native(
+        reference=cast(SolvedModel, reference if reference is not None else object()),
+        n_rep=N_REP,
+        n_jobs=1,
+    )
+
+
+# --------------------------------------------------------------------------
+# diagnostics.py
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [ljung_box_test_step, jarque_bera_test_step])
+def test_single_column_diagnostics_reject_a_wide_source(factory: object) -> None:
+    """Arena planning sizes the source, so it is what refuses a second column."""
+    step = cast(MCStep, factory("diag", source="data", field="observables"))  # type: ignore[operator]
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        step,
+    ]
+
+    with pytest.raises(ValueError, match="requires a single-column source"):
+        _lower(steps)
+
+
+def test_an_unknown_diagnostic_kind_has_no_arena() -> None:
+    """Only the kinds with a native kernel can be planned, let alone lowered."""
+    step = ljung_box_test_step("diag", source="data", field="observables", column=0)
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        dataclasses.replace(step, step_type="not_a_diagnostic"),
+    ]
+
+    with pytest.raises(NotImplementedError, match="not implemented for test step type"):
+        _lower(steps)
+
+
+def test_an_unknown_wald_kind_has_no_arena() -> None:
+    """The kind picks the native arena, so an unknown one fails before lowering."""
+    step = wald_test_step(
+        "wald", source="data", field="observables", target=np.zeros(2)
+    )
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        dataclasses.replace(step, kwargs={**step.kwargs, "kind": "median"}),
+    ]
+
+    with pytest.raises(ValueError, match="Unsupported native diagnostic kind"):
+        _lower(steps)
+
+
+def test_two_source_diagnostics_reject_a_wide_response() -> None:
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        breusch_pagan_test_step(
+            "bp",
+            residuals_source="data",
+            residuals_field="observables",
+            X_source="data",
+            X_field="observables",
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="requires a single-column source"):
+        _lower(steps)
+
+
+def test_two_source_diagnostics_reject_mismatched_row_counts() -> None:
+    """The response and the regressors are staged into one arena, row by row."""
+    steps = [
+        raw_model_data_step("data", observables=np.exp(_two_column_data())),
+        # A log difference drops a row, so this source is one shorter than the raw.
+        log_diff_step("growth", source="data", field="observables", columns=1),
+        breusch_pagan_test_step(
+            "bp",
+            residuals_source="data",
+            residuals_field="observables",
+            residual_col=0,
+            X_source="growth",
+            X_field="payload",
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="must have matching row counts"):
+        _lower(steps)
+
+
+def test_a_two_source_diagnostic_needs_both_sources() -> None:
+    step = breusch_pagan_test_step(
+        "bp",
+        residuals_source="data",
+        residuals_field="observables",
+        residual_col=0,
+        X_source="data",
+        X_field="observables",
+        X_columns=1,
+    )
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        dataclasses.replace(step, source_args=step.source_args[:1]),
+    ]
+
+    with pytest.raises(ValueError, match="requires two source arguments"):
+        _lower(steps)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"kernel": "epanechnikov"}, "Unsupported native Wald configuration"),
+        ({"bandwidth": True}, "bandwidth must be an integer, mode, or None"),
+        ({"bandwidth": "newey_west"}, "Unsupported native Wald bandwidth mode"),
+    ],
+)
+def test_wald_rejects_configurations_without_a_kernel(
+    overrides: dict[str, object], message: str
+) -> None:
+    step = wald_test_step(
+        "wald",
+        source="data",
+        field="observables",
+        target=np.zeros(2),
+    )
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        dataclasses.replace(step, kwargs={**step.kwargs, **overrides}),
+    ]
+
+    with pytest.raises(ValueError, match=message):
+        _lower(steps)
+
+
+@pytest.mark.parametrize(
+    ("kind", "target", "message"),
+    [
+        ("mean", np.zeros(3), "one value per source column"),
+        ("covariance", np.zeros((3, 3)), "match the source column count"),
+        ("covariance", np.zeros(2), "match the source column count"),
+    ],
+)
+def test_wald_targets_must_match_the_source_width(
+    kind: str, target: np.ndarray, message: str
+) -> None:
+    steps = [
+        raw_model_data_step("data", observables=_two_column_data()),
+        wald_test_step(
+            "wald",
+            source="data",
+            field="observables",
+            kind=cast(object, kind),  # type: ignore[arg-type]
+            target=target,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match=message):
+        _lower(steps)
+
+
+# --------------------------------------------------------------------------
+# filters.py
+# --------------------------------------------------------------------------
+
+
+def test_filter_rejects_a_datagen_whose_width_it_cannot_match(
+    solved: SolvedModel,
+) -> None:
+    """Unnamed raw observables must line up positionally, so the count must match."""
+    n_obs = len(solved.compiled.observable_names)
+    steps = [
+        raw_model_data_step(
+            "data", observables=np.zeros((N_REP, T, n_obs + 1), dtype=np.float64)
+        ),
+        reference_filter_step("filter"),
+    ]
+
+    with pytest.raises(ValueError, match="do not match the DATAGEN output"):
+        _lower(steps, reference=solved)
+
+
+def test_unscented_filtering_cannot_return_shocks(solved: SolvedModel) -> None:
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        reference_filter_step("filter", filter_mode="unscented", return_shocks=True),
+    ]
+
+    with pytest.raises(ValueError, match="does not support return_shocks"):
+        _lower(steps, reference=solved)
+
+
+def test_an_unknown_filter_mode_is_rejected(solved: SolvedModel) -> None:
+    """The interface resolves the mode before lowering picks a kernel for it."""
+    step = reference_filter_step("filter")
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        dataclasses.replace(step, kwargs={**step.kwargs, "filter_mode": "particle"}),
+    ]
+
+    with pytest.raises(ValueError, match="Unrecognized filter mode"):
+        _lower(steps, reference=solved)
+
+
+def test_a_filter_on_dgp_simulated_data_needs_the_dgp(solved: SolvedModel) -> None:
+    """Planning sizes the simulation first, so it is what misses the model."""
+    pipeline = MCPipeline(
+        [
+            simulation_step("sim", target="dgp", T=T, observables=True),
+            reference_filter_step("filter"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Simulation output planning requires"):
+        pipeline.lower_native(reference=solved, dgp=None, n_rep=N_REP, n_jobs=1)
+
+
+def test_filter_observables_must_be_unique(solved: SolvedModel) -> None:
+    name = solved.compiled.observable_names[0]
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        reference_filter_step("filter", observables=[name, name]),
+    ]
+
+    with pytest.raises(ValueError, match="must be unique"):
+        _lower(steps, reference=solved)
+
+
+def test_filter_observables_must_exist_on_the_reference(solved: SolvedModel) -> None:
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        reference_filter_step("filter", observables=["not_an_observable"]),
+    ]
+
+    with pytest.raises(ValueError, match="Unknown reference observables"):
+        _lower(steps, reference=solved)
+
+
+def test_filter_observables_must_be_present_in_the_datagen_output(
+    solved: SolvedModel,
+) -> None:
+    """Named raw data can carry a subset the filter does not fully cover."""
+    all_names = tuple(solved.compiled.observable_names)
+    steps = [
+        raw_model_data_step(
+            "data",
+            observables=np.zeros((N_REP, T, 1), dtype=np.float64),
+            observable_names=all_names[:1],
+        ),
+        reference_filter_step("filter", observables=list(all_names[:2])),
+    ]
+
+    with pytest.raises(ValueError, match="missing filter observables"):
+        _lower(steps, reference=solved)
+
+
+def test_filter_x0_must_cover_every_state(solved: SolvedModel) -> None:
+    n_var = len(solved.compiled.var_names)
+    steps = [
+        simulation_step("sim", target="reference", T=T, observables=True),
+        reference_filter_step("filter", x0=np.zeros(n_var - 1, dtype=np.float64)),
+    ]
+
+    with pytest.raises(ValueError, match=f"x0 must have length {n_var}"):
+        _lower(steps, reference=solved)
+
+
+def test_the_observation_binding_must_match_the_source_layout() -> None:
+    """An internal consistency check between the staged rows and the plan."""
+    layout = FieldLayout(
+        shape=(T, 2), flat_count=T * 2, dtype=np.dtype(np.float64), offset=0
+    )
+
+    with pytest.raises(ValueError, match="do not match their input layout"):
+        _filter_y_binding(layout, T + 1, np.asarray([0, 1], dtype=np.int64), 0, 2)
+
+    with pytest.raises(ValueError, match="do not match their input layout"):
+        _filter_y_binding(layout, T, np.asarray([0], dtype=np.int64), 0, 2)
+
+
+def test_the_observation_binding_must_start_where_the_constants_end() -> None:
+    """Constants are packed ahead of the observations, so their sizes must agree."""
+    constants = (np.ones(4, dtype=np.float64),)
+    binding = FloatInputBinding(
+        source_step_idx=0,
+        source_offset=0,
+        source_row_stride=2,
+        row_start=0,
+        n_rows=T,
+        columns=np.asarray([0, 1], dtype=np.int64),
+        target_offset=99,
+        target_row_stride=2,
+    )
+
+    with pytest.raises(ValueError, match="observation offset does not match"):
+        _filter_bindings(constants, binding, ())


### PR DESCRIPTION
This pull request primarily improves documentation clarity and consistency across the C and Cython core and diagnostic kernels, and refines the CI coverage reporting logic. The changes modernize and clarify docstrings and comments, making the codebase easier to understand and maintain, while also updating the test workflow to ensure accurate coverage reporting when selective test runs are performed.

**CI and Coverage Reporting Improvements:**
- Updated `.github/workflows/tests-and-badges.yml` to separate coverage reporting into its own step, and to exclude the `sr` package from coverage figures when its tests are deselected, ensuring more accurate and meaningful coverage metrics. [[1]](diffhunk://#diff-df2b697a7a63a7c264f9a0834b93549da14191b8a431977d631630dd8931ca4cL118-R118) [[2]](diffhunk://#diff-df2b697a7a63a7c264f9a0834b93549da14191b8a431977d631630dd8931ca4cR132-R152)

**Documentation and Comment Modernization:**

*Core and Common Kernels:*
- Simplified and clarified comments in `sdsge_common.h` and `sdsge_linalg.h`, reducing verbosity and focusing on essential information about types, constants, and function contracts. [[1]](diffhunk://#diff-f3f797a9a16b8ebf3c36a8fd8e97ef2db34fd1fe724dd8c3da1e3b7e80f3dc26L7-R12) [[2]](diffhunk://#diff-f3f797a9a16b8ebf3c36a8fd8e97ef2db34fd1fe724dd8c3da1e3b7e80f3dc26L29-R29) [[3]](diffhunk://#diff-f3f797a9a16b8ebf3c36a8fd8e97ef2db34fd1fe724dd8c3da1e3b7e80f3dc26L59-R49) [[4]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adL6-R8) [[5]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adL23-R20) [[6]](diffhunk://#diff-e6144edf16b324ffbf5a2400c7749e0e8bd9ea9c59c3c88c727f8a3edcdbe7adL80-R72)
- Updated comments in several header files (e.g., `bicomplex_hessian.h`, `klein_postproc.h`, `residual_path.h`, `second_order.h`, `spike.h`) to clarify function, remove redundant details, and consistently use "parity oracle" to reference the corresponding Python/numba implementation. [[1]](diffhunk://#diff-f78698a8a34b4214d95809ddf8dfd1d021520635e33da8df76ef1c007e8c7182L12-R14) [[2]](diffhunk://#diff-81123b30e9ca9c4bae21980a8f875c131d81b1b40d5174b2b99844f120887462L16-R16) [[3]](diffhunk://#diff-876a523e36dbe794839c3fbf6610a23f38ddca1109c6f47e8ea7819b7c037a4aL7-R7) [[4]](diffhunk://#diff-7597c2f0a0e5dbc6c0270f7d15bd8fbdf46e269a812a6c36bdb75c1edbed26adL7-R7) [[5]](diffhunk://#diff-7597c2f0a0e5dbc6c0270f7d15bd8fbdf46e269a812a6c36bdb75c1edbed26adL30-R37) [[6]](diffhunk://#diff-f52866bb3e78dc9453e13ff428773049fad03e0f42c83a671b5bb85922dadb3bL13-R16) [[7]](diffhunk://#diff-169f691930c7b320e4fe6d81299f5b4de554fac0aafe2a15ac9168d36d46f4cbL129-R131)

*Python/Cython Shims:*
- Modernized docstrings in Cython shims (`_core.pyx`, `_diag.pyx`) to clarify their role as buffer marshaling layers and to reference parity with Python/numba implementations. [[1]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bL4-R6) [[2]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bL461-R461) [[3]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bL500-R500) [[4]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bL541-R541) [[5]](diffhunk://#diff-abb2e2020697c71aa15786bac84f6651b9f9af589ebc34c76849e0d30f3a404bL631-R631) [[6]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0L4-R7) [[7]](diffhunk://#diff-6cf6574c51e16193334322a14b007db5be287717a0a5831a7736ca48a6cefec0L317-R317)

*Diagnostic Kernels:*
- Updated comments in `diag.h` to clarify status conventions and the fallback path for rank-deficient designs, emphasizing the separation between native and Python/numba SVD-based logic.

**Minor Mathematical/Algorithmic Comment Updates:**
- Clarified the description of the principal square root in `sdsge_bicomplex.h`, focusing on domain assumptions and removing discussion of numerical cancellation.

These changes collectively improve developer experience and maintainability by ensuring that both code and documentation are clear, concise, and consistent with the actual implementation and test practices.