### PR TITLE
Constraint parsing guards and cfunc driver

### DIFF
--- a/SymbolicDSGE/_ckernels/README.md
+++ b/SymbolicDSGE/_ckernels/README.md
@@ -55,7 +55,7 @@ protocol, so NumPy's C-API never enters the build.
 3. Re-export in `_ckernels/foo/__init__.py`: `from ._foo import bar as bar`.
 4. In the consumer (`SymbolicDSGE/foo/...`), `try` the native import and fall
    back to the numba kernel on `ImportError`.
-5. Add a parity test under `tests/_ckernels/`.
+5. Add a parity test under `tests/ckernels/`.
 
 `setup.py` auto-discovers any `_ckernels/*/_*.pyx` and links its sibling `*.c`
 plus all `_common/*.c` — no per-subsystem build edits needed.

--- a/SymbolicDSGE/_ckernels/occbin/__init__.py
+++ b/SymbolicDSGE/_ckernels/occbin/__init__.py
@@ -1,0 +1,12 @@
+"""Native OccBin kernels (regime conditions evaluated over a simulated path).
+
+Re-exports the compiled ``_occbin`` extension, which is mandatory: if it is not
+built, importing this module (and the library) raises ``ImportError``.
+"""
+
+from ._occbin import MAX_CONSTRAINTS, constraint_path
+
+__all__ = [
+    "MAX_CONSTRAINTS",
+    "constraint_path",
+]

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -1,0 +1,30 @@
+"""Type stubs for the compiled ``_occbin`` extension.
+
+The native kernels carry no inspectable type information (the type checker never
+parses ``_occbin.pyx`` nor introspects the compiled object), so these signatures
+exist solely to give the LSP and mypy the shapes of the exported functions. They
+must stay in sync with ``_occbin.pyx`` / ``occbin.c``; the tests guard the
+runtime behavior, not this stub.
+"""
+
+from numpy import float64, int8
+from numpy.typing import NDArray
+
+_F64 = NDArray[float64]
+_I8 = NDArray[int8]
+
+MAX_CONSTRAINTS: int
+
+def constraint_path(
+    cond_addr: int,
+    path: _F64,
+    par: _F64,
+    regime_in: _I8,
+    n_constraint: int,
+    out: _I8 | None = ...,
+) -> tuple[_I8, int]:
+    """(regime_out, changed) <- latched regime mask over a (T, n_var) level path.
+
+    ``out`` may alias ``regime_in`` to latch in place; ``changed`` counts the
+    periods whose mask moved.
+    """

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -1,0 +1,76 @@
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Thin Cython shim mapping NumPy buffers to the pure-C OccBin kernels.
+
+Buffer to pointer marshalling and the GIL release only; the algorithms live in
+occbin.c. The kernels' f64/i8/i64 are exactly double/int8_t/int64_t, so the
+externs are declared with those.
+"""
+
+from libc.stdint cimport int8_t, int64_t
+
+import numpy as np
+
+
+cdef extern from "occbin.h" nogil:
+    ctypedef void (*sdsge_constraint_fn)(
+        double *cur, double *par, int8_t *flags) noexcept
+    int64_t sdsge_constraint_path(
+        sdsge_constraint_fn cond, double *path, double *par,
+        const int8_t *regime_in, int8_t *regime_out,
+        int64_t T, int64_t n_var, int64_t n_constraint)
+
+
+#: Constraints the native flag buffer is sized for (``i8 flags[4]`` in occbin.c,
+#: two slots per constraint). Mirrors the OccBin cap in model_parser.
+MAX_CONSTRAINTS = 2
+
+
+def constraint_path(size_t cond_addr, path, par, regime_in,
+                    int64_t n_constraint, out=None):
+    """Latched regime mask ``(T,)`` from a constraint @cfunc over a path.
+
+    ``path`` is ``(T, n_var)`` in cur-variable order and in levels, not
+    deviations from the reference steady state. ``regime_in`` is the incoming
+    ``(T,)`` mask over declaration-ordered constraints, which the latch carries
+    across guess-and-verify iterations at a fixed period; periods never interact.
+
+    ``out`` is an optional C-contiguous int8 buffer written in place, and may be
+    ``regime_in`` itself to latch in place. Other inputs are coerced. Returns
+    ``(out, changed)``, where ``changed`` counts the periods whose mask moved and
+    so is 0 exactly at a fixed point.
+    """
+    if not 0 < n_constraint <= MAX_CONSTRAINTS:
+        raise ValueError(
+            f"n_constraint must be in 1..{MAX_CONSTRAINTS}, got {n_constraint}."
+        )
+
+    cdef double[:, ::1] pv = np.ascontiguousarray(path, dtype=np.float64)
+    cdef double[::1] parv = np.ascontiguousarray(par, dtype=np.float64)
+    cdef const int8_t[::1] inv = np.ascontiguousarray(regime_in, dtype=np.int8)
+    cdef int64_t T = pv.shape[0]
+    cdef int64_t n_var = pv.shape[1]
+    cdef int8_t[::1] ov
+    cdef int64_t changed
+
+    if inv.shape[0] != T:
+        raise ValueError(
+            f"regime_in has length {inv.shape[0]}, expected {T} to match path."
+        )
+    if out is None:
+        out = np.empty((T,), dtype=np.int8)
+    ov = out
+    if ov.shape[0] != T:
+        raise ValueError(
+            f"out has length {ov.shape[0]}, expected {T} to match path."
+        )
+
+    cdef double *path_ptr = &pv[0, 0] if (T * n_var) > 0 else NULL
+    cdef double *par_ptr = &parv[0] if parv.shape[0] > 0 else NULL
+    cdef const int8_t *in_ptr = &inv[0] if T > 0 else NULL
+    cdef int8_t *out_ptr = &ov[0] if T > 0 else NULL
+    cdef sdsge_constraint_fn fn = <sdsge_constraint_fn><void*>cond_addr
+    with nogil:
+        changed = sdsge_constraint_path(
+            fn, path_ptr, par_ptr, in_ptr, out_ptr, T, n_var, n_constraint
+        )
+    return out, changed

--- a/SymbolicDSGE/_ckernels/occbin/occbin.c
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.c
@@ -1,0 +1,22 @@
+#include "occbin.h"
+
+i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
+                          f64 *SDSGE_RESTRICT par, const i8 *regime_in,
+                          i8 *regime_out, i64 T, i64 n_var, i64 n_constraint) {
+  i8 flags[4]; // 2 * MAX_CONSTRAINTS (a constraint is a relax/bind pair)
+  i64 changed = 0;
+
+  for (i64 t = 0; t < T; ++t) {
+    cond(&path[t * n_var], par, flags);
+    const i8 prev = regime_in[t];
+    i8 next = 0;
+    for (i64 i = 0; i < n_constraint; ++i) {
+      // If the previous regime was binding, check if it should relax; if it was
+      // relaxing, check if it should bind
+      next |= (((prev >> i) & 1) ? !flags[2 * i + 1] : flags[2 * i]) << i;
+    }
+    regime_out[t] = next;
+    changed += (next != prev);
+  }
+  return changed; // No status code, call can't fail
+}

--- a/SymbolicDSGE/_ckernels/occbin/occbin.h
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.h
@@ -1,0 +1,15 @@
+#ifndef SDSGE_OCCBIN_H
+#define SDSGE_OCCBIN_H
+
+#include "../_common/sdsge_common.h"
+
+typedef void (*sdsge_constraint_fn)(f64 *cur, f64 *par, i8 *flags);
+
+i64 sdsge_constraint_path(sdsge_constraint_fn cond,
+                          f64 *SDSGE_RESTRICT path, // (T, n_var)
+                          f64 *SDSGE_RESTRICT par,  // (n_par,)
+                          const i8 *regime_in,      // (T,)
+                          i8 *regime_out,           // (T,)
+                          i64 T, i64 n_var, i64 n_constraint);
+
+#endif // SDSGE_OCCBIN_H

--- a/SymbolicDSGE/core/model_parser.py
+++ b/SymbolicDSGE/core/model_parser.py
@@ -677,9 +677,17 @@ class ModelParser:
         constraint: dict[str, Constraint] = {}
         for name, raw_spec in constraint_raw.items():
             spec = cls._require_mapping(raw_spec, f"equations.constraint.{name}")
+            if (bind := spec.get("bind")) is None:
+                raise ValueError(f"Constraint '{name}' is missing a 'bind' condition.")
+            bind = _get_relational(bind)
+            if (relax := spec.get("relax")) is None:
+                relax = Not(bind)  # Default relax for symmetric constraint
+            else:
+                relax = _get_relational(relax)
+
             constraint[name] = Constraint(
-                bind=_get_relational(spec["bind"]),
-                relax=_get_relational(spec["relax"]),
+                bind=bind,
+                relax=relax,
             )
 
         regime_raw = eq_data.get("regime", {}) or {}

--- a/tests/ckernels/test_constraint_path.py
+++ b/tests/ckernels/test_constraint_path.py
@@ -1,0 +1,262 @@
+"""Native ``constraint_path``: the regime latch over a path of variable levels.
+
+The fixture deliberately avoids complementary bind/relax pairs, because when
+``relax`` is ``not(bind)`` the latch collapses to ``next = bind`` and every
+hysteresis bug hides. ``band`` leaves a deadband on g where neither condition
+holds, so its bit is decided only by the incoming regime; ``over`` overlaps on z
+where both hold at once, so its bit flips on every pass. Declaration order puts
+band on bit 0 and over on bit 1.
+"""
+
+from __future__ import annotations
+
+import copy
+import ctypes
+
+import numpy as np
+import pytest
+import sympy as sp
+
+from SymbolicDSGE._ckernels.occbin import MAX_CONSTRAINTS, constraint_path
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from SymbolicDSGE.core.config import Constraint
+
+t = sp.Symbol("t", integer=True)
+
+BAND, OVER = 0b01, 0b10
+
+# g and z values placing each constraint in a chosen (bind, relax) cell.
+BAND_ON, BAND_DEAD, BAND_OFF = -2.0, 0.0, 2.0
+OVER_ON, OVER_BOTH, OVER_OFF = -2.0, 0.0, 2.0
+
+
+@pytest.fixture(scope="module")
+def compiled():
+    model, kalman = ModelParser("MODELS/POST82.yaml").get_all()
+    conf = copy.deepcopy(model)
+    by_name = {v.__name__: v for v in conf.variables.variables}
+    g, z = by_name["g"], by_name["z"]
+
+    conf.equations.constraint = {
+        "band": Constraint(bind=g(t) < -1, relax=g(t) > 1),
+        "over": Constraint(bind=z(t) < 1, relax=z(t) > -1),
+    }
+    target = next(iter(conf.equations.model))
+    conf.equations.regime = {
+        combo: {target: sp.Eq(g(t), 0)}
+        for combo in (
+            frozenset({"band"}),
+            frozenset({"over"}),
+            frozenset({"band", "over"}),
+        )
+    }
+    return DSGESolver(conf, kalman).compile()
+
+
+@pytest.fixture(scope="module")
+def par(compiled):
+    return np.array(
+        [
+            float(compiled.config.calibration.parameters[p])
+            for p in compiled.calib_params
+        ],
+        dtype=np.float64,
+    )
+
+
+def _path(compiled, rows):
+    """(T, n_var) level buffer with g and z set per row, every other variable 0."""
+    out = np.zeros((len(rows), len(compiled.var_names)), dtype=np.float64)
+    for i, (g, z) in enumerate(rows):
+        out[i, compiled.idx["g"]] = g
+        out[i, compiled.idx["z"]] = z
+    return out
+
+
+def _flags(cf, cur, par):
+    """The raw bind/relax flags, straight off the cfunc, bypassing the driver."""
+    fn = ctypes.CFUNCTYPE(
+        None,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_int8),
+    )(cf.address)
+    cur = np.ascontiguousarray(cur, dtype=np.float64)
+    par = np.ascontiguousarray(par, dtype=np.float64)
+    out = np.zeros(cf.n_flag, dtype=np.int8)
+    fn(
+        cur.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        par.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        out.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+    )
+    return out
+
+
+def _oracle(cf, path, par, regime_in):
+    """``next = prev ? !relax : bind``, per constraint, per period, in Python."""
+    out = np.empty(len(path), dtype=np.int8)
+    for i, row in enumerate(path):
+        flags = _flags(cf, row, par)
+        prev, nxt = int(regime_in[i]), 0
+        for c in range(cf.n_constraint):
+            on = (not flags[2 * c + 1]) if (prev >> c) & 1 else flags[2 * c]
+            nxt |= int(bool(on)) << c
+        out[i] = nxt
+    return out
+
+
+def test_fixture_conditions_are_not_complements(compiled, par):
+    """Guards the premise: a deadband and an overlap both exist as written."""
+    cf = compiled.construct_constraint_func()
+    assert compiled.constraint_names == ("band", "over")
+
+    dead = _flags(cf, _path(compiled, [(BAND_DEAD, OVER_OFF)])[0], par)
+    both = _flags(cf, _path(compiled, [(BAND_OFF, OVER_BOTH)])[0], par)
+
+    assert (dead[0], dead[1]) == (0, 0)
+    assert (both[2], both[3]) == (1, 1)
+
+
+@pytest.mark.parametrize(
+    ("regime_in", "expected"),
+    [
+        (0b00, 0b10),  # band takes bind (0), over takes bind (1)
+        (0b01, 0b11),  # band holds on !relax, over takes bind
+        (0b10, 0b00),  # band takes bind, over clears on !relax
+        (0b11, 0b01),  # band holds, over clears
+    ],
+)
+def test_latch_resolves_each_incoming_bit(compiled, par, regime_in, expected):
+    """Both constraints at their awkward cell at once, so a crossed bit shows."""
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(BAND_DEAD, OVER_BOTH)])
+
+    out, changed = constraint_path(
+        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    )
+
+    assert out.tolist() == [expected]
+    assert changed == (expected != regime_in)
+
+
+@pytest.mark.parametrize("regime_in", [0b00, BAND])
+def test_deadband_holds_the_incoming_bit(compiled, par, regime_in):
+    """Neither condition holds, so band can only come from the incoming regime."""
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(BAND_DEAD, OVER_OFF)])
+
+    out, changed = constraint_path(
+        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    )
+
+    assert out.tolist() == [regime_in]
+    assert changed == 0
+
+
+@pytest.mark.parametrize(("regime_in", "expected"), [(0b00, OVER), (OVER, 0b00)])
+def test_overlap_toggles_the_incoming_bit(compiled, par, regime_in, expected):
+    """Both conditions hold, so bind enters and !relax leaves on the same period."""
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(BAND_OFF, OVER_BOTH)])
+
+    out, changed = constraint_path(
+        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    )
+
+    assert out.tolist() == [expected]
+    assert changed == 1
+
+
+def test_fixed_point_reports_no_change(compiled, par):
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(BAND_ON, OVER_OFF)] * 6)
+    regime_in = np.full(6, BAND, dtype=np.int8)
+
+    out, changed = constraint_path(cf.address, path, par, regime_in, cf.n_constraint)
+
+    assert out.tolist() == [BAND] * 6
+    assert changed == 0
+
+
+def test_changed_counts_only_the_periods_that_moved(compiled, par):
+    cf = compiled.construct_constraint_func()
+    rows = [(BAND_ON, OVER_OFF)] * 5 + [(BAND_OFF, OVER_OFF)] * 2
+    regime_in = np.full(len(rows), BAND, dtype=np.int8)
+
+    out, changed = constraint_path(
+        cf.address, _path(compiled, rows), par, regime_in, cf.n_constraint
+    )
+
+    assert out.tolist() == [BAND] * 5 + [0b00] * 2
+    assert changed == 2
+
+
+def test_matches_a_python_latch_over_random_paths(compiled, par):
+    cf = compiled.construct_constraint_func()
+    rng = np.random.default_rng(0)
+
+    for _ in range(50):
+        rows = list(zip(rng.uniform(-3, 3, 40), rng.uniform(-3, 3, 40)))
+        path = _path(compiled, rows)
+        regime_in = rng.integers(0, 4, 40).astype(np.int8)
+
+        out, changed = constraint_path(
+            cf.address, path, par, regime_in, cf.n_constraint
+        )
+        want = _oracle(cf, path, par, regime_in)
+
+        assert out.tolist() == want.tolist()
+        assert changed == int((want != regime_in).sum())
+
+
+def test_latches_in_place_when_out_aliases_regime_in(compiled, par):
+    cf = compiled.construct_constraint_func()
+    rng = np.random.default_rng(1)
+    rows = list(zip(rng.uniform(-3, 3, 32), rng.uniform(-3, 3, 32)))
+    path = _path(compiled, rows)
+    regime_in = rng.integers(0, 4, 32).astype(np.int8)
+
+    fresh, fresh_changed = constraint_path(
+        cf.address, path, par, regime_in, cf.n_constraint
+    )
+    buf = regime_in.copy()
+    same, same_changed = constraint_path(
+        cf.address, path, par, buf, cf.n_constraint, out=buf
+    )
+
+    assert same is buf
+    assert same.tolist() == fresh.tolist()
+    assert same_changed == fresh_changed
+
+
+def test_empty_path_is_a_no_op(compiled, par):
+    cf = compiled.construct_constraint_func()
+    path = np.zeros((0, len(compiled.var_names)), dtype=np.float64)
+
+    out, changed = constraint_path(
+        cf.address, path, par, np.zeros(0, dtype=np.int8), cf.n_constraint
+    )
+
+    assert out.shape == (0,)
+    assert changed == 0
+
+
+@pytest.mark.parametrize("n_constraint", [0, -1, MAX_CONSTRAINTS + 1])
+def test_rejects_a_constraint_count_the_flag_buffer_cannot_hold(
+    compiled, par, n_constraint
+):
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(0.0, 0.0)])
+
+    with pytest.raises(ValueError, match="n_constraint"):
+        constraint_path(cf.address, path, par, np.zeros(1, dtype=np.int8), n_constraint)
+
+
+def test_rejects_a_regime_length_that_does_not_match_the_path(compiled, par):
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(0.0, 0.0)] * 3)
+
+    with pytest.raises(ValueError, match="regime_in has length"):
+        constraint_path(
+            cf.address, path, par, np.zeros(2, dtype=np.int8), cf.n_constraint
+        )


### PR DESCRIPTION
This pull request implements a native C-based regime constraint kernel for the OccBin algorithm, including its C, Cython, and Python bindings, as well as comprehensive parity tests. The kernel efficiently computes the regime mask over a simulated path, supporting multiple constraints with correct hysteresis and edge case handling. The pull request also improves configuration validation and updates documentation and test placement for consistency.

**New native OccBin constraint kernel:**

* Added `occbin.c` and `occbin.h` implementing the core constraint path algorithm in C, which latches regime bits per period and constraint, supporting up to two constraints (`MAX_CONSTRAINTS`). [[1]](diffhunk://#diff-65c23fb346fcca4704790f87d80bff209680581377163c035ebc55b9813d07b9R1-R22) [[2]](diffhunk://#diff-b22799833f42c125f94bc34f0b27735d3479dc4a82fa818fc1b271a5eb5198f5R1-R15)
* Added a Cython shim (`_occbin.pyx`) to marshal NumPy buffers and expose the kernel as a Python function, releasing the GIL and validating inputs.
* Added type stubs (`_occbin.pyi`) for static type checking and IDE support.
* Added a Python re-export (`occbin/__init__.py`) to make the compiled extension available as a mandatory import.

**Testing and validation:**

* Added an extensive parity test suite (`test_constraint_path.py`) covering normal, edge, and error cases, including randomized paths and in-place latching.
* Moved the kernel test directory from `tests/_ckernels/` to `tests/ckernels/` for consistency.

**Configuration and validation improvements:**

* Improved constraint parsing in `model_parser.py` to default the relax condition to `not(bind)` if not provided, and to raise an error if `bind` is missing.

These changes provide a robust, high-performance native implementation of regime constraint evaluation, with strong test coverage and improved configuration safety.

closes #395 