### PR TITLE
Replace internal scratch allocation with caller-provided arenas

### DIFF
--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -66,24 +66,37 @@ cdef extern from "core.h" nogil:
         int64_t T, int64_t nx, int64_t ny, int64_t n_exog,
         double *x_out, double *y_out)
 
+cdef extern from "../_common/sdsge_common.h" nogil:
+    ctypedef struct arena_size:
+        int64_t n_float
+        int64_t n_int
+
 cdef extern from "bicomplex_hessian.h" nogil:
     ctypedef void (*bc_residual_fn)(
         const bc256 *fwd, const bc256 *cur, const bc256 *par, bc256 *out)
-    int64_t sdsge_bicomplex_hessian(
+    arena_size sdsge_bicomplex_hessian_arena_size(
+        int64_t n_var, int64_t n_par, int64_t n_eq)
+    void sdsge_bicomplex_hessian(
         bc_residual_fn residual, const double *ss, const double *par,
-        int64_t n_var, int64_t n_par, int64_t n_eq, double *hessian)
+        int64_t n_var, int64_t n_par, int64_t n_eq, double *hessian,
+        double *arena)
 
 cdef extern from "klein_preproc.h" nogil:
     ctypedef void (*sdsge_residual_fn)(
         c128 *fwd, c128 *cur, c128 *par, c128 *out)
-    int64_t klein_preproc(
+    arena_size klein_preproc_arena_size(
+        int64_t n_var, int64_t n_par, int64_t n_eq)
+    void klein_preproc(
         sdsge_residual_fn resid, const double *ss, const double *par,
-        int64_t n_var, int64_t n_par, int64_t n_eq, double *a, double *b)
+        int64_t n_var, int64_t n_par, int64_t n_eq, double *a, double *b,
+        double *arena)
 
 cdef extern from "klein_postproc.h" nogil:
+    arena_size klein_postproc_arena_size(int64_t n_s, int64_t n_cs)
     int64_t klein_postproc(
         const c128 *s, const c128 *t, const c128 *z, int64_t n_s, int64_t n_cs,
-        c128 *f, c128 *p, int64_t *stab, c128 *eig)
+        c128 *f, c128 *p, int64_t *stab, c128 *eig, double *arena,
+        int64_t *iarena)
 
 
 cdef extern from "klein_qz.h" nogil:
@@ -91,10 +104,11 @@ cdef extern from "klein_qz.h" nogil:
     # header. We only reinterpret the scipy cython_lapack ``zgges`` capsule
     # pointer to this type and hand it straight to the C routine.
     ctypedef void (*klein_zgges_fn)()
+    arena_size klein_qz_arena_size(int64_t n)
     int64_t c_klein_qz "klein_qz" (
-        klein_zgges_fn zgges_ptr, int64_t n, c128 *s, c128 *t, c128 *z)
+        klein_zgges_fn zgges_ptr, int64_t n, c128 *s, c128 *t, c128 *z,
+        double *arena, int64_t *iarena)
     int KLEIN_QZ_OK
-    int KLEIN_QZ_ALLOC_FAIL
     int KLEIN_QZ_LAPACK_FAIL
 
 
@@ -161,8 +175,10 @@ cdef extern from "klein_solve.h" nogil:
         double *gss
         double *hss
 
-    int64_t sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out)
-    int SDSGE_KLEIN_SOLVE_ALLOC
+    arena_size sdsge_klein_solve1_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl, int64_t n_par)
+    int64_t sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out,
+                               double *arena, int64_t *iarena)
     int SDSGE_KLEIN_SOLVE_SS_SINGULAR
     int SDSGE_KLEIN_SOLVE_SS_NO_CONVERGE
     int SDSGE_KLEIN_SOLVE_QZ
@@ -171,34 +187,40 @@ cdef extern from "klein_solve.h" nogil:
     int SDSGE_KLEIN_SOLVE_SECOND_ORDER
     int SDSGE_KLEIN_SOLVE_RISK
 
+    arena_size sdsge_sgu_klein_solve2_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl, int64_t n_par,
+        int64_t n_exog)
     int64_t sdsge_sgu_klein_solve2(const sgu_klein_spec *spec,
-                                   sdsge_solve1 *out1, sdsge_solve2 *out2)
+                                   sdsge_solve1 *out1, sdsge_solve2 *out2,
+                                   double *arena, int64_t *iarena)
 
 cdef extern from "steady_state.h" nogil:
+    arena_size sdsge_newton_arena_size(int64_t n_var, int64_t n_par)
     int64_t sdsge_steady_state_newton(
         sdsge_residual_fn residual, const double *seed, const double *par,
         int64_t n_var, int64_t n_par, int64_t max_iter, double tol,
-        double *ss, int64_t *iters)
+        double *ss, int64_t *iters, double *arena, int64_t *iarena)
 
 
 cdef extern from "second_order.h" nogil:
+    arena_size sdsge_second_order_arena_size(int64_t n, int64_t nx)
     int64_t sdsge_second_order(
         const double *a, const double *b, const double *f_xx,
         const double *gx, const double *hx, int64_t n, int64_t nx,
-        double *gxx, double *hxx)
+        double *gxx, double *hxx, double *arena, int64_t *iarena)
+    arena_size sdsge_second_order_risk_arena_size(
+        int64_t n, int64_t nx, int64_t ne)
     int64_t sdsge_second_order_risk(
         const double *a, const double *b, const double *f_xx,
         const double *gx, const double *gxx, const double *eta,
-        int64_t n, int64_t nx, int64_t ne, double *gss, double *hss)
+        int64_t n, int64_t nx, int64_t ne, double *gss, double *hss,
+        double *arena, int64_t *iarena)
 
 
 cdef _raise_solve_error(int64_t err, str who):
     """Map a fused-solve status onto the staged shims' messages, verbatim:
-    callers match on them. An allocation failure names the fused entry point
-    rather than the stage that hit it, since every stage reports the same thing.
+    callers match on them.
     """
-    if err == SDSGE_KLEIN_SOLVE_ALLOC:
-        raise MemoryError(f"{who}: allocation failed.")
     if err == SDSGE_KLEIN_SOLVE_SS_SINGULAR:
         raise ValueError("steady_state_newton: singular Jacobian (a - b).")
     if err == SDSGE_KLEIN_SOLVE_SS_NO_CONVERGE:
@@ -382,13 +404,16 @@ def klein_postprocess(s, t, z, int64_t n_states):
     cdef double complex[::1] ev = eig
     cdef int64_t stab = 0
     cdef int64_t err
+    cdef arena_size sz = klein_postproc_arena_size(n_s, n_cs)
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
         err = klein_postproc(
             <c128 *>&sv[0, 0], <c128 *>&tv[0, 0], <c128 *>&zv[0, 0], n_s, n_cs,
             <c128 *>&fv[0, 0] if n_cs > 0 else NULL,
-            <c128 *>&pv[0, 0], &stab, <c128 *>&ev[0])
-    if err == -1:
-        raise MemoryError("klein_postprocess: allocation failed.")
+            <c128 *>&pv[0, 0], &stab, <c128 *>&ev[0], &arv[0], &iarv[0])
     if err == -2:
         raise ValueError(
             "klein_postprocess: singular z11/s11 (Blanchard-Kahn failure)."
@@ -438,13 +463,14 @@ def klein_preprocess(
     cdef const double *ss_ptr = &ssv[0] if n_var > 0 else NULL
     cdef const double *par_ptr = &parv[0] if n_par > 0 else NULL
     cdef sdsge_residual_fn resid = <sdsge_residual_fn><void*>residual_addr
-    cdef int64_t err
+    arena = np.empty(
+        klein_preproc_arena_size(n_var, n_par, n_eq).n_float, dtype=np.float64
+    )
+    cdef double[::1] arv = arena
     with nogil:
-        err = klein_preproc(
+        klein_preproc(
             resid, ss_ptr, par_ptr, n_var, n_par, n_eq,
-            &av[0, 0], &bv[0, 0])
-    if err != 0:
-        raise MemoryError("klein_preprocess: allocation failed.")
+            &av[0, 0], &bv[0, 0], &arv[0])
     return a, b
 
 
@@ -474,12 +500,16 @@ def klein_qz(a, b):
     cdef double complex[::1, :] bv = b_f
     cdef double complex[::1, :] zv = z
     cdef int64_t status
+    cdef arena_size sz = klein_qz_arena_size(n)
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
         status = c_klein_qz(
             _zgges, n,
-            <c128 *>&av[0, 0], <c128 *>&bv[0, 0], <c128 *>&zv[0, 0])
-    if status == KLEIN_QZ_ALLOC_FAIL:
-        raise MemoryError("klein_qz: workspace allocation failed.")
+            <c128 *>&av[0, 0], <c128 *>&bv[0, 0], <c128 *>&zv[0, 0],
+            &arv[0], &iarv[0])
     if status != KLEIN_QZ_OK:
         raise RuntimeError("klein_qz: LAPACK zgges failed.")
     return a_f, b_f, z
@@ -494,7 +524,7 @@ def steady_state_newton(
 ):
     """Newton solve of ``F(ss, ss) = 0`` from ``seed``, driving a numba residual
     @cfunc (``build_cfunc``) by its ``.address``. The Jacobian ``a - b`` comes from
-    ``klein_preproc`` each step; the update is ``sdsge_solve``. Returns
+    ``klein_preproc`` each step; the update is an in-place LU. Returns
     ``(ss, iters)``; raises on singular Jacobian or non-convergence.
     """
     cdef int64_t n_var = seed.shape[0]
@@ -513,12 +543,15 @@ def steady_state_newton(
     cdef sdsge_residual_fn resid = <sdsge_residual_fn><void*>residual_addr
     cdef int64_t iters = 0
     cdef int64_t err
+    cdef arena_size sz = sdsge_newton_arena_size(n_var, n_par)
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
         err = sdsge_steady_state_newton(
             resid, seed_ptr, par_ptr, n_var, n_par, max_iter, tol,
-            ss_ptr, &iters)
-    if err == -1:
-        raise MemoryError("steady_state_newton: allocation failed.")
+            ss_ptr, &iters, &arv[0], &iarv[0])
     if err == -2:
         raise ValueError("steady_state_newton: singular Jacobian (a - b).")
     if err == -3:
@@ -613,8 +646,15 @@ def klein_solve1(
     out.B = &Bv[0, 0] if n_exog > 0 else NULL
 
     cdef int64_t err
+    cdef arena_size sz = sdsge_klein_solve1_arena_size(
+        n_var, n_state, n_ctrl, n_par
+    )
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
-        err = sdsge_klein_solve1(&spec, &out)
+        err = sdsge_klein_solve1(&spec, &out, &arv[0], &iarv[0])
 
     _raise_solve_error(err, "klein_solve1")
     return ss, a, b, f, p, int(out.stab), eig, A, B
@@ -741,8 +781,15 @@ def sgu_klein_solve2(
     out2.hss = &hssv[0]
 
     cdef int64_t err
+    cdef arena_size sz = sdsge_sgu_klein_solve2_arena_size(
+        n_var, n_state, n_ctrl, n_par, n_exog
+    )
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
-        err = sdsge_sgu_klein_solve2(&spec, &out, &out2)
+        err = sdsge_sgu_klein_solve2(&spec, &out, &out2, &arv[0], &iarv[0])
 
     _raise_solve_error(err, "sgu_klein_solve2")
     return ss, f, p, int(out.stab), eig, gxx, hxx, gss, hss, A, B
@@ -776,12 +823,15 @@ def second_order(a, b, f_xx, gx, hx, int64_t n_state):
     cdef const double *gx_ptr = &gxv[0, 0] if ny > 0 else NULL
     cdef double *gv_ptr = &gv[0, 0, 0] if ny > 0 else NULL
     cdef int64_t err
+    cdef arena_size sz = sdsge_second_order_arena_size(n, nx)
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
         err = sdsge_second_order(
             &av[0, 0], &bv[0, 0], &fxxv[0, 0, 0], gx_ptr, &hxv[0, 0], n, nx,
-            gv_ptr, &hv[0, 0, 0])
-    if err == -1:
-        raise MemoryError("solve_second_order: allocation failed.")
+            gv_ptr, &hv[0, 0, 0], &arv[0], &iarv[0])
     if err == -2:
         raise ValueError("solve_second_order: singular symmetry-reduced system.")
     return gxx, hxx
@@ -815,12 +865,15 @@ def second_order_risk(a, b, f_xx, gx, gxx, eta, int64_t n_state):
     cdef const double *eta_ptr = &etav[0, 0] if ne > 0 else NULL
     cdef double *gss_ptr = &gssv[0] if ny > 0 else NULL
     cdef int64_t err
+    cdef arena_size sz = sdsge_second_order_risk_arena_size(n, nx, ne)
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iarv = iarena
     with nogil:
         err = sdsge_second_order_risk(
             &av[0, 0], &bv[0, 0], &fxxv[0, 0, 0], gx_ptr, gxx_ptr, eta_ptr,
-            n, nx, ne, gss_ptr, &hssv[0])
-    if err == -1:
-        raise MemoryError("solve_second_order_risk: allocation failed.")
+            n, nx, ne, gss_ptr, &hssv[0], &arv[0], &iarv[0])
     if err == -2:
         raise ValueError("solve_second_order_risk: singular [Qg Qh] system.")
     return gss, hss
@@ -964,12 +1017,15 @@ def bicomplex_hessian(
     cdef const double *ss_ptr = &steady_state[0] if n_var > 0 else NULL
     cdef const double *par_ptr = &params[0] if n_par > 0 else NULL
     cdef bc_residual_fn residual = <bc_residual_fn><void*>residual_addr
-    cdef int64_t err
+    arena = np.empty(
+        sdsge_bicomplex_hessian_arena_size(n_var, n_par, n_eq).n_float,
+        dtype=np.float64,
+    )
+    cdef double[::1] arv = arena
     with nogil:
-        err = sdsge_bicomplex_hessian(
-            residual, ss_ptr, par_ptr, n_var, n_par, n_eq, &hv[0, 0, 0])
-    if err != 0:
-        raise MemoryError("bicomplex_hessian: allocation failed.")
+        sdsge_bicomplex_hessian(
+            residual, ss_ptr, par_ptr, n_var, n_par, n_eq, &hv[0, 0, 0],
+            &arv[0])
     return hessian
 
 

--- a/SymbolicDSGE/_ckernels/core/bicomplex_hessian.c
+++ b/SymbolicDSGE/_ckernels/core/bicomplex_hessian.c
@@ -1,5 +1,4 @@
 #include "bicomplex_hessian.h"
-#include <stdlib.h>
 
 /* Component slots of a bc256: real = a.re, i-unit = a.im, j-unit = b.re,
  * ij = b.im. Perturbations set the i/j slots of a stacked arg (fwd for idx <
@@ -23,24 +22,27 @@ static void set_j_unit(bc256 *SDSGE_RESTRICT fwd, bc256 *SDSGE_RESTRICT cur,
   }
 }
 
-i64 sdsge_bicomplex_hessian(bc_residual_fn residual,
-                            const f64 *SDSGE_RESTRICT ss,
-                            const f64 *SDSGE_RESTRICT par, i64 n_var, i64 n_par,
-                            i64 n_eq, f64 *SDSGE_RESTRICT hessian) {
+arena_size sdsge_bicomplex_hessian_arena_size(const i64 n_var, const i64 n_par,
+                                              const i64 n_eq) {
+  return make_sizer(4 * (2 * n_var + n_par + n_eq), /* fwd, cur, par, out */
+                    0);
+}
+
+void sdsge_bicomplex_hessian(bc_residual_fn residual,
+                             const f64 *SDSGE_RESTRICT ss,
+                             const f64 *SDSGE_RESTRICT par, i64 n_var, i64 n_par,
+                             i64 n_eq, f64 *SDSGE_RESTRICT hessian,
+                             f64 *SDSGE_RESTRICT arena) {
   const i64 n2 = 2 * n_var;
 
-  bc256 *fwd = (bc256 *)malloc((size_t)(n_var > 0 ? n_var : 1) * sizeof(bc256));
-  bc256 *cur = (bc256 *)malloc((size_t)(n_var > 0 ? n_var : 1) * sizeof(bc256));
-  bc256 *par_c =
-      (bc256 *)malloc((size_t)(n_par > 0 ? n_par : 1) * sizeof(bc256));
-  bc256 *out = (bc256 *)malloc((size_t)(n_eq > 0 ? n_eq : 1) * sizeof(bc256));
-  if (!fwd || !cur || !par_c || !out) {
-    free(fwd);
-    free(cur);
-    free(par_c);
-    free(out);
-    return SDSGE_HESSIAN_ALLOC_FAIL;
-  }
+  bc256 *bp = (bc256 *)arena;
+  bc256 *fwd = bp;
+  bp += n_var;
+  bc256 *cur = bp;
+  bp += n_var;
+  bc256 *par_c = bp;
+  bp += n_par;
+  bc256 *out = bp;
 
   /* Base: real steady state at both t+1 and t; params real. Set once. */
   for (i64 k = 0; k < n_var; ++k) {
@@ -69,10 +71,4 @@ i64 sdsge_bicomplex_hessian(bc_residual_fn residual,
       set_j_unit(fwd, cur, n_var, j, 0.0);
     }
   }
-
-  free(fwd);
-  free(cur);
-  free(par_c);
-  free(out);
-  return SDSGE_HESSIAN_OK;
 }

--- a/SymbolicDSGE/_ckernels/core/bicomplex_hessian.h
+++ b/SymbolicDSGE/_ckernels/core/bicomplex_hessian.h
@@ -20,10 +20,14 @@
 typedef void (*bc_residual_fn)(const bc256 *fwd, const bc256 *cur,
                                const bc256 *par, bc256 *out);
 
-i64 sdsge_bicomplex_hessian(bc_residual_fn residual,
-                            const f64 *SDSGE_RESTRICT ss,
-                            const f64 *SDSGE_RESTRICT par, i64 n_var, i64 n_par,
-                            i64 n_eq, f64 *SDSGE_RESTRICT hessian);
+arena_size sdsge_bicomplex_hessian_arena_size(i64 n_var, i64 n_par, i64 n_eq);
+
+/* Total: the sweep has no failure mode once its scratch comes from the caller. */
+void sdsge_bicomplex_hessian(bc_residual_fn residual,
+                             const f64 *SDSGE_RESTRICT ss,
+                             const f64 *SDSGE_RESTRICT par, i64 n_var, i64 n_par,
+                             i64 n_eq, f64 *SDSGE_RESTRICT hessian,
+                             f64 *SDSGE_RESTRICT arena);
 
 /* The step, and the only source of it: the sweep reads this directly.
  *
@@ -38,8 +42,5 @@ i64 sdsge_bicomplex_hessian(bc_residual_fn residual,
  * stays flat to at least 1e-13. 1e-9 sits a decade inside that plateau. */
 #define SDSGE_HESSIAN_STEP 1e-9
 #define SDSGE_HESSIAN_INV_STEP2 1e18
-
-#define SDSGE_HESSIAN_OK 0
-#define SDSGE_HESSIAN_ALLOC_FAIL -1
 
 #endif /* SDSGE_BICOMPLEX_HESSIAN_H */

--- a/SymbolicDSGE/_ckernels/core/klein_postproc.c
+++ b/SymbolicDSGE/_ckernels/core/klein_postproc.c
@@ -1,10 +1,19 @@
 #include "klein_postproc.h"
-#include <stdlib.h>
+
+arena_size klein_postproc_arena_size(const i64 n_s, const i64 n_cs) {
+  const i64 sq = n_s * n_s;
+  return make_sizer(2 * (6 * sq        /* z11, s11, t11, z11i, dyn, tmp */
+                         + n_cs * n_s  /* z21 */
+                         + sq          /* LU factor copy */
+                         + sq),        /* identity RHS for the inverse */
+                    n_s /* LU pivot */);
+}
 
 i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
                    const c128 *SDSGE_RESTRICT z, const i64 n_s, const i64 n_cs,
                    c128 *SDSGE_RESTRICT f, c128 *SDSGE_RESTRICT p,
-                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig) {
+                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig,
+                   f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena) {
   i64 N = n_s + n_cs;
 
   /* Stamp the stab sentinel up front: every early-return failure below leaves a
@@ -13,32 +22,31 @@ i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
    * with the real 0 / -1 / +1 on the successful path. */
   *stab = SDSGE_KLEIN_STAB_UNSET;
 
-  /* A model with no states has no Klein solution. Fail fast before any
-   * allocation -- the state/inv/solve routines all assume n_s >= 1. */
+  /* A model with no states has no Klein solution. Fail fast: the state/inv/solve
+   * routines all assume n_s >= 1. */
   if (n_s <= 0) {
     return SDSGE_KLEIN_POSTPROC_INVALID;
   }
 
-  /* Allocate z11, z21, s11, t11 */
-  c128 *SDSGE_RESTRICT z11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-  c128 *SDSGE_RESTRICT z21 = (c128 *)malloc(sizeof(c128) * n_cs * n_s);
-  c128 *SDSGE_RESTRICT s11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-  c128 *SDSGE_RESTRICT t11 = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-  c128 *SDSGE_RESTRICT z11i = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-
-  c128 *SDSGE_RESTRICT dyn = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-  c128 *SDSGE_RESTRICT tmp = (c128 *)malloc(sizeof(c128) * n_s * n_s);
-
-  if (!z11 || !z21 || !s11 || !t11 || !z11i || !dyn || !tmp) {
-    free(z11);
-    free(z21);
-    free(s11);
-    free(t11);
-    free(z11i);
-    free(dyn);
-    free(tmp);
-    return SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
-  }
+  const i64 sq = n_s * n_s;
+  c128 *cp = (c128 *)arena;
+  c128 *SDSGE_RESTRICT z11 = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT z21 = cp;
+  cp += n_cs * n_s;
+  c128 *SDSGE_RESTRICT s11 = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT t11 = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT z11i = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT dyn = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT tmp = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT lu = cp;
+  cp += sq;
+  c128 *SDSGE_RESTRICT eye = cp;
 
   /* Fill z11, s11, t11 */
   for (i64 i = 0; i < n_s; ++i) {
@@ -56,20 +64,20 @@ i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
     }
   }
 
-  /* Invert z11. c128_inv returns SDSGE_LU_SINGULAR when z11 is singular (a
-   * Blanchard-Kahn failure), or SDSGE_LU_ALLOC_FAIL on OOM. */
-  i64 err_z = c128_inv(z11, n_s, z11i);
-  if (err_z != SDSGE_LU_SUCCESS) {
-    free(z11);
-    free(z21);
-    free(s11);
-    free(t11);
-    free(z11i);
-    free(dyn);
-    free(tmp);
-    return (err_z == SDSGE_LU_SINGULAR) ? SDSGE_KLEIN_POSTPROC_SINGULAR
-                                        : SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
+  /* z11i = z11^-1, factored out of place because z11 is still needed below. A
+   * singular z11 is a Blanchard-Kahn failure. */
+  for (i64 i = 0; i < sq; ++i) {
+    lu[i] = z11[i];
   }
+  for (i64 i = 0; i < n_s; ++i) {
+    for (i64 j = 0; j < n_s; ++j) {
+      eye[i * n_s + j] = c128_make(i == j ? 1.0 : 0.0, 0.0);
+    }
+  }
+  if (c128_lu_factor_inplace(lu, iarena, n_s) != SDSGE_LU_SUCCESS) {
+    return SDSGE_KLEIN_POSTPROC_SINGULAR;
+  }
+  c128_lu_solve(lu, iarena, eye, z11i, n_s, n_s);
 
   *stab = 0;
   if (c128_abs(t[(n_s - 1) * N + (n_s - 1)]) >
@@ -92,31 +100,16 @@ i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
     }
   }
 
-  /* dyn = solve(s11, t11). Singular s11 is again a Blanchard-Kahn failure. */
-  i64 dyn_err = c128_solve(s11, t11, n_s, n_s, dyn);
-  if (dyn_err != SDSGE_LU_SUCCESS) {
-    free(z11);
-    free(z21);
-    free(s11);
-    free(t11);
-    free(z11i);
-    free(dyn);
-    free(tmp);
-    return (dyn_err == SDSGE_LU_SINGULAR) ? SDSGE_KLEIN_POSTPROC_SINGULAR
-                                          : SDSGE_KLEIN_POSTPROC_ALLOC_FAIL;
+  /* dyn = solve(s11, t11). s11 is dead after this, so it factors in place.
+   * Singular s11 is again a Blanchard-Kahn failure. */
+  if (c128_lu_factor_inplace(s11, iarena, n_s) != SDSGE_LU_SUCCESS) {
+    return SDSGE_KLEIN_POSTPROC_SINGULAR;
   }
+  c128_lu_solve(s11, iarena, t11, dyn, n_s, n_s);
 
   c128_matmul(z21, z11i, n_cs, n_s, n_s, f);
   c128_matmul(z11, dyn, n_s, n_s, n_s, tmp);
   c128_matmul(tmp, z11i, n_s, n_s, n_s, p);
-
-  free(z11);
-  free(z21);
-  free(s11);
-  free(t11);
-  free(z11i);
-  free(dyn);
-  free(tmp);
 
   return SDSGE_KLEIN_POSTPROC_SUCCESS;
 }

--- a/SymbolicDSGE/_ckernels/core/klein_postproc.h
+++ b/SymbolicDSGE/_ckernels/core/klein_postproc.h
@@ -3,13 +3,15 @@
 #include "../_common/sdsge_common.h"
 #include "../_common/sdsge_complex.h"
 
+arena_size klein_postproc_arena_size(i64 n_s, i64 n_cs);
+
 i64 klein_postproc(const c128 *SDSGE_RESTRICT s, const c128 *SDSGE_RESTRICT t,
                    const c128 *SDSGE_RESTRICT z, const i64 n_s, const i64 n_cs,
                    c128 *SDSGE_RESTRICT f, c128 *SDSGE_RESTRICT p,
-                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig);
+                   i64 *SDSGE_RESTRICT stab, c128 *SDSGE_RESTRICT eig,
+                   f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena);
 
 #define SDSGE_KLEIN_POSTPROC_SUCCESS 0
-#define SDSGE_KLEIN_POSTPROC_ALLOC_FAIL -1
 #define SDSGE_KLEIN_POSTPROC_SINGULAR -2
 #define SDSGE_KLEIN_POSTPROC_INVALID -3
 

--- a/SymbolicDSGE/_ckernels/core/klein_preproc.c
+++ b/SymbolicDSGE/_ckernels/core/klein_preproc.c
@@ -1,5 +1,4 @@
 #include "klein_preproc.h"
-#include <stdlib.h>
 
 #define CJAC_STEP 1e-30
 
@@ -29,23 +28,26 @@ static void perturb_sweep(sdsge_residual_fn resid,
   }
 }
 
-i64 klein_preproc(sdsge_residual_fn resid, const f64 *SDSGE_RESTRICT ss,
-                  const f64 *SDSGE_RESTRICT par, const i64 n_var,
-                  const i64 n_par, const i64 n_eq, f64 *SDSGE_RESTRICT a,
-                  f64 *SDSGE_RESTRICT b) {
-  c128 *base = (c128 *)malloc((size_t)(n_var > 0 ? n_var : 1) * sizeof(c128));
-  c128 *par_c = (c128 *)malloc((size_t)(n_par > 0 ? n_par : 1) * sizeof(c128));
-  c128 *fwd = (c128 *)malloc((size_t)(n_var > 0 ? n_var : 1) * sizeof(c128));
-  c128 *cur = (c128 *)malloc((size_t)(n_var > 0 ? n_var : 1) * sizeof(c128));
-  c128 *out = (c128 *)malloc((size_t)(n_eq > 0 ? n_eq : 1) * sizeof(c128));
-  if (!base || !par_c || !fwd || !cur || !out) {
-    free(base);
-    free(par_c);
-    free(fwd);
-    free(cur);
-    free(out);
-    return SDSGE_PREKLEIN_ALLOC_FAIL;
-  }
+arena_size klein_preproc_arena_size(const i64 n_var, const i64 n_par,
+                                    const i64 n_eq) {
+  return make_sizer(2 * (3 * n_var + n_par + n_eq), /* base, fwd, cur, par, out */
+                    0);
+}
+
+void klein_preproc(sdsge_residual_fn resid, const f64 *SDSGE_RESTRICT ss,
+                   const f64 *SDSGE_RESTRICT par, const i64 n_var,
+                   const i64 n_par, const i64 n_eq, f64 *SDSGE_RESTRICT a,
+                   f64 *SDSGE_RESTRICT b, f64 *SDSGE_RESTRICT arena) {
+  c128 *p = (c128 *)arena;
+  c128 *base = p;
+  p += n_var;
+  c128 *par_c = p;
+  p += n_par;
+  c128 *fwd = p;
+  p += n_var;
+  c128 *cur = p;
+  p += n_var;
+  c128 *out = p;
 
   for (i64 i = 0; i < n_var; ++i) {
     base[i] = c128_from_real(ss[i]);
@@ -57,11 +59,4 @@ i64 klein_preproc(sdsge_residual_fn resid, const f64 *SDSGE_RESTRICT ss,
 
   perturb_sweep(resid, base, fwd, cur, par_c, n_var, n_eq, 1, 1.0, a, out);
   perturb_sweep(resid, base, fwd, cur, par_c, n_var, n_eq, 0, -1.0, b, out);
-
-  free(base);
-  free(par_c);
-  free(fwd);
-  free(cur);
-  free(out);
-  return SDSGE_PREKLEIN_OK;
 }

--- a/SymbolicDSGE/_ckernels/core/klein_preproc.h
+++ b/SymbolicDSGE/_ckernels/core/klein_preproc.h
@@ -7,13 +7,13 @@
 typedef void (*sdsge_residual_fn)(const c128 *fwd, const c128 *cur,
                                   const c128 *par, c128 *out);
 
-i64 klein_preproc(sdsge_residual_fn residual, const f64 *SDSGE_RESTRICT ss,
-                  const f64 *SDSGE_RESTRICT par, const i64 n_var,
-                  const i64 n_par, const i64 n_eq, f64 *SDSGE_RESTRICT a,
-                  f64 *SDSGE_RESTRICT b);
+arena_size klein_preproc_arena_size(i64 n_var, i64 n_par, i64 n_eq);
 
-/* ERROR CODES */
-#define SDSGE_PREKLEIN_OK 0
-#define SDSGE_PREKLEIN_ALLOC_FAIL -1
+/* Complex-step pencil a = dF/dfwd, b = -dF/dcur at `ss`. Total: the sweep has no
+ * failure mode once its scratch comes from the caller. */
+void klein_preproc(sdsge_residual_fn residual, const f64 *SDSGE_RESTRICT ss,
+                   const f64 *SDSGE_RESTRICT par, const i64 n_var,
+                   const i64 n_par, const i64 n_eq, f64 *SDSGE_RESTRICT a,
+                   f64 *SDSGE_RESTRICT b, f64 *SDSGE_RESTRICT arena);
 
 #endif /* SDSGE_KLEIN_PREPROC_H */

--- a/SymbolicDSGE/_ckernels/core/klein_qz.c
+++ b/SymbolicDSGE/_ckernels/core/klein_qz.c
@@ -1,7 +1,5 @@
 #include "klein_qz.h"
 
-#include <stdlib.h>
-
 /* Klein 'ouc' selection: select |alpha/beta| > 1, i.e. the generalized
  * eigenvalue lies outside the unit circle. Division-safe magnitude compare
  * (|alpha|^2 > |beta|^2); beta == 0 (infinite eigenvalue) selects true, as it
@@ -13,8 +11,16 @@ static int klein_ouc(const c128 *alpha, const c128 *beta) {
   return aa > bb;
 }
 
+arena_size klein_qz_arena_size(const i64 n) {
+  return make_sizer(2 * n + 2 * n                       /* alpha, beta */
+                        + 8 * n                         /* rwork */
+                        + 2 * KLEIN_QZ_LWORK_PER_N * n, /* work */
+                    (n + 1) / 2 /* bwork, n Fortran LOGICALs */);
+}
+
 i64 klein_qz(klein_zgges_fn zgges, i64 n, c128 *SDSGE_RESTRICT s,
-             c128 *SDSGE_RESTRICT t, c128 *SDSGE_RESTRICT z) {
+             c128 *SDSGE_RESTRICT t, c128 *SDSGE_RESTRICT z,
+             f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena) {
   if (n == 0) {
     return KLEIN_QZ_OK;
   }
@@ -32,48 +38,20 @@ i64 klein_qz(klein_zgges_fn zgges, i64 n, c128 *SDSGE_RESTRICT s,
   int ldvsl = 1;
   c128 vsl_dummy = c128_make(0.0, 0.0); /* not referenced when jobvsl = 'N' */
 
-  c128 *alpha = (c128 *)malloc((size_t)n * sizeof(c128));
-  c128 *beta = (c128 *)malloc((size_t)n * sizeof(c128));
-  f64 *rwork = (f64 *)malloc((size_t)(8 * n) * sizeof(f64));
-  int *bwork = (int *)malloc((size_t)n * sizeof(int));
-  if (alpha == NULL || beta == NULL || rwork == NULL || bwork == NULL) {
-    free(alpha);
-    free(beta);
-    free(rwork);
-    free(bwork);
-    return KLEIN_QZ_ALLOC_FAIL;
-  }
+  c128 *cp = (c128 *)arena;
+  c128 *alpha = cp;
+  cp += n;
+  c128 *beta = cp;
+  cp += n;
+  f64 *rwork = (f64 *)cp;
+  c128 *work = (c128 *)(rwork + 8 * n);
+  int *bwork = (int *)iarena;
 
-  /* Workspace query (lwork = -1): zgges writes the optimal complex work size to
-   * wq.re. */
-  c128 wq = c128_make(0.0, 0.0);
-  int lwork = -1;
-  zgges(&jobvsl, &jobvsr, &sort, &klein_ouc, &n32, s, &n32, t, &n32, &sdim,
-        alpha, beta, &vsl_dummy, &ldvsl, z, &n32, &wq, &lwork, rwork, bwork,
-        &info);
-
-  lwork = (int)wq.re;
-  if (lwork < 1) {
-    lwork = 1;
-  }
-  c128 *work = (c128 *)malloc((size_t)lwork * sizeof(c128));
-  if (work == NULL) {
-    free(alpha);
-    free(beta);
-    free(rwork);
-    free(bwork);
-    return KLEIN_QZ_ALLOC_FAIL;
-  }
+  const int lwork = (int)(KLEIN_QZ_LWORK_PER_N * n);
 
   zgges(&jobvsl, &jobvsr, &sort, &klein_ouc, &n32, s, &n32, t, &n32, &sdim,
         alpha, beta, &vsl_dummy, &ldvsl, z, &n32, work, &lwork, rwork, bwork,
         &info);
-
-  free(work);
-  free(alpha);
-  free(beta);
-  free(rwork);
-  free(bwork);
 
   return (info != 0) ? KLEIN_QZ_LAPACK_FAIL : KLEIN_QZ_OK;
 }

--- a/SymbolicDSGE/_ckernels/core/klein_qz.h
+++ b/SymbolicDSGE/_ckernels/core/klein_qz.h
@@ -12,8 +12,8 @@ typedef int (*klein_zselect2_fn)(const c128 *alpha, const c128 *beta);
 /* LAPACK zgges, reached through a runtime function-pointer address (pulled from
  * scipy.linalg.cython_lapack.__pyx_capi__['zgges'] on the Python side), so this
  * translation unit links against no LAPACK at build time. All INTEGER arguments
- * are 32-bit `int` (LAPACK default INTEGER; scipy's cython_lapack is not ILP64);
- * `bwork` is a Fortran LOGICAL array, i.e. `int*`. */
+ * are 32-bit `int` (LAPACK default INTEGER; scipy's cython_lapack is not
+ * ILP64); `bwork` is a Fortran LOGICAL array, i.e. `int*`. */
 typedef void (*klein_zgges_fn)(const char *jobvsl, const char *jobvsr,
                                const char *sort, klein_zselect2_fn selctg,
                                const int *n, c128 *a, const int *lda, c128 *b,
@@ -31,15 +31,25 @@ typedef void (*klein_zgges_fn)(const char *jobvsl, const char *jobvsr,
  *   t : IN  the B pencil        -> OUT ordered Schur factor T
  *   z : OUT right Schur vectors Z  (need not be initialized)
  * s and t are overwritten in place; the caller materializes the complex pencil
- * into them. All scratch (alpha/beta/rwork/bwork/work) is allocated internally.
+ * into them. alpha/beta/rwork/work come off `arena`, bwork off `iarena`.
  *
- * Returns KLEIN_QZ_OK, KLEIN_QZ_ALLOC_FAIL, or KLEIN_QZ_LAPACK_FAIL (zgges
- * info != 0). n == 0 is a no-op returning KLEIN_QZ_OK. */
+ * Returns KLEIN_QZ_OK or KLEIN_QZ_LAPACK_FAIL (zgges info != 0). n == 0 is a
+ * no-op returning KLEIN_QZ_OK. */
+arena_size klein_qz_arena_size(i64 n);
+
 i64 klein_qz(klein_zgges_fn zgges, i64 n, c128 *SDSGE_RESTRICT s,
-             c128 *SDSGE_RESTRICT t, c128 *SDSGE_RESTRICT z);
+             c128 *SDSGE_RESTRICT t, c128 *SDSGE_RESTRICT z,
+             f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena);
 
 #define KLEIN_QZ_OK 0
-#define KLEIN_QZ_ALLOC_FAIL -1
 #define KLEIN_QZ_LAPACK_FAIL -2
+
+/* Provisioned zgges complex workspace, in units of n. LAPACK's documented
+ optimum is `n*(nb+1)` for block size nb; 64 is the largest `nb` shipped by
+ reference builds. We allocate the entire n*(64 + 1) unconditionally as the
+ maximum possible `nb` encountered in the reference spec. The arena space is
+ therefore guaranteed to be runtime-optimal but have no memory-optimality
+ guarantees. */
+#define KLEIN_QZ_LWORK_PER_N 65
 
 #endif /* KLEIN_QZ_H */

--- a/SymbolicDSGE/_ckernels/core/klein_solve.c
+++ b/SymbolicDSGE/_ckernels/core/klein_solve.c
@@ -50,7 +50,34 @@ static inline void sdsge_bx_from_B(const f64 *SDSGE_RESTRICT B,
   }
 }
 
-i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out) {
+/* Componentwise max: the stages run one after another off the same arena. */
+static inline arena_size sdsge_max_arena(const arena_size a,
+                                         const arena_size b) {
+  return make_sizer(max_i64(a.n_float, b.n_float), max_i64(a.n_int, b.n_int));
+}
+
+arena_size sdsge_klein_solve1_arena_size(const i64 n_var, const i64 n_state,
+                                         const i64 n_ctrl, const i64 n_par) {
+  arena_size size = sdsge_newton_arena_size(n_var, n_par);
+  size = sdsge_max_arena(size, klein_preproc_arena_size(n_var, n_par, n_var));
+  size = sdsge_max_arena(size, klein_qz_arena_size(n_var));
+  return sdsge_max_arena(size, klein_postproc_arena_size(n_state, n_ctrl));
+}
+
+arena_size sdsge_sgu_klein_solve2_arena_size(const i64 n_var, const i64 n_state,
+                                             const i64 n_ctrl, const i64 n_par,
+                                             const i64 n_exog) {
+  arena_size size =
+      sdsge_klein_solve1_arena_size(n_var, n_state, n_ctrl, n_par);
+  size = sdsge_max_arena(
+      size, sdsge_bicomplex_hessian_arena_size(n_var, n_par, n_var));
+  size = sdsge_max_arena(size, sdsge_second_order_arena_size(n_var, n_state));
+  return sdsge_max_arena(
+      size, sdsge_second_order_risk_arena_size(n_var, n_state, n_exog));
+}
+
+i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out,
+                          f64 *arena, i64 *iarena) {
   const i64 n = spec->n_var;
 
   /* Resolve the steady state at the current params by Newton from ss_seed, then
@@ -59,28 +86,24 @@ i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out) {
   i64 iters = 0;
   const i64 rc = sdsge_steady_state_newton(
       spec->residual, spec->ss_seed, spec->params, n, spec->n_par,
-      SDSGE_SS_MAX_ITER, SDSGE_SS_TOL, out->ss, &iters);
+      SDSGE_SS_MAX_ITER, SDSGE_SS_TOL, out->ss, &iters, arena, iarena);
   if (rc != SDSGE_NEWTON_OK) {
     return rc;
   }
 
-  if (klein_preproc(spec->residual, out->ss, spec->params, n, spec->n_par, n,
-                    out->a_real, out->b_real) != SDSGE_PREKLEIN_OK) {
-    return SDSGE_KLEIN_SOLVE_ALLOC;
-  }
+  klein_preproc(spec->residual, out->ss, spec->params, n, spec->n_par, n,
+                out->a_real, out->b_real, arena);
   return SDSGE_KLEIN_SOLVE_OK;
 }
 
-i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out) {
+i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out,
+                            f64 *arena, i64 *iarena) {
   const i64 n = spec->n_var;
 
   sdsge_to_complex_colmajor(out->a_real, out->s, n);
   sdsge_to_complex_colmajor(out->b_real, out->t, n);
-  const i64 qz = klein_qz(spec->zgges, n, out->s, out->t, out->z);
-  if (qz == KLEIN_QZ_ALLOC_FAIL) {
-    return SDSGE_KLEIN_SOLVE_ALLOC;
-  }
-  if (qz != KLEIN_QZ_OK) {
+  if (klein_qz(spec->zgges, n, out->s, out->t, out->z, arena, iarena) !=
+      KLEIN_QZ_OK) {
     return SDSGE_KLEIN_SOLVE_QZ;
   }
 
@@ -90,11 +113,9 @@ i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out) {
   sdsge_transpose_sq(out->z, n);
 
   switch (klein_postproc(out->s, out->t, out->z, spec->n_state, spec->n_ctrl,
-                         out->f, out->p, &out->stab, out->eig)) {
+                         out->f, out->p, &out->stab, out->eig, arena, iarena)) {
   case SDSGE_KLEIN_POSTPROC_SUCCESS:
     break;
-  case SDSGE_KLEIN_POSTPROC_ALLOC_FAIL:
-    return SDSGE_KLEIN_SOLVE_ALLOC;
   case SDSGE_KLEIN_POSTPROC_INVALID:
     return SDSGE_KLEIN_SOLVE_NO_STATES;
   default:
@@ -106,19 +127,20 @@ i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out) {
   return SDSGE_KLEIN_SOLVE_OK;
 }
 
-i64 sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out) {
-  const i64 rc = sdsge_klein_linearize(spec, out);
+i64 sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out, f64 *arena,
+                       i64 *iarena) {
+  const i64 rc = sdsge_klein_linearize(spec, out, arena, iarena);
   if (rc != SDSGE_KLEIN_SOLVE_OK) {
     return rc;
   }
-  return sdsge_klein_from_pencil(spec, out);
+  return sdsge_klein_from_pencil(spec, out, arena, iarena);
 }
 
 i64 sdsge_sgu_klein_solve2(const sgu_klein_spec *spec, sdsge_solve1 *out1,
-                           sdsge_solve2 *out2) {
+                           sdsge_solve2 *out2, f64 *arena, i64 *iarena) {
   const klein_spec *s1 = &spec->first;
 
-  const i64 rc = sdsge_klein_solve1(s1, out1);
+  const i64 rc = sdsge_klein_solve1(s1, out1, arena, iarena);
   if (rc != SDSGE_KLEIN_SOLVE_OK) {
     return rc;
   }
@@ -129,32 +151,19 @@ i64 sdsge_sgu_klein_solve2(const sgu_klein_spec *spec, sdsge_solve1 *out1,
   sdsge_real_part(out1->f, out2->gx_real, s1->n_ctrl * s1->n_state);
   sdsge_bx_from_B(out1->B, s1->n_state, s1->n_exog, out2->bx);
 
-  /* The sweep's only failure mode is allocation. */
-  if (sdsge_bicomplex_hessian(spec->bc_residual, out1->ss, s1->params,
-                              s1->n_var, s1->n_par, s1->n_var,
-                              out2->f_xx) != SDSGE_HESSIAN_OK) {
-    return SDSGE_KLEIN_SOLVE_ALLOC;
-  }
+  sdsge_bicomplex_hessian(spec->bc_residual, out1->ss, s1->params, s1->n_var,
+                          s1->n_par, s1->n_var, out2->f_xx, arena);
 
-  switch (sdsge_second_order(out1->a_real, out1->b_real, out2->f_xx,
-                             out2->gx_real, out2->hx_real, s1->n_var,
-                             s1->n_state, out2->gxx, out2->hxx)) {
-  case SDSGE_SECOND_ORDER_OK:
-    break;
-  case SDSGE_SECOND_ORDER_ALLOC_FAIL:
-    return SDSGE_KLEIN_SOLVE_ALLOC;
-  default:
+  if (sdsge_second_order(out1->a_real, out1->b_real, out2->f_xx, out2->gx_real,
+                         out2->hx_real, s1->n_var, s1->n_state, out2->gxx,
+                         out2->hxx, arena, iarena) != SDSGE_SECOND_ORDER_OK) {
     return SDSGE_KLEIN_SOLVE_SECOND_ORDER;
   }
 
-  switch (sdsge_second_order_risk(
-      out1->a_real, out1->b_real, out2->f_xx, out2->gx_real, out2->gxx,
-      out2->eta, s1->n_var, s1->n_state, s1->n_exog, out2->gss, out2->hss)) {
-  case SDSGE_SECOND_ORDER_OK:
-    break;
-  case SDSGE_SECOND_ORDER_ALLOC_FAIL:
-    return SDSGE_KLEIN_SOLVE_ALLOC;
-  default:
+  if (sdsge_second_order_risk(out1->a_real, out1->b_real, out2->f_xx,
+                              out2->gx_real, out2->gxx, out2->eta, s1->n_var,
+                              s1->n_state, s1->n_exog, out2->gss, out2->hss,
+                              arena, iarena) != SDSGE_SECOND_ORDER_OK) {
     return SDSGE_KLEIN_SOLVE_RISK;
   }
   return SDSGE_KLEIN_SOLVE_OK;

--- a/SymbolicDSGE/_ckernels/core/klein_solve.h
+++ b/SymbolicDSGE/_ckernels/core/klein_solve.h
@@ -36,9 +36,16 @@ typedef struct {
   f64 *B; /* n_var*n_exog */
 } sdsge_solve1;
 
+/* Scratch for a whole first-order solve: the componentwise max over its stages,
+ * which run one after another off the same buffer. `arena` holds n_float f64,
+ * `iarena` n_int i64; both are caller-owned and may be reused across solves. */
+arena_size sdsge_klein_solve1_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                         i64 n_par);
+
 /* Newton-resolve the steady state from spec->ss_seed, then linearize there.
  * Writes out->ss, out->a_real and out->b_real. */
-i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out);
+i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out, f64 *arena,
+                          i64 *iarena);
 
 /* QZ and post-proc on the assembled real pencil (out->a_real, out->b_real),
  * then the state space. Split from the linearization so a caller can patch the
@@ -46,10 +53,12 @@ i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out);
  *
  * out->stab is reported, never acted on: a nonzero stab still leaves f/p/A/B
  * usable and the caller decides whether that is fatal. */
-i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out);
+i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out,
+                            f64 *arena, i64 *iarena);
 
 /* sdsge_klein_linearize, then sdsge_klein_from_pencil. */
-i64 sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out);
+i64 sdsge_klein_solve1(const klein_spec *spec, sdsge_solve1 *out, f64 *arena,
+                       i64 *iarena);
 
 /* Second-order (SGU) solve: the first-order spec plus the bicomplex residual
  * the Hessian sweep drives. Klein supplies the first order and nothing else,
@@ -80,13 +89,15 @@ typedef struct {
  * the sigma^2 risk correction. Every first-order output stays in `out1`.
  *
  * out1->stab is reported, never acted on, exactly as at first order. */
-i64 sdsge_sgu_klein_solve2(const sgu_klein_spec *spec, sdsge_solve1 *out1,
-                           sdsge_solve2 *out2);
+arena_size sdsge_sgu_klein_solve2_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                             i64 n_par, i64 n_exog);
 
-/* ERROR CODES. -1..-3 come straight off sdsge_steady_state_newton, so the
+i64 sdsge_sgu_klein_solve2(const sgu_klein_spec *spec, sdsge_solve1 *out1,
+                           sdsge_solve2 *out2, f64 *arena, i64 *iarena);
+
+/* ERROR CODES. -2 and -3 come straight off sdsge_steady_state_newton, so the
  * linearization half passes its status through unmapped. */
 #define SDSGE_KLEIN_SOLVE_OK 0
-#define SDSGE_KLEIN_SOLVE_ALLOC -1
 #define SDSGE_KLEIN_SOLVE_SS_SINGULAR -2
 #define SDSGE_KLEIN_SOLVE_SS_NO_CONVERGE -3
 #define SDSGE_KLEIN_SOLVE_QZ -4

--- a/SymbolicDSGE/_ckernels/core/second_order.c
+++ b/SymbolicDSGE/_ckernels/core/second_order.c
@@ -1,18 +1,33 @@
 #include "second_order.h"
 #include "../_common/sdsge_linalg.h"
-#include <stdlib.h>
 #include <string.h>
 
-/* malloc size guard: never request 0 bytes (implementation-defined). */
-static void *so_alloc(size_t count) {
-  return malloc((count > 0 ? count : 1) * sizeof(f64));
+/* Reduced-system dimensions, shared by the sizer and the solve. */
+static i64 so_reduced(const i64 n, const i64 nx) {
+  const i64 ny = n - nx;
+  return ny * nx * (nx + 1) / 2 + nx * nx * (nx + 1) / 2;
+}
+
+arena_size sdsge_second_order_arena_size(const i64 n, const i64 nx) {
+  const i64 ny = n - nx;
+  const i64 ncols = n * nx * nx;
+  const i64 R = so_reduced(n, nx);
+  return make_sizer(ny * nx        /* gxhx */
+                        + n * nx   /* hcoef */
+                        + R * ncols /* big_q */
+                        + ncols * R /* sym */
+                        + R * R    /* qt */
+                        + 2 * R    /* q, xt */
+                        + ncols,   /* full */
+                    R /* LU pivot */);
 }
 
 i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
                        const f64 *SDSGE_RESTRICT f_xx,
                        const f64 *SDSGE_RESTRICT gx,
                        const f64 *SDSGE_RESTRICT hx, const i64 n, const i64 nx,
-                       f64 *SDSGE_RESTRICT gxx, f64 *SDSGE_RESTRICT hxx) {
+                       f64 *SDSGE_RESTRICT gxx, f64 *SDSGE_RESTRICT hxx,
+                       f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena) {
   const i64 ny = n - nx;
   const i64 n2 = 2 * n;
   /* stacked-arg block offsets in f_xx: z = [x'; y'; x; y]. */
@@ -25,21 +40,22 @@ i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
   const i64 n_red_h = nx * nx * (nx + 1) / 2;
   const i64 R = n_red_g + n_red_h; /* reduced unknowns == number of rows */
 
-  f64 *SDSGE_RESTRICT gxhx = so_alloc((size_t)(ny * nx));   /* gx @ hx  (ny, nx) */
-  f64 *SDSGE_RESTRICT hcoef = so_alloc((size_t)(n * nx));   /* fyp@gx + fxp (n, nx) */
-  f64 *SDSGE_RESTRICT big_q = so_alloc((size_t)(R * ncols)); /* (R, ncols) */
-  f64 *SDSGE_RESTRICT sym = so_alloc((size_t)(ncols * R));   /* (ncols, R) */
-  f64 *SDSGE_RESTRICT qt = so_alloc((size_t)(R * R));        /* big_q @ sym */
-  f64 *SDSGE_RESTRICT q = so_alloc((size_t)R);
-  f64 *SDSGE_RESTRICT xt = so_alloc((size_t)R);
-  f64 *SDSGE_RESTRICT full = so_alloc((size_t)ncols);
-
-  i64 status = SDSGE_SECOND_ORDER_OK;
-
-  if (!gxhx || !hcoef || !big_q || !sym || !qt || !q || !xt || !full) {
-    status = SDSGE_SECOND_ORDER_ALLOC_FAIL;
-    goto done;
-  }
+  f64 *p = arena;
+  f64 *SDSGE_RESTRICT gxhx = p; /* gx @ hx  (ny, nx) */
+  p += ny * nx;
+  f64 *SDSGE_RESTRICT hcoef = p; /* fyp@gx + fxp (n, nx) */
+  p += n * nx;
+  f64 *SDSGE_RESTRICT big_q = p; /* (R, ncols) */
+  p += R * ncols;
+  f64 *SDSGE_RESTRICT sym = p; /* (ncols, R) */
+  p += ncols * R;
+  f64 *SDSGE_RESTRICT qt = p; /* big_q @ sym */
+  p += R * R;
+  f64 *SDSGE_RESTRICT q = p;
+  p += R;
+  f64 *SDSGE_RESTRICT xt = p;
+  p += R;
+  f64 *SDSGE_RESTRICT full = p;
 
   /* big_q starts zeroed: the loop writes only the structural nonzeros (the gxx
    * block is dense, the hxx block is one line per row). */
@@ -152,17 +168,12 @@ i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
 
   /* qt = big_q @ sym  (R, R);  xt = -solve(qt, q);  full = sym @ xt. */
   sdsge_matmul(big_q, sym, qt, R, ncols, R);
-  {
-    i64 serr = sdsge_solve(qt, q, R, 1, xt);
-    if (serr == SDSGE_LU_SINGULAR) {
-      status = SDSGE_SECOND_ORDER_SINGULAR;
-      goto done;
-    }
-    if (serr != SDSGE_LU_SUCCESS) {
-      status = SDSGE_SECOND_ORDER_ALLOC_FAIL;
-      goto done;
-    }
+  /* qt is dead after the solve, so it factors in place. */
+  if (sdsge_lu_factor_inplace(qt, iarena, R) != SDSGE_LU_SUCCESS) {
+    return SDSGE_SECOND_ORDER_SINGULAR;
   }
+  sdsge_lu_solve(qt, iarena, q, xt, R, 1);
+
   for (i64 r = 0; r < R; ++r) {
     xt[r] = -xt[r];
   }
@@ -171,16 +182,17 @@ i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
   memcpy(gxx, full, (size_t)ngxx * sizeof(f64));
   memcpy(hxx, full + ngxx, (size_t)nhxx * sizeof(f64));
 
-done:
-  free(gxhx);
-  free(hcoef);
-  free(big_q);
-  free(sym);
-  free(qt);
-  free(q);
-  free(xt);
-  free(full);
-  return status;
+  return SDSGE_SECOND_ORDER_OK;
+}
+
+arena_size sdsge_second_order_risk_arena_size(const i64 n, const i64 nx,
+                                              const i64 ne) {
+  const i64 ny = n - nx;
+  return make_sizer(ny * ne         /* gxe */
+                        + nx * nx   /* g4 */
+                        + n * n     /* coeff */
+                        + 2 * n,    /* q, x */
+                    n /* LU pivot */);
 }
 
 i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
@@ -190,23 +202,22 @@ i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
                             const f64 *SDSGE_RESTRICT gxx,
                             const f64 *SDSGE_RESTRICT eta, const i64 n,
                             const i64 nx, const i64 ne, f64 *SDSGE_RESTRICT gss,
-                            f64 *SDSGE_RESTRICT hss) {
+                            f64 *SDSGE_RESTRICT hss, f64 *SDSGE_RESTRICT arena,
+                            i64 *SDSGE_RESTRICT iarena) {
   const i64 ny = n - nx;
   const i64 n2 = 2 * n;
   const i64 XP = 0, YP = nx; /* only the forward blocks enter */
 
-  f64 *SDSGE_RESTRICT gxe = so_alloc((size_t)(ny * ne)); /* gx @ eta (ny, ne) */
-  f64 *SDSGE_RESTRICT g4 = so_alloc((size_t)(nx * nx));  /* fyp[i] . gxx (nx, nx) */
-  f64 *SDSGE_RESTRICT coeff = so_alloc((size_t)(n * n)); /* [Qg | Qh] (n, n) */
-  f64 *SDSGE_RESTRICT q = so_alloc((size_t)n);
-  f64 *SDSGE_RESTRICT x = so_alloc((size_t)n);
-
-  i64 status = SDSGE_SECOND_ORDER_OK;
-
-  if (!gxe || !g4 || !coeff || !q || !x) {
-    status = SDSGE_SECOND_ORDER_ALLOC_FAIL;
-    goto done;
-  }
+  f64 *p = arena;
+  f64 *SDSGE_RESTRICT gxe = p; /* gx @ eta (ny, ne) */
+  p += ny * ne;
+  f64 *SDSGE_RESTRICT g4 = p; /* fyp[i] . gxx (nx, nx) */
+  p += nx * nx;
+  f64 *SDSGE_RESTRICT coeff = p; /* [Qg | Qh] (n, n) */
+  p += n * n;
+  f64 *SDSGE_RESTRICT q = p;
+  p += n;
+  f64 *SDSGE_RESTRICT x = p;
 
   /* gxe = gx @ eta (contiguous inputs). */
   if (ny > 0 && ne > 0) {
@@ -275,18 +286,13 @@ i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
     q[i] = t;
   }
 
-  /* x = -solve(coeff, q); gss = x[:ny], hss = x[ny:]. */
-  {
-    i64 serr = sdsge_solve(coeff, q, n, 1, x);
-    if (serr == SDSGE_LU_SINGULAR) {
-      status = SDSGE_SECOND_ORDER_SINGULAR;
-      goto done;
-    }
-    if (serr != SDSGE_LU_SUCCESS) {
-      status = SDSGE_SECOND_ORDER_ALLOC_FAIL;
-      goto done;
-    }
+  /* x = -solve(coeff, q); gss = x[:ny], hss = x[ny:]. coeff is dead after the
+   * solve, so it factors in place. */
+  if (sdsge_lu_factor_inplace(coeff, iarena, n) != SDSGE_LU_SUCCESS) {
+    return SDSGE_SECOND_ORDER_SINGULAR;
   }
+  sdsge_lu_solve(coeff, iarena, q, x, n, 1);
+
   for (i64 aa = 0; aa < ny; ++aa) {
     gss[aa] = -x[aa];
   }
@@ -294,11 +300,5 @@ i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
     hss[aa] = -x[ny + aa];
   }
 
-done:
-  free(gxe);
-  free(g4);
-  free(coeff);
-  free(q);
-  free(x);
-  return status;
+  return SDSGE_SECOND_ORDER_OK;
 }

--- a/SymbolicDSGE/_ckernels/core/second_order.h
+++ b/SymbolicDSGE/_ckernels/core/second_order.h
@@ -18,11 +18,14 @@
  * hxx(nx, nx, nx)  states, symmetric in the last two indices
  *
  * Returns one of the SDSGE_SECOND_ORDER_* codes. */
+arena_size sdsge_second_order_arena_size(i64 n, i64 nx);
+
 i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
                        const f64 *SDSGE_RESTRICT f_xx,
                        const f64 *SDSGE_RESTRICT gx,
                        const f64 *SDSGE_RESTRICT hx, const i64 n, const i64 nx,
-                       f64 *SDSGE_RESTRICT gxx, f64 *SDSGE_RESTRICT hxx);
+                       f64 *SDSGE_RESTRICT gxx, f64 *SDSGE_RESTRICT hxx,
+                       f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena);
 
 /* Sigma^2 risk correction (g_ss, h_ss). Parity oracle:
  * core.second_order.solve_second_order_risk. Inputs as above plus:
@@ -35,6 +38,8 @@ i64 sdsge_second_order(const f64 *SDSGE_RESTRICT a, const f64 *SDSGE_RESTRICT b,
  * hss (nx,) states risk correction
  *
  * Same return codes. */
+arena_size sdsge_second_order_risk_arena_size(i64 n, i64 nx, i64 ne);
+
 i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
                             const f64 *SDSGE_RESTRICT b,
                             const f64 *SDSGE_RESTRICT f_xx,
@@ -42,11 +47,11 @@ i64 sdsge_second_order_risk(const f64 *SDSGE_RESTRICT a,
                             const f64 *SDSGE_RESTRICT gxx,
                             const f64 *SDSGE_RESTRICT eta, const i64 n,
                             const i64 nx, const i64 ne, f64 *SDSGE_RESTRICT gss,
-                            f64 *SDSGE_RESTRICT hss);
+                            f64 *SDSGE_RESTRICT hss, f64 *SDSGE_RESTRICT arena,
+                            i64 *SDSGE_RESTRICT iarena);
 
 /* ERROR CODES */
 #define SDSGE_SECOND_ORDER_OK 0
-#define SDSGE_SECOND_ORDER_ALLOC_FAIL -1
 #define SDSGE_SECOND_ORDER_SINGULAR -2 /* symmetry-reduced system singular */
 
 #endif /* SDSGE_SECOND_ORDER_H */

--- a/SymbolicDSGE/_ckernels/core/steady_state.c
+++ b/SymbolicDSGE/_ckernels/core/steady_state.c
@@ -1,33 +1,47 @@
 #include "steady_state.h"
 #include "../_common/sdsge_linalg.h"
+#include "klein_preproc.h"
 #include <math.h>
-#include <stdlib.h>
+
+arena_size sdsge_newton_arena_size(const i64 n_var, const i64 n_par) {
+  const i64 own = 2 * (2 * n_var + n_par) /* x_c, out_c, par_c */
+                  + 2 * n_var             /* r, dx */
+                  + 3 * n_var * n_var;    /* a, b, J */
+  const arena_size pre = klein_preproc_arena_size(n_var, n_par, n_var);
+  return make_sizer(own + pre.n_float, n_var /* LU pivot */);
+}
 
 i64 sdsge_steady_state_newton(sdsge_residual_fn residual,
                               const f64 *SDSGE_RESTRICT seed,
                               const f64 *SDSGE_RESTRICT par, const i64 n_var,
                               const i64 n_par, const i64 max_iter, const f64 tol,
-                              f64 *SDSGE_RESTRICT ss, i64 *SDSGE_RESTRICT iters) {
+                              f64 *SDSGE_RESTRICT ss, i64 *SDSGE_RESTRICT iters,
+                              f64 *SDSGE_RESTRICT arena,
+                              i64 *SDSGE_RESTRICT iarena) {
   const i64 n = n_var;
   const i64 nn = n * n;
 
   /* n_eq == n_var: the steady-state system is square. */
-  c128 *SDSGE_RESTRICT x_c = (c128 *)malloc((size_t)(n > 0 ? n : 1) * sizeof(c128));
-  c128 *SDSGE_RESTRICT par_c =
-      (c128 *)malloc((size_t)(n_par > 0 ? n_par : 1) * sizeof(c128));
-  c128 *SDSGE_RESTRICT out_c = (c128 *)malloc((size_t)(n > 0 ? n : 1) * sizeof(c128));
-  f64 *SDSGE_RESTRICT r = (f64 *)malloc((size_t)(n > 0 ? n : 1) * sizeof(f64));
-  f64 *SDSGE_RESTRICT dx = (f64 *)malloc((size_t)(n > 0 ? n : 1) * sizeof(f64));
-  f64 *SDSGE_RESTRICT a = (f64 *)malloc((size_t)(nn > 0 ? nn : 1) * sizeof(f64));
-  f64 *SDSGE_RESTRICT b = (f64 *)malloc((size_t)(nn > 0 ? nn : 1) * sizeof(f64));
-  f64 *SDSGE_RESTRICT J = (f64 *)malloc((size_t)(nn > 0 ? nn : 1) * sizeof(f64));
+  c128 *cp = (c128 *)arena;
+  c128 *x_c = cp;
+  cp += n;
+  c128 *par_c = cp;
+  cp += n_par;
+  c128 *out_c = cp;
+  cp += n;
 
-  i64 status = SDSGE_NEWTON_NO_CONVERGE;
-
-  if (!x_c || !par_c || !out_c || !r || !dx || !a || !b || !J) {
-    status = SDSGE_NEWTON_ALLOC_FAIL;
-    goto done;
-  }
+  f64 *p = (f64 *)cp;
+  f64 *r = p;
+  p += n;
+  f64 *dx = p;
+  p += n;
+  f64 *a = p;
+  p += nn;
+  f64 *b = p;
+  p += nn;
+  f64 *J = p;
+  p += nn;
+  f64 *sweep = p;
 
   for (i64 i = 0; i < n; ++i) {
     ss[i] = seed[i];
@@ -53,45 +67,26 @@ i64 sdsge_steady_state_newton(sdsge_residual_fn residual,
       }
     }
     if (!isfinite(nrm)) {
-      status = SDSGE_NEWTON_NO_CONVERGE;
-      goto done;
+      return SDSGE_NEWTON_NO_CONVERGE;
     }
     if (nrm < tol) {
       *iters = it;
-      status = SDSGE_NEWTON_OK;
-      goto done;
+      return SDSGE_NEWTON_OK;
     }
 
     /* Jacobian of F(x, x): dF/dfwd + dF/dcur = a + (-b) = a - b. */
-    i64 perr = klein_preproc(residual, ss, par, n_var, n_par, n_var, a, b);
-    if (perr != SDSGE_PREKLEIN_OK) {
-      status = SDSGE_NEWTON_ALLOC_FAIL;
-      goto done;
-    }
+    klein_preproc(residual, ss, par, n_var, n_par, n_var, a, b, sweep);
     sdsge_vsub(a, b, J, nn);
 
-    /* dx = J^-1 r, then x -= dx. */
-    i64 serr = sdsge_solve(J, r, n, 1, dx);
-    if (serr == SDSGE_LU_SINGULAR) {
-      status = SDSGE_NEWTON_SINGULAR;
-      goto done;
+    /* dx = J^-1 r, then x -= dx. J is rebuilt next iteration, so the
+     * factorization overwrites it. */
+    if (sdsge_lu_factor_inplace(J, iarena, n) != SDSGE_LU_SUCCESS) {
+      return SDSGE_NEWTON_SINGULAR;
     }
-    if (serr != SDSGE_LU_SUCCESS) {
-      status = SDSGE_NEWTON_ALLOC_FAIL;
-      goto done;
-    }
+    sdsge_lu_solve(J, iarena, r, dx, n, 1);
     sdsge_vsub(ss, dx, ss, n);
     *iters = it + 1;
   }
 
-done:
-  free(x_c);
-  free(par_c);
-  free(out_c);
-  free(r);
-  free(dx);
-  free(a);
-  free(b);
-  free(J);
-  return status;
+  return SDSGE_NEWTON_NO_CONVERGE;
 }

--- a/SymbolicDSGE/_ckernels/core/steady_state.h
+++ b/SymbolicDSGE/_ckernels/core/steady_state.h
@@ -14,15 +14,18 @@
  *
  * Writes the converged point into `ss` (n_var); `*iters` gets the iteration
  * count. Returns one of the SDSGE_NEWTON_* codes. */
+arena_size sdsge_newton_arena_size(i64 n_var, i64 n_par);
+
 i64 sdsge_steady_state_newton(sdsge_residual_fn residual,
                               const f64 *SDSGE_RESTRICT seed,
                               const f64 *SDSGE_RESTRICT par, const i64 n_var,
                               const i64 n_par, const i64 max_iter, const f64 tol,
-                              f64 *SDSGE_RESTRICT ss, i64 *SDSGE_RESTRICT iters);
+                              f64 *SDSGE_RESTRICT ss, i64 *SDSGE_RESTRICT iters,
+                              f64 *SDSGE_RESTRICT arena,
+                              i64 *SDSGE_RESTRICT iarena);
 
 /* ERROR CODES */
 #define SDSGE_NEWTON_OK 0
-#define SDSGE_NEWTON_ALLOC_FAIL -1
 #define SDSGE_NEWTON_SINGULAR -2   /* Jacobian a - b singular */
 #define SDSGE_NEWTON_NO_CONVERGE -3 /* tol not met within max_iter (or non-finite) */
 

--- a/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
@@ -121,6 +121,8 @@ cdef extern from "estimation.h":
         double *std_q
         double *std_r
         double *filter_arena
+        double *solve_arena
+        int64_t *solve_iarena
         int64_t bk_violations
 
     ctypedef struct sdsge_linear_ctx:
@@ -170,6 +172,14 @@ cdef extern from "sdsge_common.h":
     ctypedef struct arena_size:
         int64_t n_float
         int64_t n_int
+
+
+cdef extern from "../core/klein_solve.h":
+    arena_size sdsge_klein_solve1_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl, int64_t n_par) nogil
+    arena_size sdsge_sgu_klein_solve2_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl, int64_t n_par,
+        int64_t n_exog) nogil
 
 
 cdef extern from "../kalman/kalman.h":
@@ -375,6 +385,16 @@ def obj_linear_base(
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
 
+    cdef arena_size solve_sz = sdsge_klein_solve1_arena_size(
+        n_var, n_state, n_ctrl, n_par
+    )
+    solve_arena = np.empty(solve_sz.n_float, dtype=np.float64)
+    solve_iarena = np.empty(solve_sz.n_int, dtype=np.int64)
+    cdef double[::1] solve_arena_v = solve_arena
+    cdef int64_t[::1] solve_iarena_v = solve_iarena
+    b.solve_arena = &solve_arena_v[0]
+    b.solve_iarena = &solve_iarena_v[0]
+
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
     ctx.solve.b_real = &brv[0, 0]
@@ -509,6 +529,16 @@ def obj_extended_base(
     )
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
+
+    cdef arena_size solve_sz = sdsge_klein_solve1_arena_size(
+        n_var, n_state, n_ctrl, n_par
+    )
+    solve_arena = np.empty(solve_sz.n_float, dtype=np.float64)
+    solve_iarena = np.empty(solve_sz.n_int, dtype=np.int64)
+    cdef double[::1] solve_arena_v = solve_arena
+    cdef int64_t[::1] solve_iarena_v = solve_iarena
+    b.solve_arena = &solve_arena_v[0]
+    b.solve_iarena = &solve_iarena_v[0]
 
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
@@ -677,6 +707,16 @@ def obj_unscented_base(
     )
     cdef double[::1] filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
+
+    cdef arena_size solve_sz = sdsge_sgu_klein_solve2_arena_size(
+        n_var, n_state, n_ctrl, n_par, n_exog
+    )
+    solve_arena = np.empty(solve_sz.n_float, dtype=np.float64)
+    solve_iarena = np.empty(solve_sz.n_int, dtype=np.int64)
+    cdef double[::1] solve_arena_v = solve_arena
+    cdef int64_t[::1] solve_iarena_v = solve_iarena
+    b.solve_arena = &solve_arena_v[0]
+    b.solve_iarena = &solve_iarena_v[0]
 
     ctx.solve.ss = &ssv[0]
     ctx.solve.a_real = &arv[0, 0]
@@ -971,6 +1011,9 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     cdef double[::1] p_me_v
     cdef double[::1] p_mlc_v
     cdef double[::1] filter_arena_v
+    cdef double[::1] solve_arena_v
+    cdef int64_t[::1] solve_iarena_v
+    cdef arena_size solve_sz
     cdef int64_t p_nscalar = 0
     cdef int64_t p_nblocks = 0
 
@@ -1159,6 +1202,21 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     nc.keep.append(filter_arena)
     filter_arena_v = filter_arena
     b.filter_arena = &filter_arena_v[0]
+
+    if mode == "unscented":
+        solve_sz = sdsge_sgu_klein_solve2_arena_size(
+            n_var, n_state, n_ctrl, n_par, n_exog
+        )
+    else:
+        solve_sz = sdsge_klein_solve1_arena_size(n_var, n_state, n_ctrl, n_par)
+    solve_arena = np.empty(solve_sz.n_float, dtype=np.float64)
+    solve_iarena = np.empty(solve_sz.n_int, dtype=np.int64)
+    nc.keep.append(solve_arena)
+    nc.keep.append(solve_iarena)
+    solve_arena_v = solve_arena
+    solve_iarena_v = solve_iarena
+    b.solve_arena = &solve_arena_v[0]
+    b.solve_iarena = &solve_iarena_v[0]
 
     s1.ss = &ssv2[0]
     s1.a_real = &arv[0, 0]

--- a/SymbolicDSGE/_ckernels/estimation/estimation.c
+++ b/SymbolicDSGE/_ckernels/estimation/estimation.c
@@ -142,7 +142,7 @@ static inline int sdsge_classify(const i64 rc, const i64 stab) {
 
 static inline int sdsge_solve1_run(sdsge_obj_common *b, sdsge_solve1 *s) {
   const klein_spec spec = sdsge_spec_from(b);
-  const i64 rc = sdsge_klein_solve1(&spec, s);
+  const i64 rc = sdsge_klein_solve1(&spec, s, b->solve_arena, b->solve_iarena);
   return sdsge_classify(rc, s->stab);
 }
 
@@ -150,7 +150,8 @@ static inline int sdsge_solve2_run(sdsge_obj_common *b, sdsge_solve1 *s,
                                    sdsge_solve2 *s2) {
   const sgu_klein_spec spec = {.first = sdsge_spec_from(b),
                                .bc_residual = b->bc_residual};
-  const i64 rc = sdsge_sgu_klein_solve2(&spec, s, s2);
+  const i64 rc =
+      sdsge_sgu_klein_solve2(&spec, s, s2, b->solve_arena, b->solve_iarena);
   return sdsge_classify(rc, s->stab);
 }
 

--- a/SymbolicDSGE/_ckernels/estimation/estimation.h
+++ b/SymbolicDSGE/_ckernels/estimation/estimation.h
@@ -114,6 +114,11 @@ typedef struct {
   f64 *filter_arena; /* scratch for the filter sizeof(f64)*<filter>_arena_size()
                       */
 
+  /* Scratch for the per-draw solve, sized by sdsge_klein_solve1_arena_size or
+   * sdsge_sgu_klein_solve2_arena_size. Held for the run so no draw allocates. */
+  f64 *solve_arena;
+  i64 *solve_iarena;
+
   i64 bk_violations;
 } sdsge_obj_common;
 


### PR DESCRIPTION
Replace internal malloc/free scratch space with caller-provided arenas across the core solve path. This removes allocation-failure return codes, adds per-kernel arena sizing helpers, and wires the estimation layer to keep reusable solve buffers for first- and second-order runs.