### PR TITLE
OccBin pencil patch

### DIFF
--- a/SymbolicDSGE/_ckernels/README.md
+++ b/SymbolicDSGE/_ckernels/README.md
@@ -11,18 +11,12 @@ _ckernels/
   __init__.py            # leaf package; no SymbolicDSGE imports
   _common/               # shared pure-C primitives (no Python, no NumPy C-API)
     sdsge_common.h       # portable macros (restrict, ...)
-    sdsge_linalg.{c,h}   # (future) matmul/cholesky/triangular solves, etc.
+    sdsge_linalg.{c,h}   # matmul/cholesky/triangular solves, etc.
   core/                  # one subsystem (also: kalman regression distributions diag)
     __init__.py          # re-exports the compiled _<name>
     _core.pyx            # thin Cython shim: NumPy buffer -> double*
     core.{c,h}           # pure-C numeric kernels
 ```
-
-Every subsystem currently holds empty placeholders (`<name>.{c,h}`,
-`_<name>.pyx`, `__init__.py`) — the scaffold, no kernels yet.
-
-One compiled extension **per subsystem** (`core/_core.pyx` → `_core`). Small
-incremental rebuilds, parallel compilation, import only what you need.
 
 ## Division of labor
 
@@ -31,9 +25,6 @@ incremental rebuilds, parallel compilation, import only what you need.
 - **Cython shim (`_<name>.pyx`)** — *only* maps NumPy memoryviews to `double*`
   and calls the C. No logic. `double[:, ::1]` validates dtype + C-contiguity and
   hands `&A[0, 0]` to C; `with nogil:` drops the GIL around the kernel.
-
-No `cimport numpy` / `import_array()` anywhere: memoryviews ride the buffer
-protocol, so NumPy's C-API never enters the build.
 
 ## Conventions
 

--- a/SymbolicDSGE/_ckernels/occbin/__init__.py
+++ b/SymbolicDSGE/_ckernels/occbin/__init__.py
@@ -1,12 +1,13 @@
-"""Native OccBin kernels (regime conditions evaluated over a simulated path).
+"""Native OccBin kernels: the regime latch over a path, and per-regime pencils.
 
 Re-exports the compiled ``_occbin`` extension, which is mandatory: if it is not
 built, importing this module (and the library) raises ``ImportError``.
 """
 
-from ._occbin import MAX_CONSTRAINTS, constraint_path
+from ._occbin import MAX_CONSTRAINTS, constraint_path, regime_pencil
 
 __all__ = [
     "MAX_CONSTRAINTS",
     "constraint_path",
+    "regime_pencil",
 ]

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -7,11 +7,12 @@ must stay in sync with ``_occbin.pyx`` / ``occbin.c``; the tests guard the
 runtime behavior, not this stub.
 """
 
-from numpy import float64, int8
+from numpy import float64, int8, int64
 from numpy.typing import NDArray
 
 _F64 = NDArray[float64]
 _I8 = NDArray[int8]
+_I64 = NDArray[int64]
 
 MAX_CONSTRAINTS: int
 
@@ -27,4 +28,18 @@ def constraint_path(
 
     ``out`` may alias ``regime_in`` to latch in place; ``changed`` counts the
     periods whose mask moved.
+    """
+
+def regime_pencil(
+    pencil_addr: int,
+    rows: _I64,
+    ss: _F64,
+    par: _F64,
+    a_ref: _F64,
+    b_ref: _F64,
+) -> tuple[_F64, _F64, _F64]:
+    """(a, b, c) <- the reference pencil with ``rows`` patched by one regime.
+
+    ``pencil_addr`` of 0 is the reference regime: the copy alone, ``c`` zero.
+    ``c`` is ``(n_var,)`` and zero off ``rows``.
     """

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -2,13 +2,19 @@
 """Thin Cython shim mapping NumPy buffers to the pure-C OccBin kernels.
 
 Buffer to pointer marshalling and the GIL release only; the algorithms live in
-occbin.c. The kernels' f64/i8/i64 are exactly double/int8_t/int64_t, so the
-externs are declared with those.
+occbin.c and regime_pencil.c. The kernels' f64/i8/i64 are exactly
+double/int8_t/int64_t, so the externs are declared with those.
 """
 
 from libc.stdint cimport int8_t, int64_t
 
 import numpy as np
+
+
+cdef extern from "../_common/sdsge_common.h" nogil:
+    ctypedef struct arena_size:
+        int64_t n_float
+        int64_t n_int
 
 
 cdef extern from "occbin.h" nogil:
@@ -18,6 +24,23 @@ cdef extern from "occbin.h" nogil:
         sdsge_constraint_fn cond, double *path, double *par,
         const int8_t *regime_in, int8_t *regime_out,
         int64_t T, int64_t n_var, int64_t n_constraint)
+
+
+cdef extern from "regime_pencil.h" nogil:
+    ctypedef void (*sdsge_regime_pencil_fn)(
+        const double *cur, const double *par, double *out) noexcept
+    ctypedef struct regime_ctx:
+        sdsge_regime_pencil_fn pencil
+        int64_t n_row
+        const int64_t *rows
+        double *a
+        double *b
+        double *c
+    arena_size sdsge_regime_pencil_arena_size(int64_t n_var, int64_t n_row)
+    void sdsge_regime_pencil(
+        regime_ctx *regime, const double *ss, const double *par,
+        const double *a_ref, const double *b_ref,
+        int64_t n_var, double *arena)
 
 
 #: Constraints the native flag buffer is sized for (``i8 flags[4]`` in occbin.c,
@@ -74,3 +97,83 @@ def constraint_path(size_t cond_addr, path, par, regime_in,
             fn, path_ptr, par_ptr, in_ptr, out_ptr, T, n_var, n_constraint
         )
     return out, changed
+
+
+def regime_pencil(size_t pencil_addr, rows, ss, par, a_ref, b_ref):
+    """One regime's pencil ``(a, b, c)``, from the reference pencil and a patch.
+
+    ``pencil_addr`` is the ``.address`` of a regime pencil @cfunc
+    (``CompiledModel.construct_regime_pencil_func()``), and ``rows`` the
+    reference rows that regime replaces. The reference pencil is copied, then
+    those rows are overwritten; ``c`` is the regime's residual at ``ss`` and is
+    zero off ``rows``, so ``a E[y+] = b y - c``.
+
+    ``pencil_addr`` of 0 is the reference regime itself: the copy alone, with
+    ``c`` zero and ``rows`` ignored. ``ss`` is the *reference* steady state in
+    levels, which every regime linearizes around.
+
+    Returns freshly allocated ``(a, b, c)``, shaped ``(n_var, n_var)``,
+    ``(n_var, n_var)`` and ``(n_var,)``; nothing aliases the inputs.
+    """
+    cdef double[:, ::1] arefv = np.ascontiguousarray(a_ref, dtype=np.float64)
+    cdef double[:, ::1] brefv = np.ascontiguousarray(b_ref, dtype=np.float64)
+    cdef int64_t n_var = arefv.shape[0]
+
+    if arefv.shape[1] != n_var:
+        raise ValueError(
+            f"a_ref is {arefv.shape[0]}x{arefv.shape[1]}, expected square."
+        )
+    if brefv.shape[0] != n_var or brefv.shape[1] != n_var:
+        raise ValueError(
+            f"b_ref is {brefv.shape[0]}x{brefv.shape[1]}, expected "
+            f"{n_var}x{n_var} to match a_ref."
+        )
+
+    cdef double[::1] ssv = np.ascontiguousarray(ss, dtype=np.float64)
+    cdef double[::1] parv = np.ascontiguousarray(par, dtype=np.float64)
+    cdef const int64_t[::1] rowv = np.ascontiguousarray(rows, dtype=np.int64)
+    cdef int64_t n_row = rowv.shape[0]
+    cdef int64_t i
+
+    if ssv.shape[0] != n_var:
+        raise ValueError(
+            f"ss has length {ssv.shape[0]}, expected {n_var} to match a_ref."
+        )
+    # The kernel scatters straight into a[row], so an out-of-range row would
+    # write past the output rather than raise.
+    for i in range(n_row):
+        if not 0 <= rowv[i] < n_var:
+            raise ValueError(
+                f"rows[{i}] is {rowv[i]}, outside 0..{n_var - 1}."
+            )
+
+    a = np.empty((n_var, n_var), dtype=np.float64)
+    b = np.empty((n_var, n_var), dtype=np.float64)
+    c = np.empty((n_var,), dtype=np.float64)
+    cdef double[:, ::1] av = a
+    cdef double[:, ::1] bv = b
+    cdef double[::1] cv = c
+
+    arena = np.empty(
+        sdsge_regime_pencil_arena_size(n_var, n_row).n_float, dtype=np.float64
+    )
+    cdef double[::1] arv = arena
+
+    cdef regime_ctx ctx
+    ctx.pencil = <sdsge_regime_pencil_fn><void*>pencil_addr
+    ctx.n_row = n_row
+    ctx.rows = &rowv[0] if n_row > 0 else NULL
+    ctx.a = &av[0, 0] if n_var > 0 else NULL
+    ctx.b = &bv[0, 0] if n_var > 0 else NULL
+    ctx.c = &cv[0] if n_var > 0 else NULL
+
+    cdef const double *ss_ptr = &ssv[0] if n_var > 0 else NULL
+    cdef const double *par_ptr = &parv[0] if parv.shape[0] > 0 else NULL
+    cdef const double *a_ptr = &arefv[0, 0] if n_var > 0 else NULL
+    cdef const double *b_ptr = &brefv[0, 0] if n_var > 0 else NULL
+    cdef double *arena_ptr = &arv[0] if arv.shape[0] > 0 else NULL
+    with nogil:
+        sdsge_regime_pencil(
+            &ctx, ss_ptr, par_ptr, a_ptr, b_ptr, n_var, arena_ptr
+        )
+    return a, b, c

--- a/SymbolicDSGE/_ckernels/occbin/regime_pencil.c
+++ b/SymbolicDSGE/_ckernels/occbin/regime_pencil.c
@@ -1,0 +1,55 @@
+#include "regime_pencil.h"
+#include "../_common/sdsge_common.h"
+#include <stddef.h> // NULL
+#include <string.h> // memcpy, memset
+
+arena_size sdsge_regime_pencil_arena_size(i64 n_var, i64 n_row) {
+  return make_sizer(2 * n_row * n_var + n_row, 0);
+}
+
+void sdsge_regime_pencil(regime_ctx *regime, const f64 *SDSGE_RESTRICT ss,
+                         const f64 *SDSGE_RESTRICT par,
+                         const f64 *SDSGE_RESTRICT a_ref,
+                         const f64 *SDSGE_RESTRICT b_ref, i64 n_var,
+                         f64 *SDSGE_RESTRICT arena) {
+  const size_t row_bytes = n_var * sizeof(f64);
+
+  // Set reference regime
+  memcpy(regime->a, a_ref, n_var * row_bytes);
+  memcpy(regime->b, b_ref, n_var * row_bytes);
+  memset(regime->c, 0, // c == 0 since ss is solved for the reference.
+         row_bytes);
+
+  if (regime->pencil == NULL) {
+    return; // reference regime
+  }
+
+  // regime != reference, pencil produces a/b/c for swapped rows
+  // we then scatter the swapped rows into the reference regime a/b/c
+  const i64 n_row = regime->n_row;
+
+  // pencil into flat arena [a; b; c]
+  regime->pencil(ss, par, arena);
+  const f64 *blk_a = arena;
+  const f64 *blk_b = blk_a + n_row * n_var;
+  const f64 *blk_c = blk_b + n_row * n_var;
+
+  for (i64 i = 0; i < n_row; ++i) {
+    const i64 row = regime->rows[i];
+    memcpy(&regime->a[row * n_var], &blk_a[i * n_var], row_bytes);
+    memcpy(&regime->b[row * n_var], &blk_b[i * n_var], row_bytes);
+    regime->c[row] = blk_c[i];
+  }
+}
+
+void regime_table(regime_ctx *table, i64 n_regime, const f64 *SDSGE_RESTRICT ss,
+                  const f64 *SDSGE_RESTRICT par,
+                  const f64 *SDSGE_RESTRICT a_ref,
+                  const f64 *SDSGE_RESTRICT b_ref, i64 n_var,
+                  f64 *SDSGE_RESTRICT arena) {
+  // Caller sizes arena by max(n_row) in the table so every regime can use the
+  // same arena.
+  for (i64 mask = 0; mask < n_regime; ++mask) {
+    sdsge_regime_pencil(&table[mask], ss, par, a_ref, b_ref, n_var, arena);
+  }
+}

--- a/SymbolicDSGE/_ckernels/occbin/regime_pencil.h
+++ b/SymbolicDSGE/_ckernels/occbin/regime_pencil.h
@@ -1,0 +1,33 @@
+#ifndef SDSGE_REGIME_PENCIL_H
+#define SDSGE_REGIME_PENCIL_H
+
+#include "../_common/sdsge_common.h"
+
+typedef void (*sdsge_regime_pencil_fn)(const f64 *cur, const f64 *par,
+                                       f64 *out);
+
+typedef struct {
+  sdsge_regime_pencil_fn pencil; // NULL for reference regime
+  i64 n_row;                     // number of rows a regime swaps
+  const i64 *rows;               // n_row; indices of the rows a regime swaps
+  f64 *a;                        // n_var*n_var
+  f64 *b;                        // n_var*n_var
+  f64 *c;                        // n_var
+} regime_ctx;
+
+arena_size sdsge_regime_pencil_arena_size(i64 n_var, i64 n_row);
+void sdsge_regime_pencil(
+    regime_ctx *regime, const f64 *SDSGE_RESTRICT ss,
+    const f64 *SDSGE_RESTRICT par,
+    const f64 *SDSGE_RESTRICT a_ref, // a at reference regime
+    const f64 *SDSGE_RESTRICT b_ref, // b at reference regime
+    i64 n_var, f64 *SDSGE_RESTRICT arena);
+
+void regime_table(regime_ctx *table, // indexed by regime bitmask
+                  i64 n_regime, const f64 *SDSGE_RESTRICT ss,
+                  const f64 *SDSGE_RESTRICT par,
+                  const f64 *SDSGE_RESTRICT a_ref,
+                  const f64 *SDSGE_RESTRICT b_ref, i64 n_var,
+                  f64 *SDSGE_RESTRICT arena);
+
+#endif // SDSGE_REGIME_PENCIL_H

--- a/SymbolicDSGE/core/compiled_model.py
+++ b/SymbolicDSGE/core/compiled_model.py
@@ -114,21 +114,22 @@ class RegimeBlock:
     residuals: list[Expr] = field(default_factory=list)
     jac_a: list[Expr] = field(default_factory=list)
     jac_b: list[Expr] = field(default_factory=list)
+    constants: list[Expr] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
-class RegimeJacobianFunc:
+class RegimePencilFunc:
     """Compiled regime pencil rows, and everything the native side needs to call them.
 
     One cfunc per regime, keyed by the same bitmask as ``regimes``, writing
-    ``[jac_a; jac_b]`` into a single ``2 * n_row * n_var`` buffer: the whole a
-    block first, then the whole b block, each row-major ``(n_row, n_var)`` and
-    ordered like ``rows``. Concatenated rather than interleaved because the two
-    halves patch into two separate copies of the reference pencil, so each row
-    is a contiguous copy on both sides.
+    ``[jac_a; jac_b; constants]`` into a single ``2 * n_row * n_var + n_row``
+    buffer: the whole a block, then the whole b block, each row-major
+    ``(n_row, n_var)`` and ordered like ``rows``, then the constants. Concatenated
+    rather than interleaved because the blocks patch into separate copies of the
+    reference pencil, so each row is a contiguous copy on every side.
 
-    ``jac_b`` carries klein_preproc's sign, so both halves drop into a reference
-    pencil copy as they are.
+    ``jac_b`` carries klein_preproc's sign and ``constants`` is unnegated, so all
+    three drop into a reference pencil copy as they are.
     """
 
     cfuncs: dict[int, Any]
@@ -150,8 +151,9 @@ class RegimeJacobianFunc:
         return int(self.rows[mask].shape[0])
 
     def n_out(self, mask: int) -> int:
-        """Length of ``out``: both blocks, ``2 * n_row * n_var``."""
-        return 2 * self.n_row(mask) * self.n_var
+        """Length of ``out``: both blocks, ``2 * n_row * n_var + n_row``."""
+        n_row = self.n_row(mask)
+        return 2 * n_row * self.n_var + n_row
 
 
 @dataclass(frozen=True)
@@ -213,7 +215,7 @@ class CompiledModel:
         return self._regime_cfuncs
 
     @cached_property
-    def _regime_jacobian_func(self) -> RegimeJacobianFunc | None:
+    def _regime_pencil_func(self) -> RegimePencilFunc | None:
         # Replaced rows of each regime pencil as one cfunc per regime, so the
         # assembly patches a reference pencil copy instead of sweeping the whole
         # regime. Both blocks share a cfunc: after the fwd fold they are
@@ -226,14 +228,20 @@ class CompiledModel:
         cfuncs: dict[int, Any] = {}
         rows: dict[int, NDArray[int64]] = {}
         for mask, block in self.regimes.items():
-            want = len(block.rows) * base.n_var
-            if len(block.jac_a) != want or len(block.jac_b) != want:
+            want_jac = len(block.rows) * base.n_var
+            want_const = len(block.rows)
+            if len(block.jac_a) != want_jac or len(block.jac_b) != want_jac:
                 raise ValueError(
                     f"Regime {mask} has {len(block.jac_a)}/{len(block.jac_b)} "
-                    f"jacobian entries, expected {want} for {len(block.rows)} "
+                    f"jacobian entries, expected {want_jac} for {len(block.rows)} "
                     f"rows over {base.n_var} variables."
                 )
-            exprs = [*block.jac_a, *block.jac_b]
+            if len(block.constants) != want_const:
+                raise ValueError(
+                    f"Regime {mask} has {len(block.constants)} constants, "
+                    f"expected {want_const} for {len(block.rows)} rows."
+                )
+            exprs = [*block.jac_a, *block.jac_b, *block.constants]
             layout = MeasurementLayout(
                 slot=base.slot,
                 n_var=base.n_var,
@@ -243,12 +251,12 @@ class CompiledModel:
             cfuncs[mask] = build_measurement_cfunc(exprs, layout)
             rows[mask] = np.asarray(block.rows, dtype=np.int64)
 
-        return RegimeJacobianFunc(
+        return RegimePencilFunc(
             cfuncs=cfuncs, rows=rows, n_var=base.n_var, n_par=base.n_par
         )
 
-    def construct_regime_jacobian_func(self) -> RegimeJacobianFunc | None:
-        return self._regime_jacobian_func
+    def construct_regime_pencil_func(self) -> RegimePencilFunc | None:
+        return self._regime_pencil_func
 
     @cached_property
     def _constraint_func(self) -> ConstraintFunc | None:

--- a/SymbolicDSGE/core/solver.py
+++ b/SymbolicDSGE/core/solver.py
@@ -194,7 +194,8 @@ class DSGESolver:
         ``rows`` records which reference rows the regime replaced, so the native
         assembly can patch those rows into a copy of the reference pencil instead
         of sweeping the whole regime. ``jac_a``/``jac_b`` are those rows' pencil
-        blocks, flat row-major ``(len(rows), n_var)``.
+        blocks, flat row-major ``(len(rows), n_var)``; ``constants`` is those rows'
+        residual at the expansion point, ``(len(rows),)``.
         """
         regimes = conf.equations.regime
         if not regimes:
@@ -236,8 +237,8 @@ class DSGESolver:
                     rows.append(row)
 
             # Pencils are taken at the expansion point, where fwd and cur are the
-            # same vector; differentiating before that fold is what keeps the two
-            # blocks distinct. b carries klein_preproc's sign on the cur sweep.
+            # same vector; differentiating before that fold is what keeps a and b
+            # distinct. b carries klein_preproc's sign on the cur sweep.
             replaced = [residuals[row] for row in rows]
             jac_a = [
                 sp.diff(resid, sym).subs(fwd_to_cur)  # pyright: ignore
@@ -249,9 +250,18 @@ class DSGESolver:
                 for resid in replaced
                 for sym in cur_syms
             ]
+            # The regime's own residual there, unnegated where b is negated:
+            # a E[y+] = b y - c. Zero on unreplaced rows, so only these are kept.
+            constants = [
+                resid.subs(fwd_to_cur) for resid in replaced  # pyright: ignore
+            ]
 
             compiled[sum(1 << bit[name] for name in key)] = RegimeBlock(
-                residuals=residuals, rows=rows, jac_a=jac_a, jac_b=jac_b
+                residuals=residuals,
+                rows=rows,
+                jac_a=jac_a,
+                jac_b=jac_b,
+                constants=constants,
             )
         return compiled
 

--- a/tests/ckernels/test_regime_pencil.py
+++ b/tests/ckernels/test_regime_pencil.py
@@ -1,0 +1,169 @@
+# type: ignore
+"""Native ``regime_pencil``: the reference pencil with one regime's rows patched.
+
+The fixture is a levels RBC rather than a gap model on purpose. A regime's
+constant is its residual at the *reference* steady state, so at ss = 0 it can
+read as right while being zero for the wrong reason. Here the expansion point is
+nonzero and the constant is the delta * k_ss the shut-off investment rule leaves
+behind, which is what the piecewise solve actually consumes.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+
+import numpy as np
+import pytest
+import sympy as sp
+
+from SymbolicDSGE._ckernels.core import (
+    klein_preprocess,
+    residual_eval,
+    steady_state_newton,
+)
+from SymbolicDSGE._ckernels.occbin import regime_pencil
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from SymbolicDSGE.core.config import Constraint
+
+t = sp.Symbol("t", integer=True)
+
+LOW = 0b1
+
+
+@pytest.fixture(scope="module")
+def compiled(rbc_second_order_test_model_path):
+    """Levels RBC where a bad-TFP regime shuts investment off."""
+    model, kalman = ModelParser(rbc_second_order_test_model_path).get_all()
+    conf = copy.deepcopy(model)
+    _, k, z = conf.variables.variables
+    delta = sp.Symbol("delta")
+
+    conf.equations.constraint = {"low": Constraint(bind=z(t) < 0, relax=z(t) >= 0)}
+    conf.equations.regime = {
+        frozenset({"low"}): {"euler": sp.Eq(k(t + 1), (1 - delta) * k(t))}
+    }
+    return DSGESolver(conf, kalman).compile()
+
+
+@pytest.fixture(scope="module")
+def par(compiled):
+    calib = compiled.config.calibration.parameters
+    return np.array([float(calib[p]) for p in compiled.calib_params])
+
+
+@pytest.fixture(scope="module")
+def ss_ref(compiled, par):
+    """Reference steady state, which every regime linearizes around.
+
+    A lag aux starts where its origin does, so the suffix is stripped before the
+    `<name>_ss` lookup; a shock state and an unseeded variable start at zero.
+    """
+    calib = compiled.config.calibration.parameters
+    seed = []
+    for name in compiled.var_names:
+        origin = re.sub(r"_lag\d+$", "", name)
+        sym = sp.Symbol(f"{origin}_ss")
+        seed.append(float(calib[sym]) if sym in calib else 0.0)
+
+    ss, _ = steady_state_newton(
+        compiled.construct_objective_cfunc().address, np.array(seed), par
+    )
+    # The whole point of a levels fixture: the expansion point is not the origin.
+    assert np.abs(ss).max() > 1.0
+    return ss
+
+
+@pytest.fixture(scope="module")
+def reference(compiled, par, ss_ref):
+    n_var = len(compiled.var_names)
+    return klein_preprocess(
+        compiled.construct_objective_cfunc().address, ss_ref, par, n_var
+    )
+
+
+@pytest.fixture(scope="module")
+def patched(compiled, par, ss_ref, reference):
+    func = compiled.construct_regime_pencil_func()
+    a_ref, b_ref = reference
+    return regime_pencil(func.address(LOW), func.rows[LOW], ss_ref, par, a_ref, b_ref)
+
+
+def _rows(compiled):
+    return compiled.construct_regime_pencil_func().rows[LOW]
+
+
+def test_patched_rows_match_a_full_sweep_of_the_regime(compiled, par, ss_ref, patched):
+    # The patch is only worth doing if it lands where sweeping the whole regime
+    # residual would have.
+    n_var = len(compiled.var_names)
+    rows = _rows(compiled)
+    a, b, _ = patched
+
+    regime_cfunc = compiled.construct_regime_cfuncs()[LOW]
+    a_r, b_r = klein_preprocess(regime_cfunc.address, ss_ref, par, n_var)
+
+    np.testing.assert_allclose(a[rows], a_r[rows])
+    np.testing.assert_allclose(b[rows], b_r[rows])
+
+
+def test_unreplaced_rows_are_copied_verbatim(compiled, reference, patched):
+    # memcpy, not arithmetic: anything but bit equality means a row moved.
+    n_var = len(compiled.var_names)
+    other = np.setdiff1d(np.arange(n_var), _rows(compiled))
+    a_ref, b_ref = reference
+    a, b, _ = patched
+
+    assert other.size > 0
+    np.testing.assert_array_equal(a[other], a_ref[other])
+    np.testing.assert_array_equal(b[other], b_ref[other])
+
+
+def test_constants_are_the_regime_residual_at_the_reference(
+    compiled, par, ss_ref, patched
+):
+    n_var = len(compiled.var_names)
+    rows = _rows(compiled)
+    _, _, c = patched
+
+    regime_cfunc = compiled.construct_regime_cfuncs()[LOW]
+    c_r = residual_eval(regime_cfunc.address, ss_ref, ss_ref, par, n_var).real
+
+    want = np.zeros(n_var)
+    want[rows] = c_r[rows]
+    np.testing.assert_allclose(c, want, atol=1e-10)
+
+    # In levels the constant is delta * k_ss, and it is the whole mechanism: a
+    # zero here would pass the comparison above while solving the wrong model.
+    assert np.abs(c[rows]).min() > 0.5
+    assert np.count_nonzero(c) == rows.size
+
+
+def test_reference_regime_is_a_verbatim_copy(compiled, par, ss_ref, reference):
+    # A null pencil is how the mask-0 slot of the table gets filled, so the
+    # backward recursion can index it without a branch.
+    n_var = len(compiled.var_names)
+    a_ref, b_ref = reference
+    a, b, c = regime_pencil(0, np.empty(0, dtype=np.int64), ss_ref, par, a_ref, b_ref)
+
+    np.testing.assert_array_equal(a, a_ref)
+    np.testing.assert_array_equal(b, b_ref)
+    np.testing.assert_array_equal(c, np.zeros(n_var))
+
+
+def test_rows_outside_the_pencil_are_rejected(compiled, par, ss_ref, reference):
+    # The kernel scatters straight into a[row]; an unchecked index writes past
+    # the output instead of raising.
+    n_var = len(compiled.var_names)
+    func = compiled.construct_regime_pencil_func()
+    a_ref, b_ref = reference
+
+    with pytest.raises(ValueError, match=rf"outside 0\.\.{n_var - 1}"):
+        regime_pencil(
+            func.address(LOW),
+            np.array([n_var], dtype=np.int64),
+            ss_ref,
+            par,
+            a_ref,
+            b_ref,
+        )

--- a/tests/core/test_constraint_compile.py
+++ b/tests/core/test_constraint_compile.py
@@ -242,7 +242,7 @@ def compiled_lead_regime(parsed_post82):
     return solver.compile()
 
 
-def test_regime_jacobians_match_the_complex_step_pencil(compiled_lead_regime):
+def test_regime_pencil_rows_match_the_complex_step_sweep(compiled_lead_regime):
     # The blocks replace a complex-step sweep of the regime, so they have to
     # reproduce it on the replaced rows. Checked away from the steady state too:
     # a gap model sits at ss = 0, where a wrong block can still read as right.
@@ -273,7 +273,7 @@ def test_regime_jacobians_match_the_complex_step_pencil(compiled_lead_regime):
         )
 
 
-def test_regime_jacobians_fold_fwd_symbols_onto_cur(compiled_lead_regime):
+def test_regime_pencil_rows_fold_fwd_symbols_onto_cur(compiled_lead_regime):
     # The blocks are printed against a single `cur` input vector, so a surviving
     # fwd symbol would be unresolvable at emission.
     compiled = compiled_lead_regime
@@ -284,8 +284,8 @@ def test_regime_jacobians_fold_fwd_symbols_onto_cur(compiled_lead_regime):
         assert not expr.free_symbols & fwd_syms
 
 
-def _call_jac(func, mask, cur, par):
-    """The regime jacobian cfunc's output as a (2, n_row, n_var) `[a, b]` view."""
+def _call_pencil(func, mask, cur, par):
+    """The regime pencil cfunc's output split into its `(a, b, c)` blocks."""
     fn = ctypes.CFUNCTYPE(
         None,
         ctypes.POINTER(ctypes.c_double),
@@ -300,22 +300,24 @@ def _call_jac(func, mask, cur, par):
         par.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
         out.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
     )
-    return out.reshape(2, func.n_row(mask), func.n_var)
+    n_row, n_var = func.n_row(mask), func.n_var
+    jac = out[: 2 * n_row * n_var].reshape(2, n_row, n_var)
+    return jac[0], jac[1], out[2 * n_row * n_var :]
 
 
-def test_regime_jacobian_cfunc_writes_both_pencil_blocks(compiled_lead_regime):
+def test_regime_pencil_cfunc_writes_every_block(compiled_lead_regime):
     # One call has to reproduce the regime's own complex-step sweep on the
-    # replaced rows, a block first then b, so the halves patch a reference
-    # pencil copy unchanged.
+    # replaced rows, a then b, plus its residual at the same point, so all three
+    # blocks patch a reference pencil copy unchanged.
     compiled = compiled_lead_regime
-    func = compiled.construct_regime_jacobian_func()
+    func = compiled.construct_regime_pencil_func()
     par = _params(compiled)
     n_var = len(compiled.var_names)
     rows = func.rows[1]
     cfunc = compiled.construct_regime_cfuncs()[1]
 
     assert func.masks == (1,)
-    assert func.n_out(1) == 2 * len(rows) * n_var
+    assert func.n_out(1) == 2 * len(rows) * n_var + len(rows)
 
     rng = np.random.default_rng(0)
     for trial in range(5):
@@ -323,15 +325,18 @@ def test_regime_jacobian_cfunc_writes_both_pencil_blocks(compiled_lead_regime):
             np.zeros(n_var) if trial == 0 else np.round(rng.normal(0, 0.3, n_var), 3)
         )
         a_r, b_r = klein_preprocess(cfunc.address, point, par, n_var)
-        got = _call_jac(func, 1, point, par)
+        c_r = residual_eval(cfunc.address, point, point, par, n_var).real
+        got_a, got_b, got_c = _call_pencil(func, 1, point, par)
 
-        assert np.abs(got).max() > 0.0
-        np.testing.assert_allclose(got[0], a_r[rows, :])
-        np.testing.assert_allclose(got[1], b_r[rows, :])
+        for block in (got_a, got_b, got_c):
+            assert np.abs(block).max() > 0.0
+        np.testing.assert_allclose(got_a, a_r[rows, :])
+        np.testing.assert_allclose(got_b, b_r[rows, :])
+        np.testing.assert_allclose(got_c, c_r[rows])
 
 
-def test_regime_jacobian_func_carries_every_regime_and_is_cached(compiled_regimes):
-    func = compiled_regimes.construct_regime_jacobian_func()
+def test_regime_pencil_func_carries_every_regime_and_is_cached(compiled_regimes):
+    func = compiled_regimes.construct_regime_pencil_func()
 
     assert func.masks == (1, 2, 3)
     assert (func.n_var, func.n_par) == (
@@ -344,10 +349,10 @@ def test_regime_jacobian_func_carries_every_regime_and_is_cached(compiled_regime
         assert func.rows[mask].tolist() == block.rows
         assert func.n_row(mask) == len(block.rows)
 
-    assert compiled_regimes.construct_regime_jacobian_func() is func
+    assert compiled_regimes.construct_regime_pencil_func() is func
 
 
-def test_regime_jacobian_rejects_a_block_that_does_not_match_its_rows(compiled_regimes):
+def test_regime_pencil_rejects_a_block_that_does_not_match_its_rows(compiled_regimes):
     # Emission is where both the block and n_var are in scope; a short block
     # would otherwise reshape into a wrong pencil rather than fail.
     broken = dataclasses.replace(
@@ -355,7 +360,17 @@ def test_regime_jacobian_rejects_a_block_that_does_not_match_its_rows(compiled_r
     )
 
     with pytest.raises(ValueError, match="expected"):
-        broken.construct_regime_jacobian_func()
+        broken.construct_regime_pencil_func()
+
+    # A full pencil row with no constant to go with it: caught on its own branch,
+    # since the jacobian check above never sees it.
+    row = [sp.Integer(0)] * len(compiled_regimes.var_names)
+    no_const = dataclasses.replace(
+        compiled_regimes, regimes={1: RegimeBlock(rows=[0], jac_a=row, jac_b=row)}
+    )
+
+    with pytest.raises(ValueError, match="constants"):
+        no_const.construct_regime_pencil_func()
 
 
 @pytest.fixture(scope="module")
@@ -579,7 +594,7 @@ def test_regime_replacing_an_undeclared_equation_is_rejected(parsed_post82):
 def test_model_without_regimes_has_no_regime_blocks(compiled_post82):
     assert compiled_post82.regimes == {}
     assert compiled_post82.construct_regime_cfuncs() == {}
-    assert compiled_post82.construct_regime_jacobian_func() is None
+    assert compiled_post82.construct_regime_pencil_func() is None
 
 
 def test_model_without_constraints_has_no_constraint_func(compiled_post82):

--- a/tests/core/test_constraint_compile.py
+++ b/tests/core/test_constraint_compile.py
@@ -473,6 +473,42 @@ def test_regime_pencils_swap_only_the_replaced_row(compiled_regimes):
         np.testing.assert_allclose(c_r, want, atol=1e-12)
 
 
+def test_regime_rows_survive_an_aux_equation_only_the_regime_needs(parsed_post82):
+    # A regime lagging deeper than the reference makes desugar inject an aux
+    # equation into the reference model. Rows are positions in that merged order,
+    # so an aux landing anywhere but the end misplaces the patch onto a row the
+    # regime never touched, with no numerical symptom at compile time.
+    model, _ = parsed_post82
+    r, Pi = model.variables.variables[2], model.variables.variables[4]
+    solver = _with_constraints(
+        parsed_post82,
+        {"elb": Constraint(bind=r(t) < 0, relax=r(t) >= 0)},
+        {frozenset({"elb"}): {"taylor": sp.Eq(r(t), Pi(t - 1))}},
+    )
+
+    compiled = solver.compile()
+    names = list(compiled.config.equations.model)
+
+    assert "Pi_lag1" in compiled.var_names
+    assert compiled.regimes[1].rows == [names.index("taylor")]
+
+    # The rows the pencil actually moves are the rows we recorded, which is the
+    # part an index shift would break.
+    par = _params(compiled)
+    n_eq = len(compiled.var_names)
+    ref_cfunc = compiled.construct_objective_cfunc()
+    ss_ref, _ = steady_state_newton(ref_cfunc.address, np.zeros(n_eq), par)
+
+    a_ref, b_ref = klein_preprocess(ref_cfunc.address, ss_ref, par, n_eq)
+    a_r, b_r = klein_preprocess(
+        compiled.construct_regime_cfuncs()[1].address, ss_ref, par, n_eq
+    )
+    changed = np.maximum(
+        np.abs(a_r - a_ref).max(axis=1), np.abs(b_r - b_ref).max(axis=1)
+    )
+    assert np.flatnonzero(changed).tolist() == compiled.regimes[1].rows
+
+
 @pytest.fixture(scope="module")
 def compiled_rbc_obc(rbc_second_order_test_model_path):
     """Levels RBC where a bad-TFP regime shuts investment off.


### PR DESCRIPTION
This pull request introduces a new native implementation for regime pencils in the OccBin subsystem, enabling efficient computation of regime-dependent linear system blocks ("pencils") in piecewise-linear DSGE models. The main changes add a new C kernel (`regime_pencil.c`/`.h`), expose it via the Cython shim, and update the Python-side API and data structures to support the new constants vector in each regime's pencil. This allows for more accurate and efficient regime switching by patching only the affected rows in the system matrices and their constants.

**Major new feature: Regime pencil kernel**

- **New C kernel for regime pencils:** Implements `sdsge_regime_pencil` and related helpers in `regime_pencil.c`/`.h`, allowing efficient patching of only the rows modified by regime switches, including the constants vector (`c`). [[1]](diffhunk://#diff-8e4817bc14c27881e795182076ee5bfb25c4ce46219cec8ba7a63a414467c66cR1-R55) [[2]](diffhunk://#diff-440253bd1b8d06f496fd9eb971eec1c4dccb5e708dbba096b3860f92967e0655R1-R33)

**Cython and Python bindings:**

- **Cython wrapper and Python API:** Exposes the new regime pencil kernel through `regime_pencil` in `_occbin.pyx`, with input validation and memory management, and updates the public API (`__init__.py`, stub file, and `__all__`). [[1]](diffhunk://#diff-e39312bd6a08d3c0e3a86714935b3d68b8c74eb290f8048cad23c633ddf8f2f6R29-R45) [[2]](diffhunk://#diff-e39312bd6a08d3c0e3a86714935b3d68b8c74eb290f8048cad23c633ddf8f2f6R100-R179) [[3]](diffhunk://#diff-e9c9730fdaa5b229334818a4f6fa7e9344442cab1fb822c252ea23d80ffe96b7L1-R12) [[4]](diffhunk://#diff-19e5a886ce33402730a9e8774aa493a7a4623d5b8d3091fdc8413b025f7564dbL10-R15) [[5]](diffhunk://#diff-19e5a886ce33402730a9e8774aa493a7a4623d5b8d3091fdc8413b025f7564dbR32-R45)

**Data structure and API changes:**

- **Adds constants to regime blocks:** Updates `RegimeBlock` and all related logic to include a `constants` vector for each regime, which is now compiled and checked for correctness. [[1]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fR117-R132) [[2]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L197-R198) [[3]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911L239-R241) [[4]](diffhunk://#diff-5f7324be8f45960993de92f133cba13ee86f4b748c7d0b237493b26a7422c911R253-R264)
- **Refactors regime pencil function:** Renames and updates the regime Jacobian function to `RegimePencilFunc`, updating the buffer layout and all related methods to handle the new constants component. [[1]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fL153-R156) [[2]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fL216-R218) [[3]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fL229-R244) [[4]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fL246-R259)

**Documentation and cleanup:**

- **Updates and clarifies documentation:** Cleans up and clarifies documentation in the `_ckernels/README.md` and related docstrings to reflect the new regime pencil implementation and conventions. [[1]](diffhunk://#diff-1666d1550ecd7db91ccc789aee0e4af5ea092a79fc70f77d4ab5382530c98f70L14-L26) [[2]](diffhunk://#diff-1666d1550ecd7db91ccc789aee0e4af5ea092a79fc70f77d4ab5382530c98f70L35-L37)

These changes collectively enable more modular and efficient handling of regime-dependent system matrices and constants in piecewise-linear DSGE models.

closes #399 