### PR TITLE
Expose transform outputs on MC results

### DIFF
--- a/SymbolicDSGE/monte_carlo/core.py
+++ b/SymbolicDSGE/monte_carlo/core.py
@@ -338,7 +338,7 @@ class MCPipeline:
                 np.count_nonzero(prep.allocation.failure_status_by_rep == 0)
             ),
             test_summaries=test_summaries,
-            payloads=None,
+            transform_outputs=payload_columns if payload_columns else None,
             failures=tuple(failures),
             regression_summaries=regression_summaries,
             postproc=postprocs,

--- a/SymbolicDSGE/monte_carlo/mc_constructs.py
+++ b/SymbolicDSGE/monte_carlo/mc_constructs.py
@@ -262,7 +262,7 @@ class MCPipelineResult:
     n_rep: int
     n_successful: int
     test_summaries: Mapping[str, MCResult]
-    payloads: tuple[Mapping[str, Any], ...] | None
+    transform_outputs: Mapping[str, NDF] | None
     failures: tuple[MCFailure, ...] = ()
     regression_summaries: Mapping[str, MCRegressionResult] = dataclass_field(
         default_factory=dict

--- a/docs/assets/monte_carlo.ipynb
+++ b/docs/assets/monte_carlo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "id": "8b55608d",
    "metadata": {},
    "outputs": [],
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "id": "fbd00cbe",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "id": "7868d0e5",
    "metadata": {},
    "outputs": [],
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "c4a12aa7",
    "metadata": {},
    "outputs": [
@@ -145,19 +145,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MC run concluded successfully in 0.25s with 40529.48 it/s.\n",
+      "MC run concluded successfully in 0.30s with 32984.92 it/s.\n",
       "Per-step Report:\n",
       "\n",
-      "\tdatagen: 0 failures, 47156.51 worker it/s (0.21 worker-s), 40529.48 wall it/s.\n",
-      "\tfilter: 0 failures, 2908.28 worker it/s (3.44 worker-s), 40529.48 wall it/s.\n",
-      "\tcustom_std: 0 failures, 219709.70 worker it/s (0.05 worker-s), 40529.48 wall it/s.\n",
-      "\tbuiltin_std: 0 failures, 172673.13 worker it/s (0.06 worker-s), 40529.48 wall it/s.\n",
-      "\tstd_innov_mean: 0 failures, 87742.76 worker it/s (0.11 worker-s), 40529.48 wall it/s.\n",
+      "\tdatagen: 0 failures, 44423.49 worker it/s (0.23 worker-s), 32984.92 wall it/s.\n",
+      "\tfilter: 0 failures, 2498.51 worker it/s (4.00 worker-s), 32984.92 wall it/s.\n",
+      "\tcustom_std: 0 failures, 196956.26 worker it/s (0.05 worker-s), 32984.92 wall it/s.\n",
+      "\tbuiltin_std: 0 failures, 177326.93 worker it/s (0.06 worker-s), 32984.92 wall it/s.\n",
+      "\tstd_innov_mean: 0 failures, 68340.57 worker it/s (0.15 worker-s), 32984.92 wall it/s.\n",
       "\n",
       "Post-processing Report:\n",
       "\n",
-      "\tcustom_postproc: Succeeded in 0.0184s.\n",
-      "\tbuiltin_kde: Succeeded in 9.1390s.\n"
+      "\tcustom_postproc: Succeeded in 0.0197s.\n",
+      "\tbuiltin_kde: Succeeded in 9.4414s.\n"
      ]
     }
    ],
@@ -173,19 +173,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "48110503",
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'mc' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 10\u001b[39m\n\u001b[32m      6\u001b[39m             \u001b[33m\"rejection_rate\"\u001b[39m: res.rejection_rate,\n\u001b[32m      7\u001b[39m             \u001b[33m\"ci_low\"\u001b[39m: res.pval_confidence_interval()[\u001b[32m0\u001b[39m],\n\u001b[32m      8\u001b[39m             \u001b[33m\"ci_high\"\u001b[39m: res.pval_confidence_interval()[\u001b[32m1\u001b[39m],\n\u001b[32m      9\u001b[39m         }\n\u001b[32m---> \u001b[39m\u001b[32m10\u001b[39m         \u001b[38;5;28;01mfor\u001b[39;00m name, res \u001b[38;5;28;01min\u001b[39;00m mc.test_summaries.items()\n\u001b[32m     11\u001b[39m     }\n\u001b[32m     12\u001b[39m ).T\n\u001b[32m     13\u001b[39m print(t_summary.round(\u001b[32m3\u001b[39m))\n",
-      "\u001b[31mNameError\u001b[39m: name 'mc' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                mean_statistic  mean_pval  rejection_rate  ci_low  ci_high\n",
+      "std_innov_mean           2.773      0.547           0.054   0.049    0.058\n"
      ]
     }
    ],

--- a/docs/documentation/monte_carlo/core_containers.md
+++ b/docs/documentation/monte_carlo/core_containers.md
@@ -140,7 +140,7 @@ class MCPipelineResult(
     n_rep: int,
     n_successful: int,
     test_summaries: Mapping[str, MCResult],
-    payloads: tuple[Mapping[str, Any], ...] | None,
+    transform_outputs: Mapping[str, ndarray] | None,
     failures: tuple[MCFailure, ...] = (),
     regression_summaries: Mapping[str, MCRegressionResult] = {},
     postproc: Mapping[str, Any] = {},
@@ -157,7 +157,7 @@ __Fields and Properties:__
 | n_rep | `#!python int` | Requested replication count. |
 | n_successful | `#!python int` | Number of completed replications. |
 | test_summaries | `#!python Mapping[str, MCResult]` | Per-test aggregate result containers. |
-| payloads | `#!python tuple[Mapping[str, Any], ...] | None` | Reserved slot for per-replication payload dictionaries. The native runner leaves it `None`; retained transform output is read from the stacked `payload.<name>` traces instead. |
+| transform_outputs | `#!python Mapping[str, ndarray] | None` | Retained transform output stacked across replications, keyed by step name, each shaped `(n_retained, *output_shape)`. `None` when the pipeline has no transform steps. Post-loop ops see the same arrays as `payload.<name>` traces. |
 | failures | `#!python tuple[MCFailure, ...]` | Failures collected when `fail_fast=False`. |
 | regression_summaries | `#!python Mapping[str, MCRegressionResult]` | Per-regression aggregate result containers. |
 | postproc | `#!python Mapping[str, Any]` | Post-loop artifacts keyed by step name, or `"<step>.<key>"` for multi-artifact ops. Values are `Summary` or `Raw` wrappers. |

--- a/docs/documentation/monte_carlo/result_access.md
+++ b/docs/documentation/monte_carlo/result_access.md
@@ -25,6 +25,12 @@ __Summary Fields and Methods:__
 
 `MCRegressionResult` carries the same retention fields alongside `coef_trace`, `ssr_trace`, `sst_trace`, and, for OLS, a standard-error trace.
 
+__Transform Output:__
+
+`MCPipelineResult.transform_outputs` maps each transform step name to its output stacked across retained replications, shaped `(n_retained, *output_shape)`. A transform writing `(T, p)` per replication appears as `(n_retained, T, p)`. The mapping is `None` when the pipeline has no transform steps. Retention follows the step's `n_retain`, and the producing step's `retained_reps` records which replications the rows came from.
+
+These are the same arrays post-loop ops receive under the `payload.<name>` trace keys below, so a value read here needs no post-processing step to reach it.
+
 __Across-Replication Traces:__
 
 Every producer's stacked output is addressable by a trace key. Post-loop ops receive these keys in their `traces` mapping, and `available_traces(spec)` enumerates them from a spec alone, before a run.

--- a/docs/guides/monte_carlo_guide.md
+++ b/docs/guides/monte_carlo_guide.md
@@ -234,7 +234,7 @@ builtin_std = standardize_step(
 
 Post-processing is executed separately from the replication loop. The `kde_step` function is the only built-in. Custom post-processing steps stay in plain Python and are encapsulated by a `pandas_operation` decorator, which extends the numeric namespace with allowed `pandas` functionality. Post-processing functions do not see individual replications. Instead, they receive a flattened `traces` dictionary containing transform payloads, test results, and regression results.
 
-Access to a given array follows a `"."` separated path, for example, the custom standardization step (which is a payload) is accessed as `traces["payload.custom_std"]`. Payload traces are stacked across retained replications, so a transform writing `(T, p)` per replication appears as `(n_retained, T, p)`. Test and regression results are structured:
+Access to a given array follows a `"."` separated path, for example, the custom standardization step (which is a payload) is accessed as `traces["payload.custom_std"]`. Payload traces are stacked across retained replications, so a transform writing `(T, p)` per replication appears as `(n_retained, T, p)`. The same stacked arrays are on the result as `result.transform_outputs["custom_std"]`. Test and regression results are structured:
 
 __Test Traces:__
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,36 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.xdist_group("sr"))
 
 
+#: More memory than any test plan sizes to.
+ABUNDANT_MEMORY_BYTES = 1 << 50
+
+
+@pytest.fixture(autouse=True)
+def abundant_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the machine's own free memory out of every test in the suite.
+
+    The Monte Carlo memory profiler is the sole `psutil` consumer, and it reads
+    physical and swap availability live. Left alone, any test running a plan
+    large enough to approach whatever the machine happens to have free either
+    warns or raises, so a pass depends on ambient load rather than on the code
+    under test. Tests that care about scarcity pin their own readings.
+    """
+    import SymbolicDSGE.monte_carlo.memory as memory
+
+    class _Reading:
+        def __init__(self, **fields: int) -> None:
+            self.__dict__.update(fields)
+
+    monkeypatch.setattr(
+        memory.psutil,
+        "virtual_memory",
+        lambda: _Reading(available=ABUNDANT_MEMORY_BYTES),
+    )
+    monkeypatch.setattr(
+        memory.psutil, "swap_memory", lambda: _Reading(free=ABUNDANT_MEMORY_BYTES)
+    )
+
+
 @pytest.fixture(scope="session")
 def post82_test_model_path() -> Path:
     return POST82_TEST_MODEL_PATH

--- a/tests/monte_carlo/test_postproc.py
+++ b/tests/monte_carlo/test_postproc.py
@@ -226,10 +226,21 @@ def test_transform_payloads_are_stacked_into_traces() -> None:
         ],
         [_postproc("p", op)],
     )
-    pipeline.run(reference=_REFERENCE, n_rep=5, verbosity=0)
+    result = pipeline.run(reference=_REFERENCE, n_rep=5, verbosity=0)
 
     assert captured["has_payload"] is True
     assert captured["shape"][0] == 5  # stacked over replications
+
+    # The same stacked arrays reach the caller on the result, unkeyed.
+    assert result.transform_outputs is not None
+    assert set(result.transform_outputs) == {"s"}
+    assert result.transform_outputs["s"].shape == captured["shape"]
+
+
+def test_transform_outputs_is_none_without_transform_steps() -> None:
+    result = _run([], n_rep=4)
+
+    assert result.transform_outputs is None
 
 
 def test_postproc_step_is_excluded_from_per_rep_step_counts() -> None:

--- a/tests/monte_carlo/test_serialize.py
+++ b/tests/monte_carlo/test_serialize.py
@@ -40,7 +40,7 @@ def _table_result(postproc: dict) -> MCPipelineResult:
         ),
         n_successful=3,
         test_summaries={},
-        payloads=None,
+        transform_outputs=None,
         postproc=postproc,
     )
 
@@ -55,7 +55,7 @@ def _postproc_result() -> MCPipelineResult:
         ),
         n_successful=5,
         test_summaries={},
-        payloads=None,
+        transform_outputs=None,
         postproc={
             "pcs": Summary(value=0.6, title="PCS"),
             "selection": Raw(value=np.array([0.0, 1.0, 0.0, 1.0, 0.0])),
@@ -217,7 +217,7 @@ def test_postproc_wire_reconstructs_dropped_all_nan_array() -> None:
         ),
         n_successful=3,
         test_summaries={},
-        payloads=None,
+        transform_outputs=None,
         postproc={"empty": Raw(value=np.full(3, np.nan))},
     )
     document = result_document(result, run_id="r1")

--- a/tests/ui/test_backend.py
+++ b/tests/ui/test_backend.py
@@ -1055,7 +1055,7 @@ def test_ui_backend_serializes_detailed_mc_summaries() -> None:
         ),
         n_successful=2,
         test_summaries={"diagnostic": tests},
-        payloads=None,
+        transform_outputs=None,
         regression_summaries={"ols": regressions},
     )
 


### PR DESCRIPTION
Replace `MCPipelineResult.payloads` with `transform_outputs`, a mapping of transform step names to stacked retained arrays, and wire it from `monte_carlo.core.run`. Update docs and tests to reflect direct access via `result.transform_outputs` (while keeping `payload.*` traces for post-processing), add coverage for the no-transform `None` case, and stabilize suite behavior by autouse-mocking MC memory readings to abundant availability unless a test overrides them.

closes #382 