### PR TITLE
Lower OccBin regimes and conditions through compile

### DIFF
--- a/SymbolicDSGE/_symbolic_printers/__init__.py
+++ b/SymbolicDSGE/_symbolic_printers/__init__.py
@@ -1,6 +1,12 @@
 """Symbolic expression printers used by native numeric callbacks."""
 
 from .base import ExpressionPrinter, Layout, OpTable
+from .constraint_printer import (
+    ConstraintLayout,
+    ConstraintOps,
+    ConstraintPrinter,
+    build_constraint_cfunc,
+)
 from .measurement_printer import (
     F64Ops,
     MeasurementLayout,
@@ -19,6 +25,9 @@ from .residual_printer import (
 __all__ = [
     "BicomplexOps",
     "C128Ops",
+    "ConstraintLayout",
+    "ConstraintOps",
+    "ConstraintPrinter",
     "ExpressionPrinter",
     "F64Ops",
     "Layout",
@@ -28,6 +37,7 @@ __all__ = [
     "ResidualLayout",
     "ResidualPrinter",
     "build_cfunc",
+    "build_constraint_cfunc",
     "build_measurement_cfunc",
     "build_njit",
 ]

--- a/SymbolicDSGE/_symbolic_printers/constraint_printer.py
+++ b/SymbolicDSGE/_symbolic_printers/constraint_printer.py
@@ -1,0 +1,170 @@
+"""Constraint expression printers for native regime callbacks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+import sympy as sp
+from numba import cfunc, types
+from sympy import Symbol
+
+from .base import ExpressionPrinter, OpTable
+from .measurement_printer import F64Ops
+
+
+class ConstraintOpTable(OpTable, Protocol):
+    """Op table extended with the comparisons and connectives conditions need."""
+
+    def lt(self, a: str, b: str) -> str: ...
+    def le(self, a: str, b: str) -> str: ...
+    def gt(self, a: str, b: str) -> str: ...
+    def ge(self, a: str, b: str) -> str: ...
+    def eq(self, a: str, b: str) -> str: ...
+    def ne(self, a: str, b: str) -> str: ...
+    def and_(self, a: str, b: str) -> str: ...
+    def or_(self, a: str, b: str) -> str: ...
+    def not_(self, a: str) -> str: ...
+
+
+class ConstraintOps(F64Ops, ConstraintOpTable):
+    """Real valued backend emitting 0/1 regime flags."""
+
+    def lt(self, a: str, b: str) -> str:
+        return f"({a} < {b})"
+
+    def le(self, a: str, b: str) -> str:
+        return f"({a} <= {b})"
+
+    def gt(self, a: str, b: str) -> str:
+        return f"({a} > {b})"
+
+    def ge(self, a: str, b: str) -> str:
+        return f"({a} >= {b})"
+
+    def eq(self, a: str, b: str) -> str:
+        return f"({a} == {b})"
+
+    def ne(self, a: str, b: str) -> str:
+        return f"({a} != {b})"
+
+    def and_(self, a: str, b: str) -> str:
+        return f"({a} and {b})"
+
+    def or_(self, a: str, b: str) -> str:
+        return f"({a} or {b})"
+
+    def not_(self, a: str) -> str:
+        return f"(not {a})"
+
+    def store(self, buf: str, idx: int, expr: str) -> str:
+        return f"{buf}[{idx}] = 1 if {expr} else 0"
+
+
+#: Relational node types mapped to the op that renders them.
+_RELATIONAL_OPS: dict[type, Callable[[ConstraintOpTable, str, str], str]] = {
+    sp.StrictLessThan: lambda ops, a, b: ops.lt(a, b),
+    sp.LessThan: lambda ops, a, b: ops.le(a, b),
+    sp.StrictGreaterThan: lambda ops, a, b: ops.gt(a, b),
+    sp.GreaterThan: lambda ops, a, b: ops.ge(a, b),
+    sp.Equality: lambda ops, a, b: ops.eq(a, b),
+    sp.Unequality: lambda ops, a, b: ops.ne(a, b),
+}
+
+
+@dataclass(slots=True)
+class ConstraintLayout:
+    """Maps constraint symbols to native buffer slots."""
+
+    slot: dict[Any, tuple[str, int]]
+    n_var: int
+    n_par: int
+    constraint_names: tuple[str, ...] = ()
+
+    @property
+    def n_flag(self) -> int:
+        return 2 * len(self.constraint_names)
+
+    @property
+    def n_expr(self) -> int:
+        return self.n_flag
+
+    @classmethod
+    def from_compiled(
+        cls, compiled: Any, constraint_names: tuple[str, ...] | list[str]
+    ) -> ConstraintLayout:
+        slot: dict[Any, tuple[str, int]] = {}
+        for i, name in enumerate(compiled.var_names):
+            slot[Symbol(f"cur_{name}")] = ("cur", i)
+        for j, p in enumerate(compiled.calib_params):
+            slot[p] = ("par", j)
+        return cls(
+            slot=slot,
+            n_var=len(compiled.var_names),
+            n_par=len(compiled.calib_params),
+            constraint_names=tuple(constraint_names),
+        )
+
+
+class ConstraintPrinter(ExpressionPrinter):
+    def __init__(self, ops: ConstraintOpTable) -> None:
+        super().__init__(ops)
+        self.cops = ops
+
+    @property
+    def allocated_dtype(self) -> str:
+        return "np.int8"
+
+    @property
+    def context_name(self) -> str:
+        return "constraint"
+
+    def render(self, expr: Any) -> str:
+        render_op = _RELATIONAL_OPS.get(type(expr))
+        if render_op is not None:
+            lhs, rhs = expr.args
+            return render_op(self.cops, self.render(lhs), self.render(rhs))
+        if isinstance(expr, sp.And):
+            return self._fold(expr.args, self.cops.and_)
+        if isinstance(expr, sp.Or):
+            return self._fold(expr.args, self.cops.or_)
+        if isinstance(expr, sp.Not):
+            return self.cops.not_(self.render(expr.args[0]))
+        return super().render(expr)
+
+    def _fold(self, args: Any, op: Callable[[str, str], str]) -> str:
+        result = self.render(args[0])
+        for arg in args[1:]:
+            result = op(result, self.render(arg))
+        return result
+
+
+def build_constraint_cfunc(
+    exprs: list[Any], layout: ConstraintLayout, ops: ConstraintOpTable | None = None
+) -> Any:
+    table: ConstraintOpTable = ConstraintOps() if ops is None else ops
+    body = ConstraintPrinter(table).emit(exprs, layout, allocate=False)
+    preamble = [
+        f"    cur = carray(cur_ptr, ({layout.n_var},))",
+        f"    par = carray(par_ptr, ({layout.n_par},))",
+        f"    out = carray(out_ptr, ({layout.n_flag},))",
+    ]
+    src = "\n".join(
+        [
+            *table.prelude_imports,
+            "from numba import carray",
+            "",
+            "def _constraint_cf(cur_ptr, par_ptr, out_ptr):",
+            *preamble,
+            *body,
+            "",
+        ]
+    )
+    ns: dict[str, Any] = {}
+    exec(src, ns)  # noqa: S102
+    sig = types.void(
+        types.CPointer(types.float64),
+        types.CPointer(types.float64),
+        types.CPointer(types.int8),
+    )
+    return cfunc(sig)(ns["_constraint_cf"])

--- a/SymbolicDSGE/core/compiled_model.py
+++ b/SymbolicDSGE/core/compiled_model.py
@@ -115,6 +115,22 @@ class CompiledModel:
     constraint_names: tuple[str, ...] = ()
     constraint_exprs: list[Boolean] = field(default_factory=list)
 
+    # Regime residuals in reference equation order, keyed by the bitmask of the
+    # regime's binding constraints over constraint_names; printed to native
+    # cfuncs on demand (construct_regime_cfuncs).
+    regime_eqs: dict[int, list[Expr]] = field(default_factory=dict)
+
+    @cached_property
+    def _regime_cfuncs(self) -> dict[int, Any]:
+        # One residual @cfunc per regime, sharing the reference layout: regimes
+        # replace equations by name, so n_eq/n_var/n_par are unchanged. Held here
+        # so the addresses stay valid for the driver.
+        layout = ResidualLayout.from_compiled(self)
+        return {mask: build_cfunc(eqs, layout) for mask, eqs in self.regime_eqs.items()}
+
+    def construct_regime_cfuncs(self) -> dict[int, Any]:
+        return self._regime_cfuncs
+
     @cached_property
     def _constraint_func(self) -> ConstraintFunc | None:
         # Conditions as one numba @cfunc (C ABI) for the native OccBin driver.

--- a/SymbolicDSGE/core/compiled_model.py
+++ b/SymbolicDSGE/core/compiled_model.py
@@ -4,17 +4,21 @@ import numpy as np
 from numpy import complex128, float64
 from numpy.typing import NDArray
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from functools import cached_property
 from typing import Callable, Any, Mapping
+
+from sympy.logic.boolalg import Boolean
 
 from .config import ModelConfig
 from ..kalman.config import KalmanConfig
 from SymbolicDSGE._symbolic_printers import (
     BicomplexOps,
+    ConstraintLayout,
     MeasurementLayout,
     ResidualLayout,
     build_cfunc,
+    build_constraint_cfunc,
     build_measurement_cfunc,
 )
 from .._ckernels.core import jacobian_eval, measurement_eval, residual_eval
@@ -34,6 +38,52 @@ class VariableLayout:
     n_exog: int
     n_state: int
     idx: dict[str, int]
+
+
+@dataclass(frozen=True)
+class ConstraintFunc:
+    """Compiled regime conditions, and everything the native side needs to call them.
+
+    One cfunc evaluates every condition, writing ``2 * n_constraint`` int8 flags:
+    slot ``2i`` is constraint ``i`` binding, slot ``2i + 1`` is it relaxing. The
+    C caller selects with ``next = prev ? !relax : bind``, so both flags of a
+    constraint come from a single call and share their common subexpressions.
+
+    ``names`` is declaration order, which is the regime bit order.
+    """
+
+    cfunc: Any
+    names: tuple[str, ...]
+    n_var: int
+    n_par: int
+
+    @property
+    def address(self) -> int:
+        """Entry point of
+        ``void (*)(const double *cur, const double *par, int8_t *flags)``."""
+        return int(self.cfunc.address)
+
+    @property
+    def n_constraint(self) -> int:
+        return len(self.names)
+
+    @property
+    def n_flag(self) -> int:
+        return 2 * len(self.names)
+
+    def bind_slot(self, name: str) -> int:
+        return 2 * self.names.index(name)
+
+    def relax_slot(self, name: str) -> int:
+        return 2 * self.names.index(name) + 1
+
+    def bit(self, name: str) -> int:
+        """Bitmask position of ``name`` in a regime key."""
+        return self.names.index(name)
+
+    def mask(self, binding: frozenset[str] | set[str]) -> int:
+        """Regime key as a bitmask over ``names``."""
+        return sum(1 << self.bit(n) for n in binding)
 
 
 @dataclass(frozen=True)
@@ -59,6 +109,28 @@ class CompiledModel:
 
     n_state: int
     n_exog: int
+
+    # Regime conditions in declaration order, bind then relax per constraint;
+    # printed to a native cfunc on demand (construct_constraint_func).
+    constraint_names: tuple[str, ...] = ()
+    constraint_exprs: list[Boolean] = field(default_factory=list)
+
+    @cached_property
+    def _constraint_func(self) -> ConstraintFunc | None:
+        # Conditions as one numba @cfunc (C ABI) for the native OccBin driver.
+        # Held here so its .address stays valid for the driver.
+        if not self.constraint_names:
+            return None
+        layout = ConstraintLayout.from_compiled(self, self.constraint_names)
+        return ConstraintFunc(
+            cfunc=build_constraint_cfunc(self.constraint_exprs, layout),
+            names=self.constraint_names,
+            n_var=layout.n_var,
+            n_par=layout.n_par,
+        )
+
+    def construct_constraint_func(self) -> ConstraintFunc | None:
+        return self._constraint_func
 
     @cached_property
     def _objective_cfunc(self) -> Any:

--- a/SymbolicDSGE/core/model_parser.py
+++ b/SymbolicDSGE/core/model_parser.py
@@ -129,6 +129,7 @@ class ModelParser:
 
     def __post_init__(self) -> None:
         conf = self.parsed.model
+        self.validate_equations(conf)
         self.validate_constraints(conf)
         self.validate_regimes(conf)  # reads validated bind conditions
         self.validate_ss_seed(conf)
@@ -206,7 +207,12 @@ class ModelParser:
 
     @staticmethod
     def _unknown_atoms(conf: ModelConfig, *exprs: Basic) -> set[Any]:
-        """Variables and parameters referenced by *exprs* that the model omits.
+        """Symbols referenced by *exprs* that the model declares nowhere.
+
+        Declared means a variable, a parameter, or a shock: regime replacements
+        are ordinary model equations, so a shock is as legitimate there as it is
+        in the equation being replaced. Conditions reject shocks earlier, with
+        their own message, so nothing reaches here relying on the old behavior.
 
         Time symbols come from the free symbols of each applied function's
         arguments, so an offset term like ``x(t+1)`` clears ``t`` the way
@@ -221,9 +227,26 @@ class ModelParser:
         time_syms = {s for c in applied for a in c.args for s in a.free_symbols}
         var_funcs = {c.func for c in applied}
 
+        declared = set(conf.parameters) | set(conf.shock_map)
         return (var_funcs - set(conf.variables.variables)) | (
-            (free - time_syms) - set(conf.parameters)
+            (free - time_syms) - declared
         )
+
+    @classmethod
+    def validate_equations(cls, conf: ModelConfig) -> None:
+        """Reject a model equation naming a symbol the model declares nowhere.
+
+        The same check regime replacements get, on the equations they replace: a
+        typo would otherwise survive parse as a live ``Symbol`` and only fail in
+        the printer, where the name is no longer attached to an equation.
+        """
+        for name, eq in conf.equations.model.items():
+            unknown_atoms = cls._unknown_atoms(conf, eq)
+            if unknown_atoms:
+                raise ValueError(
+                    f"Equation '{name}' references unknown symbols: "
+                    f"{sorted(str(a) for a in unknown_atoms)}"
+                )
 
     @classmethod
     def validate_constraints(cls, conf: ModelConfig) -> None:

--- a/SymbolicDSGE/core/model_parser.py
+++ b/SymbolicDSGE/core/model_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import re
 import sys
 from dataclasses import dataclass
 from io import StringIO
@@ -83,6 +84,25 @@ def _caller_stacklevel() -> int:
     return level
 
 
+def _check_connective_parens(expr: str) -> None:
+    """Require each ``&``/``|`` in a condition to join parenthesized relations.
+
+    Python binds ``&``/``|`` tighter than the comparisons, so ``x > 0 | y < 1``
+    parses as ``And(x > y, y < 1)``: a valid condition that tests something the
+    user never wrote. No inspection of the parsed tree can detect that, so the
+    raw text is the only place to catch it.
+    """
+    for match in re.finditer(r"[&|]", expr):
+        before = expr[: match.start()].rstrip()
+        after = expr[match.end() :].lstrip()
+        if not before.endswith(")") or not after.startswith("("):
+            raise ValueError(
+                f"Condition {expr!r} uses '{match.group()}' outside parentheses. "
+                f"'&' and '|' bind tighter than the comparisons, so each relation "
+                f"must be parenthesized: '(x > 0) {match.group()} (y < 1)'."
+            )
+
+
 def _list_representer(dumper: yaml.Dumper, data: list[Any]) -> yaml.Node:
     return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=True)
 
@@ -141,6 +161,49 @@ class ModelParser:
         parser.parsed.model.source_yaml = text
         return parser
 
+    @classmethod
+    def _validate_condition(cls, name: str, kind: str, cond: Any) -> None:
+        """Reject a condition that is not relations joined by connectives.
+
+        ``Symbol`` subclasses ``Boolean``, so ``And(x > 0, y)`` builds without
+        complaint and the root type gate accepts it. Only a positive
+        ``Relational`` check at every leaf catches the bare operand, and a
+        positive ``Expr`` check on each side catches a relation compared against
+        another relation.
+        """
+        if isinstance(cond, (And, Or, Not)):
+            for arg in cond.args:
+                cls._validate_condition(name, kind, arg)
+            return
+
+        if not isinstance(cond, Relational):
+            raise TypeError(
+                f"{kind} condition for constraint '{name}' is not a valid "
+                f"SymPy Relational: {cond!r}"
+            )
+
+        for side in cond.args:
+            if not isinstance(side, Expr):
+                raise TypeError(
+                    f"{kind} condition for constraint '{name}' compares the truth "
+                    f"value {side!r} rather than a numeric expression, in {cond!r}. "
+                    f"Combine relations with '&' or '|' between parenthesized "
+                    f"relations, not with a comparison."
+                )
+
+    @staticmethod
+    def _shock_atoms(conf: ModelConfig, *exprs: Basic) -> set[Symbol]:
+        """Shocks referenced by *exprs*.
+
+        Conditions are tested on a realized path where the shocks have already
+        been absorbed into the variables, so a shock cannot appear in one.
+        """
+        shocks = set(conf.shock_map)
+        found: set[Symbol] = set()
+        for expr in exprs:
+            found |= expr.free_symbols & shocks  # pyright: ignore
+        return found
+
     @staticmethod
     def _unknown_atoms(conf: ModelConfig, *exprs: Basic) -> set[Any]:
         """Variables and parameters referenced by *exprs* that the model omits.
@@ -176,16 +239,21 @@ class ModelParser:
 
         for name, constraint in constraints.items():
 
-            # Check if inequalities refer to uninitialized variables
-            if not isinstance((binds := constraint.bind), _REGIME_SHIFT_CONDITIONAL):
-                raise TypeError(
-                    f"Binding condition for constraint '{name}' is not a valid SymPy Relational: {binds!r}"
-                )
-            if not isinstance((relaxes := constraint.relax), _REGIME_SHIFT_CONDITIONAL):
-                raise TypeError(
-                    f"Relaxing condition for constraint '{name}' is not a valid SymPy Relational: {relaxes!r}"
+            binds, relaxes = constraint.bind, constraint.relax
+            cls._validate_condition(name, "Binding", binds)
+            cls._validate_condition(name, "Relaxing", relaxes)
+
+            # Named before _unknown_atoms, which would report a shock as an
+            # unknown symbol: shocks are neither variables nor parameters.
+            shocks = cls._shock_atoms(conf, binds, relaxes)
+            if shocks:
+                raise ValueError(
+                    f"Constraint '{name}' references shock(s) "
+                    f"{sorted(s.name for s in shocks)}; conditions may only "
+                    f"reference model variables and parameters."
                 )
 
+            # Check if inequalities refer to uninitialized variables
             unknown_atoms = cls._unknown_atoms(conf, binds, relaxes)
             if unknown_atoms:
                 raise ValueError(
@@ -528,6 +596,7 @@ class ModelParser:
             return out
 
         def _get_relational(expr: str) -> _REGIME_SHIFT_CONDITIONAL:
+            _check_connective_parens(expr)
             out = sp.parse_expr(
                 expr,
                 local_dict=_LOCALS,

--- a/SymbolicDSGE/core/solver.py
+++ b/SymbolicDSGE/core/solver.py
@@ -115,24 +115,19 @@ class DSGESolver:
         constraint_names, constraint_exprs = self._compile_constraints(
             conf, subs_map, var_funcs, t
         )
+        regime_eqs = self._compile_regimes(
+            conf, constraint_names, subs_map, var_funcs, t
+        )
 
         shifted_obs = [
             self._offset_lags(expr, t) for expr in conf.equations.observable.values()
         ]
         observable_exprs = [sp.simplify(expr.subs(subs_map)) for expr in shifted_obs]
-        symbolic_jacobian = (
-            sp.Matrix(
-                [
-                    [sp.diff(expr, cur_sym) for cur_sym in cur_syms]
-                    for expr in observable_exprs
-                ]
-            )
-            if observable_exprs
-            else sp.zeros(0, len(cur_syms))
-        )
         # Flat row-major (n_obs, n_var) jacobian; printed to a native cfunc on
         # demand via CompiledModel.construct_observable_jacobian_cfunc.
-        observable_jacobian_eqs = list(symbolic_jacobian)  # pyright: ignore
+        observable_jacobian_eqs: list[Expr] = [
+            sp.diff(expr, cur_sym) for expr in observable_exprs for cur_sym in cur_syms
+        ]
 
         return CompiledModel(
             config=conf,
@@ -150,6 +145,7 @@ class DSGESolver:
             n_exog=layout.n_exog,
             constraint_names=constraint_names,
             constraint_exprs=constraint_exprs,
+            regime_eqs=regime_eqs,
         )
 
     def _compile_constraints(
@@ -183,6 +179,50 @@ class DSGESolver:
                     )
                 exprs.append(cond.subs(subs_map))
         return names, exprs
+
+    def _compile_regimes(
+        self,
+        conf: ModelConfig,
+        constraint_names: tuple[str, ...],
+        subs_map: dict[Any, Symbol],
+        var_funcs: list[Function],
+        t: Symbol,
+    ) -> dict[int, list[Expr]]:
+        """Regime residuals keyed by the bitmask of their binding constraints.
+
+        Each regime is the reference model with its replacements overlaid. Every
+        replacement target is a declared model equation, so the merge keeps
+        reference equation order and every regime pencil stays row-aligned with
+        the reference. Shocks are zeroed as they are on the reference residual.
+        """
+        regimes = conf.equations.regime
+        if not regimes:
+            return {}
+
+        bit = {name: i for i, name in enumerate(constraint_names)}
+        shock_zero_subs = {shock: 0.0 for shock in conf.shock_map}
+
+        compiled: dict[int, list[Expr]] = {}
+        for key, replacements in regimes.items():
+            label = ", ".join(sorted(key))
+            residuals: list[Expr] = []
+            for name, eq in {**conf.equations.model, **replacements}.items():
+                resid = self._offset_lags(
+                    sp.simplify(eq.lhs - eq.rhs), t  # pyright: ignore
+                )
+                bad = self._bad_time_offsets(resid, var_funcs, t)
+                if bad:
+                    raise ValueError(
+                        f"Equation '{name}' in regime '{label}' has bad time "
+                        f"offsets {sorted(bad)}. Only offsets of 0 and 1 are allowed."
+                    )
+                residuals.append(
+                    sp.simplify(
+                        resid.subs(subs_map).subs(shock_zero_subs)  # pyright: ignore
+                    )
+                )
+            compiled[sum(1 << bit[name] for name in key)] = residuals
+        return compiled
 
     @staticmethod
     def _coerce_variable_name(var: Any) -> str:

--- a/SymbolicDSGE/core/solver.py
+++ b/SymbolicDSGE/core/solver.py
@@ -2,7 +2,8 @@ import warnings
 from dataclasses import replace
 
 import sympy as sp
-from sympy import Symbol, Function, Expr
+from sympy import Symbol, Function, Expr, Basic
+from sympy.logic.boolalg import Boolean
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 import numpy as np
@@ -111,6 +112,10 @@ class DSGESolver:
             for expr in compiled
         ]
 
+        constraint_names, constraint_exprs = self._compile_constraints(
+            conf, subs_map, var_funcs, t
+        )
+
         shifted_obs = [
             self._offset_lags(expr, t) for expr in conf.equations.observable.values()
         ]
@@ -143,7 +148,41 @@ class DSGESolver:
             observable_jacobian_eqs=observable_jacobian_eqs,
             n_state=layout.n_state,
             n_exog=layout.n_exog,
+            constraint_names=constraint_names,
+            constraint_exprs=constraint_exprs,
         )
+
+    def _compile_constraints(
+        self,
+        conf: ModelConfig,
+        subs_map: dict[Any, Symbol],
+        var_funcs: list[Function],
+        t: Symbol,
+    ) -> tuple[tuple[str, ...], list[Boolean]]:
+        """Regime conditions in declaration order, bind then relax per constraint.
+
+        Declaration order is the regime bit order; the ``frozenset`` regime keys
+        carry none. Conditions are contemporaneous, so no lag shift applies and
+        they are never simplified.
+        """
+        constraints = conf.equations.constraint
+        if not constraints:
+            return (), []
+
+        names = tuple(constraints)
+        exprs: list[Boolean] = []
+        for name in names:
+            constraint = constraints[name]
+            for kind, cond in (("bind", constraint.bind), ("relax", constraint.relax)):
+                bad = self._bad_time_offsets(cond, var_funcs, t, allowed={0})
+                if bad:
+                    raise ValueError(
+                        f"Condition '{kind}' of constraint '{name}' has bad time "
+                        f"offsets {sorted(bad)}. Constraint conditions may only "
+                        f"reference contemporaneous variables."
+                    )
+                exprs.append(cond.subs(subs_map))
+        return names, exprs
 
     @staticmethod
     def _coerce_variable_name(var: Any) -> str:
@@ -709,8 +748,13 @@ class DSGESolver:
         return obj
 
     @staticmethod
-    def _bad_time_offsets(expr: Expr, var_funcs: list[Function], t: Symbol) -> set[int]:
-        allowed = {0, 1}
+    def _bad_time_offsets(
+        expr: Basic,
+        var_funcs: list[Function],
+        t: Symbol,
+        allowed: set[int] | None = None,
+    ) -> set[int]:
+        allowed = {0, 1} if allowed is None else allowed
         bad: set[int] = set()
 
         for call in expr.atoms(sp.Function):

--- a/tests/core/test_constraint_compile.py
+++ b/tests/core/test_constraint_compile.py
@@ -8,14 +8,23 @@ import numpy as np
 import pytest
 import sympy as sp
 
-from SymbolicDSGE.core import DSGESolver
+from SymbolicDSGE.core import DSGESolver, ModelParser
 from SymbolicDSGE.core.config import Constraint
+from SymbolicDSGE._ckernels.core import (
+    klein_preprocess,
+    residual_eval,
+    steady_state_newton,
+)
 
 t = sp.Symbol("t", integer=True)
 
 
-def _with_constraints(parsed, constraint):
-    """Parsed POST82 carrying `constraint` plus the regimes it requires."""
+def _with_constraints(parsed, constraint, replacements=None):
+    """Parsed POST82 carrying `constraint` plus the regimes it requires.
+
+    `replacements` maps a binding set to the equations that regime replaces;
+    unlisted regimes fall back to pinning the first variable at zero.
+    """
     model, kalman = parsed
     conf = copy.deepcopy(model)
     conf.equations.constraint = constraint
@@ -26,7 +35,10 @@ def _with_constraints(parsed, constraint):
     combos = [frozenset({n}) for n in names]
     if len(names) == 2:
         combos.append(frozenset(names))
-    conf.equations.regime = {c: {target: sp.Eq(var(t), 0)} for c in combos}
+    replacements = replacements or {}
+    conf.equations.regime = {
+        c: replacements.get(c, {target: sp.Eq(var(t), 0)}) for c in combos
+    }
     return DSGESolver(conf, kalman)
 
 
@@ -139,6 +151,176 @@ def test_flags_match_a_lambdify_oracle(compiled_obc):
 
         want = [int(bool(f(cur, par))) for f in oracle]
         assert _call(cf, cur, par).tolist() == want
+
+
+@pytest.fixture(scope="module")
+def compiled_regimes(parsed_post82):
+    """Two constraints whose regimes each replace the third model equation."""
+    model, _ = parsed_post82
+    g, _, r = model.variables.variables[:3]
+    beta = model.parameters[0]
+    target = list(model.equations.model)[2]
+    solver = _with_constraints(
+        parsed_post82,
+        {
+            "lo": Constraint(bind=r(t) < 0, relax=r(t) >= 0),
+            "hi": Constraint(bind=g(t) > beta, relax=g(t) <= beta),
+        },
+        {
+            frozenset({"lo"}): {target: sp.Eq(r(t), 0)},
+            frozenset({"hi"}): {target: sp.Eq(r(t), beta)},
+            frozenset({"lo", "hi"}): {target: sp.Eq(r(t), 2 * beta)},
+        },
+    )
+    return solver.compile()
+
+
+def test_regimes_are_keyed_by_binding_bitmask(compiled_regimes):
+    cf = compiled_regimes.construct_constraint_func()
+
+    assert sorted(compiled_regimes.regime_eqs) == [1, 2, 3]
+    assert cf.mask(frozenset({"lo"})) == 1
+    assert cf.mask(frozenset({"hi"})) == 2
+    assert cf.mask(frozenset({"lo", "hi"})) == 3
+
+
+def test_regimes_replace_rows_in_reference_order(compiled_regimes):
+    # Every regime pencil must stay row-aligned with the reference, so only the
+    # replaced equation's row may differ and n_eq may not change.
+    ref = compiled_regimes.objective_eqs
+
+    for mask, eqs in compiled_regimes.regime_eqs.items():
+        assert len(eqs) == len(ref)
+        differing = [
+            i for i, (a, b) in enumerate(zip(ref, eqs)) if sp.simplify(a - b) != 0
+        ]
+        assert differing == [2], f"mask {mask} changed rows {differing}"
+
+
+def test_regime_replacements_lower_to_residuals(compiled_regimes):
+    cur_r, beta = sp.Symbol("cur_r"), sp.Symbol("beta")
+
+    assert compiled_regimes.regime_eqs[1][2] == cur_r
+    assert sp.simplify(compiled_regimes.regime_eqs[2][2] - (cur_r - beta)) == 0
+    assert sp.simplify(compiled_regimes.regime_eqs[3][2] - (cur_r - 2 * beta)) == 0
+
+
+def test_regime_cfuncs_cover_every_regime_and_are_cached(compiled_regimes):
+    cfuncs = compiled_regimes.construct_regime_cfuncs()
+
+    assert sorted(cfuncs) == [1, 2, 3]
+    assert compiled_regimes.construct_regime_cfuncs() is cfuncs
+
+
+def test_regime_pencils_swap_only_the_replaced_row(compiled_regimes):
+    # The constant is the whole OccBin mechanism: regimes linearize at the
+    # reference steady state, where they do not hold, and c_r is that failure.
+    par = np.array(
+        [
+            float(compiled_regimes.config.calibration.parameters[p])
+            for p in compiled_regimes.calib_params
+        ]
+    )
+    n_eq = len(compiled_regimes.var_names)
+    ref_cfunc = compiled_regimes.construct_objective_cfunc()
+    ss_ref, _ = steady_state_newton(ref_cfunc.address, np.zeros(n_eq), par)
+
+    a_ref, b_ref = klein_preprocess(ref_cfunc.address, ss_ref, par, n_eq, False)
+    c_ref = residual_eval(ref_cfunc.address, ss_ref, ss_ref, par, n_eq).real
+    np.testing.assert_allclose(c_ref, 0.0, atol=1e-12)
+
+    beta = float(compiled_regimes.config.calibration.parameters[sp.Symbol("beta")])
+    expected_c = {1: 0.0, 2: -beta, 3: -2 * beta}
+
+    for mask, cfunc in compiled_regimes.construct_regime_cfuncs().items():
+        a_r, b_r = klein_preprocess(cfunc.address, ss_ref, par, n_eq, False)
+        c_r = residual_eval(cfunc.address, ss_ref, ss_ref, par, n_eq).real
+
+        assert np.flatnonzero(np.abs(a_r - a_ref).max(axis=1)).tolist() == [2]
+        assert np.flatnonzero(np.abs(b_r - b_ref).max(axis=1)).tolist() == [2]
+
+        want = np.zeros(n_eq)
+        want[2] = expected_c[mask]
+        np.testing.assert_allclose(c_r, want, atol=1e-12)
+
+
+@pytest.fixture(scope="module")
+def compiled_rbc_obc(rbc_second_order_test_model_path):
+    """Levels RBC where a bad-TFP regime shuts investment off.
+
+    POST82 is a gap model, so its regime constants can be zero purely because
+    the reference steady state is. This fixture is in levels, where the
+    constant is what actually drives the piecewise solve.
+    """
+    model, kalman = ModelParser(rbc_second_order_test_model_path).get_all()
+    conf = copy.deepcopy(model)
+    c, k, z = conf.variables.variables
+    delta = sp.Symbol("delta")
+
+    conf.equations.constraint = {"low": Constraint(bind=z(t) < 0, relax=z(t) >= 0)}
+    conf.equations.regime = {
+        frozenset({"low"}): {"euler": sp.Eq(k(t + 1), (1 - delta) * k(t))}
+    }
+    return DSGESolver(conf, kalman).compile()
+
+
+def test_levels_regime_constant_is_the_steady_state_residual(compiled_rbc_obc):
+    calib = compiled_rbc_obc.config.calibration.parameters
+    par = np.array([float(calib[p]) for p in compiled_rbc_obc.calib_params])
+    n_eq = len(compiled_rbc_obc.var_names)
+    seed = np.array(
+        [
+            float(calib[sp.Symbol(f"{n}_ss")]) if n != "z" else 0.0
+            for n in compiled_rbc_obc.var_names
+        ]
+    )
+
+    ref_cfunc = compiled_rbc_obc.construct_objective_cfunc()
+    ss_ref, _ = steady_state_newton(ref_cfunc.address, seed, par)
+
+    # The whole point of a levels fixture: the expansion point is not the origin.
+    assert np.abs(ss_ref).max() > 1.0
+    c_ref = residual_eval(ref_cfunc.address, ss_ref, ss_ref, par, n_eq).real
+    np.testing.assert_allclose(c_ref, 0.0, atol=1e-10)
+
+    # `euler` is row 0; the replacement k(t+1) = (1 - delta) k(t) leaves a
+    # residual of delta * k_ss at the reference steady state.
+    k_idx = compiled_rbc_obc.var_names.index("k")
+    expected = float(calib[sp.Symbol("delta")]) * ss_ref[k_idx]
+    assert expected > 0.5
+
+    cfunc = compiled_rbc_obc.construct_regime_cfuncs()[1]
+    c_r = residual_eval(cfunc.address, ss_ref, ss_ref, par, n_eq).real
+
+    want = np.zeros(n_eq)
+    want[0] = expected
+    np.testing.assert_allclose(c_r, want, atol=1e-10)
+
+
+def test_regime_replacements_zero_shocks_like_the_reference(parsed_post82):
+    # Regimes walk the reference residual path, so a shock in a replacement is
+    # accepted and then zeroed the way it is in objective_eqs.
+    model, _ = parsed_post82
+    r = model.variables.variables[2]
+    shock = next(iter(model.shock_map))
+    rho_r = sp.Symbol("rho_r")
+    solver = _with_constraints(
+        parsed_post82,
+        {"lo": Constraint(bind=r(t) < 0, relax=r(t) >= 0)},
+        {frozenset({"lo"}): {"taylor": sp.Eq(r(t), shock + rho_r * r(t))}},
+    )
+
+    compiled = solver.compile()
+
+    cur_r = sp.Symbol("cur_r")
+    assert sp.simplify(compiled.regime_eqs[1][2] - cur_r * (1 - rho_r)) == 0
+    assert shock not in compiled.regime_eqs[1][2].free_symbols
+    assert compiled.construct_regime_cfuncs()[1] is not None
+
+
+def test_model_without_regimes_has_no_regime_eqs(compiled_post82):
+    assert compiled_post82.regime_eqs == {}
+    assert compiled_post82.construct_regime_cfuncs() == {}
 
 
 def test_model_without_constraints_has_no_constraint_func(compiled_post82):

--- a/tests/core/test_constraint_compile.py
+++ b/tests/core/test_constraint_compile.py
@@ -1,0 +1,160 @@
+# type: ignore
+from __future__ import annotations
+
+import copy
+import ctypes
+
+import numpy as np
+import pytest
+import sympy as sp
+
+from SymbolicDSGE.core import DSGESolver
+from SymbolicDSGE.core.config import Constraint
+
+t = sp.Symbol("t", integer=True)
+
+
+def _with_constraints(parsed, constraint):
+    """Parsed POST82 carrying `constraint` plus the regimes it requires."""
+    model, kalman = parsed
+    conf = copy.deepcopy(model)
+    conf.equations.constraint = constraint
+
+    target = next(iter(conf.equations.model))
+    var = conf.variables.variables[0]
+    names = list(constraint)
+    combos = [frozenset({n}) for n in names]
+    if len(names) == 2:
+        combos.append(frozenset(names))
+    conf.equations.regime = {c: {target: sp.Eq(var(t), 0)} for c in combos}
+    return DSGESolver(conf, kalman)
+
+
+@pytest.fixture(scope="module")
+def compiled_obc(parsed_post82):
+    model, _ = parsed_post82
+    g, z = (v for v in model.variables.variables[:2])
+    beta = model.parameters[0]
+    solver = _with_constraints(
+        parsed_post82,
+        {
+            "lo": Constraint(bind=g(t) < 0, relax=g(t) >= 0),
+            "hi": Constraint(bind=sp.And(z(t) > beta, g(t) < 1), relax=z(t) <= beta),
+        },
+    )
+    return solver.compile()
+
+
+def test_conditions_substitute_into_cur_symbols(compiled_obc):
+    beta = sp.Symbol("beta")
+    cur_g, cur_z = sp.Symbol("cur_g"), sp.Symbol("cur_z")
+
+    assert compiled_obc.constraint_names == ("lo", "hi")
+    assert compiled_obc.constraint_exprs == [
+        cur_g < 0,
+        cur_g >= 0,
+        sp.And(cur_z > beta, cur_g < 1),
+        cur_z <= beta,
+    ]
+
+
+def test_constraint_func_layout(compiled_obc):
+    cf = compiled_obc.construct_constraint_func()
+
+    assert cf.names == ("lo", "hi")
+    assert (cf.n_constraint, cf.n_flag) == (2, 4)
+    assert (cf.n_var, cf.n_par) == (
+        len(compiled_obc.var_names),
+        len(compiled_obc.calib_params),
+    )
+    assert (cf.bind_slot("lo"), cf.relax_slot("lo")) == (0, 1)
+    assert (cf.bind_slot("hi"), cf.relax_slot("hi")) == (2, 3)
+    assert cf.mask(frozenset({"lo"})) == 0b01
+    assert cf.mask(frozenset({"hi"})) == 0b10
+    assert cf.mask(frozenset({"lo", "hi"})) == 0b11
+
+
+def test_constraint_func_is_cached(compiled_obc):
+    # The driver holds .address, so the cfunc must not be rebuilt per call.
+    assert compiled_obc.construct_constraint_func() is (
+        compiled_obc.construct_constraint_func()
+    )
+
+
+def _call(cf, cur, par):
+    fn = ctypes.CFUNCTYPE(
+        None,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_int8),
+    )(cf.address)
+    cur = np.ascontiguousarray(cur, dtype=np.float64)
+    par = np.ascontiguousarray(par, dtype=np.float64)
+    out = np.zeros(cf.n_flag, dtype=np.int8)
+    fn(
+        cur.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        par.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        out.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+    )
+    return out
+
+
+@pytest.mark.parametrize(
+    ("g", "z", "beta", "expected"),
+    [
+        # g   z   beta   lo_bind lo_relax hi_bind hi_relax
+        (-1.0, 0.0, 0.5, [1, 0, 0, 1]),
+        (0.5, 1.0, 0.5, [0, 1, 1, 0]),
+        (2.0, 1.0, 0.5, [0, 1, 0, 0]),  # z > beta but g >= 1 fails the And
+        (0.0, 0.5, 0.5, [0, 1, 0, 1]),  # exact boundaries: >= and <= both hold
+    ],
+)
+def test_flags_match_the_written_conditions(compiled_obc, g, z, beta, expected):
+    cf = compiled_obc.construct_constraint_func()
+    cur = np.zeros(cf.n_var)
+    cur[0], cur[1] = g, z
+    par = np.zeros(cf.n_par)
+    par[0] = beta
+
+    out = _call(cf, cur, par)
+
+    assert out.dtype == np.int8
+    assert out.tolist() == expected
+
+
+def test_flags_match_a_lambdify_oracle(compiled_obc):
+    cf = compiled_obc.construct_constraint_func()
+    oracle = [
+        sp.lambdify((compiled_obc.cur_syms, compiled_obc.calib_params), e, "numpy")
+        for e in compiled_obc.constraint_exprs
+    ]
+    rng = np.random.default_rng(0)
+
+    for trial in range(200):
+        cur = np.round(rng.normal(0.0, 1.0, cf.n_var), 2)
+        par = np.round(rng.normal(0.0, 1.0, cf.n_par), 2)
+        if trial % 5 == 0:  # drive the comparisons onto exact boundaries
+            cur[0] = 0.0
+            par[0] = cur[1]
+
+        want = [int(bool(f(cur, par))) for f in oracle]
+        assert _call(cf, cur, par).tolist() == want
+
+
+def test_model_without_constraints_has_no_constraint_func(compiled_post82):
+    assert compiled_post82.constraint_names == ()
+    assert compiled_post82.constraint_exprs == []
+    assert compiled_post82.construct_constraint_func() is None
+
+
+@pytest.mark.parametrize("offset", [1, -1])
+def test_conditions_reject_leads_and_lags(parsed_post82, offset):
+    model, _ = parsed_post82
+    g = model.variables.variables[0]
+    solver = _with_constraints(
+        parsed_post82,
+        {"lo": Constraint(bind=g(t + offset) < 0, relax=g(t) >= 0)},
+    )
+
+    with pytest.raises(ValueError, match="only reference contemporaneous variables"):
+        solver.compile()

--- a/tests/core/test_model_parser.py
+++ b/tests/core/test_model_parser.py
@@ -339,6 +339,27 @@ def test_parser_rejects_unparenthesized_connective(parsed_test):
         ModelParser.from_string(yaml.safe_dump(data))
 
 
+def test_validate_equations_accepts_variables_parameters_and_shocks(parsed_test):
+    # The declared set is the same one regime replacements are checked against.
+    ModelParser.validate_equations(parsed_test.model)
+
+
+def test_parser_rejects_unknown_symbol_in_model_equation():
+    data = yaml.safe_load(_R_ARITHMETIC_MODEL)
+    data["equations"]["model"]["x_process"] = "x(t+1) = rho * x(t) + e_x + typo_symbol"
+
+    with pytest.raises(ValueError, match=r"Equation 'x_process' references unknown"):
+        ModelParser.from_string(yaml.safe_dump(data))
+
+
+def test_parser_rejects_undeclared_variable_in_model_equation():
+    data = yaml.safe_load(_R_ARITHMETIC_MODEL)
+    data["equations"]["model"]["x_process"] = "x(t+1) = rho * x(t) + e_x + w(t)"
+
+    with pytest.raises(ValueError, match=r"Equation 'x_process' references unknown"):
+        ModelParser.from_string(yaml.safe_dump(data))
+
+
 def test_validate_constraints_rejects_more_than_two(parsed_test):
     conf = copy.deepcopy(parsed_test.model)
     t = sp.Symbol("t", integer=True)
@@ -389,6 +410,34 @@ def test_validate_regimes_rejects_unknown_replacement_target(parsed_test):
     conf.equations.regime = {frozenset({"obc"}): {"nosuch": sp.Eq(var(t), 0)}}
 
     with pytest.raises(ValueError, match="replaces undeclared model equations"):
+        ModelParser.validate_regimes(conf)
+
+
+def test_validate_regimes_accepts_shocks_in_replacements(parsed_test):
+    # A replacement is an ordinary model equation, so a shock is as legitimate
+    # there as in the equation it replaces. Conditions still reject shocks.
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    var = conf.variables.variables[0]
+    shock = next(iter(conf.shock_map))
+    target = next(iter(conf.equations.model))
+    conf.equations.constraint = {"obc": Constraint(bind=var(t) < 0, relax=var(t) >= 0)}
+    conf.equations.regime = {frozenset({"obc"}): {target: sp.Eq(var(t), shock)}}
+
+    ModelParser.validate_regimes(conf)
+
+
+def test_validate_regimes_rejects_unknown_symbols_in_replacements(parsed_test):
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    var = conf.variables.variables[0]
+    target = next(iter(conf.equations.model))
+    conf.equations.constraint = {"obc": Constraint(bind=var(t) < 0, relax=var(t) >= 0)}
+    conf.equations.regime = {
+        frozenset({"obc"}): {target: sp.Eq(var(t), sp.Symbol("typo_symbol"))}
+    }
+
+    with pytest.raises(ValueError, match="references unknown symbols"):
         ModelParser.validate_regimes(conf)
 
 

--- a/tests/core/test_model_parser.py
+++ b/tests/core/test_model_parser.py
@@ -9,7 +9,7 @@ import pytest
 import sympy as sp
 import yaml
 
-from SymbolicDSGE.core.model_parser import ModelParser
+from SymbolicDSGE.core.model_parser import ModelParser, _check_connective_parens
 from SymbolicDSGE.core.config import Constraint
 from SymbolicDSGE.core.linearization import LinearizationMethod
 
@@ -244,6 +244,99 @@ def test_validate_constraints_accepts_boolean_conditions(parsed_test):
     }
 
     ModelParser.validate_constraints(conf)
+
+
+def test_validate_constraints_accepts_nested_connectives(parsed_test):
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    a, b = conf.variables.variables[:2]
+    cond = sp.Or(sp.And(a(t) < 0, b(t) < 0), sp.Not(a(t) > 5))
+    conf.equations.constraint = {"obc": Constraint(bind=cond, relax=a(t) >= 0)}
+
+    ModelParser.validate_constraints(conf)
+
+
+@pytest.mark.parametrize("depth", ["root", "nested"])
+def test_validate_constraints_rejects_non_relational_leaves(parsed_test, depth):
+    # Symbol subclasses Boolean, so And(x < 0, param) builds fine and the root
+    # type gate accepts it; only the leaf walk rejects the bare operand.
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    a = conf.variables.variables[0]
+    param = conf.parameters[0]
+    bind = param if depth == "root" else sp.Or(sp.And(a(t) < 0, param), a(t) > 5)
+    conf.equations.constraint = {"obc": Constraint(bind=bind, relax=a(t) >= 0)}
+
+    with pytest.raises(TypeError, match="is not a valid SymPy Relational"):
+        ModelParser.validate_constraints(conf)
+
+
+def test_validate_constraints_rejects_relation_compared_to_relation(parsed_test):
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    a, b = conf.variables.variables[:2]
+    conf.equations.constraint = {
+        "obc": Constraint(bind=sp.Eq(a(t) < 0, b(t) < 0), relax=a(t) >= 0)
+    }
+
+    with pytest.raises(TypeError, match="compares the truth value"):
+        ModelParser.validate_constraints(conf)
+
+
+@pytest.mark.parametrize("side", ["bind", "relax"])
+def test_validate_constraints_rejects_shocks(parsed_test, side):
+    conf = copy.deepcopy(parsed_test.model)
+    t = sp.Symbol("t", integer=True)
+    a = conf.variables.variables[0]
+    shock = next(iter(conf.shock_map))
+    conditions = {"bind": a(t) < 0, "relax": a(t) >= 0}
+    conditions[side] = a(t) + shock < 0
+
+    conf.equations.constraint = {"obc": Constraint(**conditions)}
+
+    match = f"references shock\\(s\\) \\['{shock.name}'\\]"
+    with pytest.raises(ValueError, match=match):
+        ModelParser.validate_constraints(conf)
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "x(t) < 0",
+        "(x(t) > 0) & (y(t) < 1)",
+        "(x(t) > 0)|(y(t) < 1)",
+        "((x(t) > 0) & (y(t) < 1)) | (z(t) < 2)",
+        "~(x(t) < 0)",
+    ],
+)
+def test_connective_parens_accepts_parenthesized_relations(condition):
+    _check_connective_parens(condition)
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "x(t) > 0 | y(t) < 1",
+        "x(t) > 0 & y(t) < 1",
+        "(x(t) > 0) & y(t) < 1",
+        "x(t) > 0 & (y(t) < 1)",
+    ],
+)
+def test_connective_parens_rejects_unparenthesized_relations(condition):
+    # '&'/'|' bind tighter than the comparisons, so 'x > 0 | y < 1' parses as
+    # And(x > y, y < 1): a valid tree testing something never written.
+    with pytest.raises(ValueError, match="outside parentheses"):
+        _check_connective_parens(condition)
+
+
+def test_parser_rejects_unparenthesized_connective(parsed_test):
+    data = yaml.safe_load(_R_ARITHMETIC_MODEL)
+    data["equations"]["constraint"] = {
+        "obc": {"bind": "x(t) < 0 & y(t) < 0", "relax": "x(t) >= 0"}
+    }
+
+    with pytest.raises(ValueError, match="outside parentheses"):
+        ModelParser.from_string(yaml.safe_dump(data))
 
 
 def test_validate_constraints_rejects_more_than_two(parsed_test):


### PR DESCRIPTION
**Conditions.** `ConstraintPrinter` emits comparisons and boolean connectives to a real valued C kernel. One cfunc per model writes `2 * n_constraint` int8 flags, slot `2i` binding and slot `2i + 1` relaxing, so `cse` shares work between the two conditions of a constraint. `CompiledModel.construct_constraint_func` returns a `ConstraintFunc` carrying the entry point, the name to bit map, and the regime mask helper.

**Regimes.** `CompiledModel.regime_eqs` holds each regime's residuals in reference equation order, keyed by the bitmask of its binding constraints. `construct_regime_cfuncs` prints them against the reference `ResidualLayout`. Regimes replace equations by name, so every regime pencil stays square and row aligned with the reference. Mask 0 is the reference and is absent, and keys are dense over `1 .. 2**n - 1`.

A regime's pencil is `klein_preprocess(regime, ss_ref, par)` and its constant is `residual_eval(regime, ss_ref, ss_ref, par)`. No native changes.

**Validation.** Conditions reject leads, lags, and shocks, require every leaf to be a relation between numeric expressions, and require parenthesized relations around `&` and `|`, which Python binds tighter than the comparisons.

Model equations now reject symbols the model declares nowhere, matching regime replacements. This can reject a config that parsed before.


closes #385