### PR TITLE
Make Klein policy outputs real

### DIFF
--- a/SymbolicDSGE/_ckernels/core/_core.pyi
+++ b/SymbolicDSGE/_ckernels/core/_core.pyi
@@ -94,12 +94,13 @@ def klein_solve1(
     params: _F64,
     n_state: int,
     n_exog: int = ...,
-) -> tuple[_F64, _F64, _F64, _C128, _C128, int, _C128, _F64, _F64]:
+) -> tuple[_F64, _F64, _F64, _F64, _F64, int, _C128, _F64, _F64]:
     """(ss, a, b, f, p, stab, eig, A, B) <- one-shot first-order Klein solve.
 
     Fuses steady_state_newton, klein_preprocess, klein_qz, klein_postprocess and
-    assemble_state_space into one GIL release. ``stab`` is reported, not raised
-    on."""
+    assemble_state_space into one GIL release. ``f``/``p`` are real; the Schur
+    form's imaginary parts are roundoff on a real pencil. ``stab`` is reported,
+    not raised on."""
 
 def sgu_klein_solve2(
     residual_addr: int,
@@ -109,7 +110,7 @@ def sgu_klein_solve2(
     n_state: int,
     eta: _F64,
     n_exog: int = ...,
-) -> tuple[_F64, _C128, _C128, int, _C128, _F64, _F64, _F64, _F64, _F64, _F64]:
+) -> tuple[_F64, _F64, _F64, int, _C128, _F64, _F64, _F64, _F64, _F64, _F64]:
     """(ss, f, p, stab, eig, gxx, hxx, gss, hss, A, B) <- one-shot second-order
     (SGU) solve.
 

--- a/SymbolicDSGE/_ckernels/core/_core.pyx
+++ b/SymbolicDSGE/_ckernels/core/_core.pyx
@@ -153,8 +153,8 @@ cdef extern from "klein_solve.h" nogil:
         c128 *s
         c128 *t
         c128 *z
-        c128 *f
-        c128 *p
+        double *f
+        double *p
         c128 *eig
         int64_t stab
         double *A
@@ -166,8 +166,6 @@ cdef extern from "klein_solve.h" nogil:
 
     ctypedef struct sdsge_solve2:
         double *f_xx
-        double *hx_real
-        double *gx_real
         double *bx
         double *eta
         double *gxx
@@ -578,10 +576,12 @@ def klein_solve1(
     ``klein_postprocess`` reads row-major, so staging bridges them by copying
     where the driver transposes in place.
 
-    Returns ``(ss, a, b, f, p, stab, eig, A, B)``. ``a``/``b`` are the pencil the
-    solve linearized at, handed back so a second-order caller need not rebuild
-    it. ``stab`` is reported, never raised on: whether a Blanchard-Kahn
-    stability/uniqueness violation is fatal is the caller's decision.
+    Returns ``(ss, a, b, f, p, stab, eig, A, B)``. ``f``/``p`` are real: the
+    Schur form's imaginary parts are roundoff on a real pencil and the native
+    solve projects them once. ``a``/``b`` are the pencil the solve linearized at,
+    handed back so a second-order caller need not rebuild it. ``stab`` is
+    reported, never raised on: whether a Blanchard-Kahn stability/uniqueness
+    violation is fatal is the caller's decision.
     """
     cdef double[::1] seedv = np.ascontiguousarray(seed, dtype=np.float64)
     cdef double[::1] parv = np.ascontiguousarray(params, dtype=np.float64)
@@ -602,8 +602,8 @@ def klein_solve1(
     s = np.empty((n_var, n_var), dtype=np.complex128)
     t = np.empty((n_var, n_var), dtype=np.complex128)
     z = np.empty((n_var, n_var), dtype=np.complex128)
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     A = np.empty((n_var, n_var), dtype=np.float64)
     B = np.empty((n_var, n_exog), dtype=np.float64)
@@ -614,8 +614,8 @@ def klein_solve1(
     cdef double complex[:, ::1] sv = s
     cdef double complex[:, ::1] tv = t
     cdef double complex[:, ::1] zv = z
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     cdef double[:, ::1] Av = A
     cdef double[:, ::1] Bv = B
@@ -638,8 +638,8 @@ def klein_solve1(
     out.s = <c128 *>&sv[0, 0]
     out.t = <c128 *>&tv[0, 0]
     out.z = <c128 *>&zv[0, 0]
-    out.f = <c128 *>&fv[0, 0] if n_ctrl > 0 else NULL
-    out.p = <c128 *>&pv[0, 0]
+    out.f = &fv[0, 0] if n_ctrl > 0 else NULL
+    out.p = &pv[0, 0]
     out.eig = <c128 *>&eigv[0]
     out.stab = 0
     out.A = &Av[0, 0]
@@ -707,15 +707,13 @@ def sgu_klein_solve2(
     s = np.empty((n_var, n_var), dtype=np.complex128)
     t = np.empty((n_var, n_var), dtype=np.complex128)
     z = np.empty((n_var, n_var), dtype=np.complex128)
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     A = np.empty((n_var, n_var), dtype=np.float64)
     B = np.empty((n_var, n_exog), dtype=np.float64)
 
     f_xx = np.empty((n_var, n2, n2), dtype=np.float64)
-    hx_real = np.empty((n_state, n_state), dtype=np.float64)
-    gx_real = np.empty((n_ctrl, n_state), dtype=np.float64)
     bx = np.empty((n_state, n_exog), dtype=np.float64)
     gxx = np.empty((n_ctrl, n_state, n_state), dtype=np.float64)
     hxx = np.empty((n_state, n_state, n_state), dtype=np.float64)
@@ -728,15 +726,13 @@ def sgu_klein_solve2(
     cdef double complex[:, ::1] sv = s
     cdef double complex[:, ::1] tv = t
     cdef double complex[:, ::1] zv = z
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     cdef double[:, ::1] Av = A
     cdef double[:, ::1] Bv = B
 
     cdef double[:, :, ::1] fxxv = f_xx
-    cdef double[:, ::1] hxrv = hx_real
-    cdef double[:, ::1] gxrv = gx_real
     cdef double[:, ::1] bxv = bx
     cdef double[:, :, ::1] gxxv = gxx
     cdef double[:, :, ::1] hxxv = hxx
@@ -762,8 +758,8 @@ def sgu_klein_solve2(
     out.s = <c128 *>&sv[0, 0]
     out.t = <c128 *>&tv[0, 0]
     out.z = <c128 *>&zv[0, 0]
-    out.f = <c128 *>&fv[0, 0] if n_ctrl > 0 else NULL
-    out.p = <c128 *>&pv[0, 0]
+    out.f = &fv[0, 0] if n_ctrl > 0 else NULL
+    out.p = &pv[0, 0]
     out.eig = <c128 *>&eigv[0]
     out.stab = 0
     out.A = &Av[0, 0]
@@ -771,8 +767,6 @@ def sgu_klein_solve2(
 
     cdef sdsge_solve2 out2
     out2.f_xx = &fxxv[0, 0, 0]
-    out2.hx_real = &hxrv[0, 0]
-    out2.gx_real = &gxrv[0, 0] if n_ctrl > 0 else NULL
     out2.bx = &bxv[0, 0] if n_exog > 0 else NULL
     out2.eta = &etav[0, 0] if n_exog > 0 else NULL
     out2.gxx = &gxxv[0, 0, 0] if n_ctrl > 0 else NULL
@@ -802,8 +796,8 @@ def second_order(a, b, f_xx, gx, hx, int64_t n_state):
     ``(ny, nx)``, ``hx`` ``(nx, nx)``. Returns ``gxx (ny, nx, nx)``,
     ``hxx (nx, nx, nx)``.
 
-    Inputs are coerced to C-contiguous f64 (``gx``/``hx`` arrive as real-part
-    views of the complex Klein solution, so a copy is expected here).
+    Inputs are coerced to C-contiguous f64; ``gx``/``hx`` are the Klein
+    solution's ``f``/``p``, already real.
     """
     cdef double[:, ::1] av = np.ascontiguousarray(a, dtype=np.float64)
     cdef double[:, ::1] bv = np.ascontiguousarray(b, dtype=np.float64)

--- a/SymbolicDSGE/_ckernels/core/klein_solve.c
+++ b/SymbolicDSGE/_ckernels/core/klein_solve.c
@@ -56,24 +56,43 @@ static inline arena_size sdsge_max_arena(const arena_size a,
   return make_sizer(max_i64(a.n_float, b.n_float), max_i64(a.n_int, b.n_int));
 }
 
-arena_size sdsge_klein_solve1_arena_size(const i64 n_var, const i64 n_state,
-                                         const i64 n_ctrl, const i64 n_par) {
+/* f64 head reserved for the complex f/p the post-proc emits, which must outlive
+ * the post-proc's own scratch: the state-space assembly reads them after it. */
+static inline i64 sdsge_solve1_fp_reserve(const i64 n_state, const i64 n_ctrl) {
+  return 2 * (n_ctrl * n_state + n_state * n_state);
+}
+
+/* Stage max only. The reserve is added once by the public sizers, so it is never
+ * folded into a max and then compared against a later stage. */
+static inline arena_size sdsge_solve1_stage_arena(const i64 n_var,
+                                                  const i64 n_state,
+                                                  const i64 n_ctrl,
+                                                  const i64 n_par) {
   arena_size size = sdsge_newton_arena_size(n_var, n_par);
   size = sdsge_max_arena(size, klein_preproc_arena_size(n_var, n_par, n_var));
   size = sdsge_max_arena(size, klein_qz_arena_size(n_var));
   return sdsge_max_arena(size, klein_postproc_arena_size(n_state, n_ctrl));
 }
 
+arena_size sdsge_klein_solve1_arena_size(const i64 n_var, const i64 n_state,
+                                         const i64 n_ctrl, const i64 n_par) {
+  arena_size size = sdsge_solve1_stage_arena(n_var, n_state, n_ctrl, n_par);
+  size.n_float += sdsge_solve1_fp_reserve(n_state, n_ctrl);
+  return size;
+}
+
 arena_size sdsge_sgu_klein_solve2_arena_size(const i64 n_var, const i64 n_state,
                                              const i64 n_ctrl, const i64 n_par,
                                              const i64 n_exog) {
-  arena_size size =
-      sdsge_klein_solve1_arena_size(n_var, n_state, n_ctrl, n_par);
+  arena_size size = sdsge_solve1_stage_arena(n_var, n_state, n_ctrl, n_par);
   size = sdsge_max_arena(
       size, sdsge_bicomplex_hessian_arena_size(n_var, n_par, n_var));
   size = sdsge_max_arena(size, sdsge_second_order_arena_size(n_var, n_state));
-  return sdsge_max_arena(
+  size = sdsge_max_arena(
       size, sdsge_second_order_risk_arena_size(n_var, n_state, n_exog));
+  /* Second-order stages run past the same head: solve1 is nested inside. */
+  size.n_float += sdsge_solve1_fp_reserve(n_state, n_ctrl);
+  return size;
 }
 
 i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out,
@@ -84,25 +103,32 @@ i64 sdsge_klein_linearize(const klein_spec *spec, sdsge_solve1 *out,
    * linearize there. A gap model (ss = 0) seeds at 0 and converges in one step;
    * a params draw with no steady state fails and is rejected as infeasible. */
   i64 iters = 0;
+  f64 *stage = arena + sdsge_solve1_fp_reserve(spec->n_state, spec->n_ctrl);
   const i64 rc = sdsge_steady_state_newton(
       spec->residual, spec->ss_seed, spec->params, n, spec->n_par,
-      SDSGE_SS_MAX_ITER, SDSGE_SS_TOL, out->ss, &iters, arena, iarena);
+      SDSGE_SS_MAX_ITER, SDSGE_SS_TOL, out->ss, &iters, stage, iarena);
   if (rc != SDSGE_NEWTON_OK) {
     return rc;
   }
 
   klein_preproc(spec->residual, out->ss, spec->params, n, spec->n_par, n,
-                out->a_real, out->b_real, arena);
+                out->a_real, out->b_real, stage);
   return SDSGE_KLEIN_SOLVE_OK;
 }
 
 i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out,
                             f64 *arena, i64 *iarena) {
   const i64 n = spec->n_var;
+  const i64 n_fp = spec->n_ctrl * spec->n_state;
+
+  /* Complex f/p in the arena head, stages past it. */
+  c128 *f_cplx = (c128 *)arena;
+  c128 *p_cplx = f_cplx + n_fp;
+  f64 *stage = arena + sdsge_solve1_fp_reserve(spec->n_state, spec->n_ctrl);
 
   sdsge_to_complex_colmajor(out->a_real, out->s, n);
   sdsge_to_complex_colmajor(out->b_real, out->t, n);
-  if (klein_qz(spec->zgges, n, out->s, out->t, out->z, arena, iarena) !=
+  if (klein_qz(spec->zgges, n, out->s, out->t, out->z, stage, iarena) !=
       KLEIN_QZ_OK) {
     return SDSGE_KLEIN_SOLVE_QZ;
   }
@@ -113,7 +139,7 @@ i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out,
   sdsge_transpose_sq(out->z, n);
 
   switch (klein_postproc(out->s, out->t, out->z, spec->n_state, spec->n_ctrl,
-                         out->f, out->p, &out->stab, out->eig, arena, iarena)) {
+                         f_cplx, p_cplx, &out->stab, out->eig, stage, iarena)) {
   case SDSGE_KLEIN_POSTPROC_SUCCESS:
     break;
   case SDSGE_KLEIN_POSTPROC_INVALID:
@@ -122,7 +148,15 @@ i64 sdsge_klein_from_pencil(const klein_spec *spec, sdsge_solve1 *out,
     return SDSGE_KLEIN_SOLVE_SINGULAR;
   }
 
-  sdsge_assemble_state_space(out->p, out->f, spec->n_state, spec->n_ctrl,
+  if (spec->n_ctrl > 0) {
+    sdsge_real_part(f_cplx, out->f, n_fp);
+  }
+  sdsge_real_part(p_cplx, out->p, spec->n_state * spec->n_state);
+
+  /* Assembly stays complex: A's control block is Re(f @ p), which is not
+   * Re(f) @ Re(p). The cross term is roundoff here and load-bearing in the
+   * kernel's own parity test. */
+  sdsge_assemble_state_space(p_cplx, f_cplx, spec->n_state, spec->n_ctrl,
                              spec->n_exog, out->A, out->B);
   return SDSGE_KLEIN_SOLVE_OK;
 }
@@ -145,25 +179,22 @@ i64 sdsge_sgu_klein_solve2(const sgu_klein_spec *spec, sdsge_solve1 *out1,
     return rc;
   }
 
-  /* The tensors are real; p/f carry ~1e-16 imaginary roundoff from the complex
-   * Schur form. */
-  sdsge_real_part(out1->p, out2->hx_real, s1->n_state * s1->n_state);
-  sdsge_real_part(out1->f, out2->gx_real, s1->n_ctrl * s1->n_state);
+  f64 *stage = arena + sdsge_solve1_fp_reserve(s1->n_state, s1->n_ctrl);
   sdsge_bx_from_B(out1->B, s1->n_state, s1->n_exog, out2->bx);
 
   sdsge_bicomplex_hessian(spec->bc_residual, out1->ss, s1->params, s1->n_var,
-                          s1->n_par, s1->n_var, out2->f_xx, arena);
+                          s1->n_par, s1->n_var, out2->f_xx, stage);
 
-  if (sdsge_second_order(out1->a_real, out1->b_real, out2->f_xx, out2->gx_real,
-                         out2->hx_real, s1->n_var, s1->n_state, out2->gxx,
-                         out2->hxx, arena, iarena) != SDSGE_SECOND_ORDER_OK) {
+  if (sdsge_second_order(out1->a_real, out1->b_real, out2->f_xx, out1->f,
+                         out1->p, s1->n_var, s1->n_state, out2->gxx, out2->hxx,
+                         stage, iarena) != SDSGE_SECOND_ORDER_OK) {
     return SDSGE_KLEIN_SOLVE_SECOND_ORDER;
   }
 
-  if (sdsge_second_order_risk(out1->a_real, out1->b_real, out2->f_xx,
-                              out2->gx_real, out2->gxx, out2->eta, s1->n_var,
-                              s1->n_state, s1->n_exog, out2->gss, out2->hss,
-                              arena, iarena) != SDSGE_SECOND_ORDER_OK) {
+  if (sdsge_second_order_risk(out1->a_real, out1->b_real, out2->f_xx, out1->f,
+                              out2->gxx, out2->eta, s1->n_var, s1->n_state,
+                              s1->n_exog, out2->gss, out2->hss, stage,
+                              iarena) != SDSGE_SECOND_ORDER_OK) {
     return SDSGE_KLEIN_SOLVE_RISK;
   }
   return SDSGE_KLEIN_SOLVE_OK;

--- a/SymbolicDSGE/_ckernels/core/klein_solve.h
+++ b/SymbolicDSGE/_ckernels/core/klein_solve.h
@@ -20,7 +20,12 @@ typedef struct {
   i64 n_par;
 } klein_spec;
 
-/* First-order Klein solve outputs; every buffer is caller-owned. */
+/* First-order Klein solve outputs; every buffer is caller-owned.
+ *
+ * `f` and `p` are real. The Schur algebra that produces them is complex, but
+ * its imaginary parts are roundoff on a real pencil and no consumer has ever
+ * read them, so the projection happens once here rather than at each use. The
+ * complex originals live in the arena and do not outlive the solve. */
 typedef struct {
   f64 *ss;     /* n_var: Newton-resolved steady state (from ss_seed) */
   f64 *a_real; /* n_var*n_var */
@@ -28,17 +33,19 @@ typedef struct {
   c128 *s;     /* n_var*n_var */
   c128 *t;     /* n_var*n_var */
   c128 *z;     /* n_var*n_var */
-  c128 *f;     /* n_ctrl*n_state, or NULL when n_ctrl == 0 */
-  c128 *p;     /* n_state*n_state */
+  f64 *f;      /* n_ctrl*n_state, or NULL when n_ctrl == 0 */
+  f64 *p;      /* n_state*n_state */
   c128 *eig;   /* n_var */
   i64 stab;
   f64 *A; /* n_var*n_var */
   f64 *B; /* n_var*n_exog */
 } sdsge_solve1;
 
-/* Scratch for a whole first-order solve: the componentwise max over its stages,
- * which run one after another off the same buffer. `arena` holds n_float f64,
- * `iarena` n_int i64; both are caller-owned and may be reused across solves. */
+/* Scratch for a whole first-order solve: a reserved head holding the complex
+ * `f`/`p` the Schur post-proc emits, then the componentwise max over the
+ * stages, which run one after another off the buffer past that head. `arena`
+ * holds n_float f64, `iarena` n_int i64; both are caller-owned and may be
+ * reused across solves. */
 arena_size sdsge_klein_solve1_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
                                          i64 n_par);
 
@@ -71,12 +78,13 @@ typedef struct {
 /* Second-order solve buffers, all caller-owned. Outputs except `eta`, which is
  * an input: the shock loading (chol of the shock covariance in the leading
  * n_exog rows) is refactored only when that covariance moves, and only the
- * caller knows whether it did. */
+ * caller knows whether it did.
+ *
+ * The first-order rules the SGU tensors are built from are `sdsge_solve1.p` and
+ * `.f`, which are already real; this struct does not restate them. */
 typedef struct {
-  f64 *f_xx;    /* n_var*(2*n_var)*(2*n_var) */
-  f64 *hx_real; /* n_state*n_state */
-  f64 *gx_real; /* n_ctrl*n_state */
-  f64 *bx;      /* n_state*n_exog */
+  f64 *f_xx; /* n_var*(2*n_var)*(2*n_var) */
+  f64 *bx;   /* n_state*n_exog */
   f64 *eta;     /* n_state*n_exog, caller-filled */
   f64 *gxx;     /* n_ctrl*n_state*n_state */
   f64 *hxx;     /* n_state*n_state*n_state */
@@ -84,9 +92,9 @@ typedef struct {
   f64 *hss;     /* n_state */
 } sdsge_solve2;
 
-/* sdsge_klein_solve1, then the second-order tail: real p/f, the state rows of
- * B, the bicomplex Hessian at the resolved steady state, the SGU tensors and
- * the sigma^2 risk correction. Every first-order output stays in `out1`.
+/* sdsge_klein_solve1, then the second-order tail: the state rows of B, the
+ * bicomplex Hessian at the resolved steady state, the SGU tensors and the
+ * sigma^2 risk correction. Every first-order output stays in `out1`.
  *
  * out1->stab is reported, never acted on, exactly as at first order. */
 arena_size sdsge_sgu_klein_solve2_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,

--- a/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
+++ b/SymbolicDSGE/_ckernels/estimation/_estimation.pyx
@@ -89,8 +89,8 @@ cdef extern from "estimation.h":
         c128 *s
         c128 *t
         c128 *z
-        c128 *f
-        c128 *p
+        double *f
+        double *p
         c128 *eig
         int64_t stab
         double *A
@@ -137,8 +137,6 @@ cdef extern from "estimation.h":
 
     ctypedef struct sdsge_solve2:
         double *f_xx
-        double *hx_real
-        double *gx_real
         double *bx
         double *eta
         double *gxx
@@ -304,8 +302,8 @@ def obj_linear_base(
     s = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     t = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     z = np.empty((n_var, n_var), dtype=np.complex128, order="F")
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     x0 = np.zeros(n_var, dtype=np.float64)
     A = np.empty((n_var, n_var), dtype=np.float64)
@@ -320,8 +318,8 @@ def obj_linear_base(
     cdef double complex[::1, :] sv = s
     cdef double complex[::1, :] tv = t
     cdef double complex[::1, :] zv = z
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     cdef double[::1] x0v = x0
     cdef double[:, ::1] Av = A
@@ -401,8 +399,8 @@ def obj_linear_base(
     ctx.solve.s = <c128*>&sv[0, 0]
     ctx.solve.t = <c128*>&tv[0, 0]
     ctx.solve.z = <c128*>&zv[0, 0]
-    ctx.solve.f = <c128*>&fv[0, 0]
-    ctx.solve.p = <c128*>&pv[0, 0]
+    ctx.solve.f = &fv[0, 0]
+    ctx.solve.p = &pv[0, 0]
     ctx.solve.eig = <c128*>&eigv[0]
     ctx.solve.A = &Av[0, 0]
     ctx.solve.B = &Bv[0, 0]
@@ -453,8 +451,8 @@ def obj_extended_base(
     s = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     t = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     z = np.empty((n_var, n_var), dtype=np.complex128, order="F")
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     x0 = np.zeros(n_var, dtype=np.float64)
     A = np.empty((n_var, n_var), dtype=np.float64)
@@ -467,8 +465,8 @@ def obj_extended_base(
     cdef double complex[::1, :] sv = s
     cdef double complex[::1, :] tv = t
     cdef double complex[::1, :] zv = z
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     cdef double[::1] x0v = x0
     cdef double[:, ::1] Av = A
@@ -546,8 +544,8 @@ def obj_extended_base(
     ctx.solve.s = <c128*>&sv[0, 0]
     ctx.solve.t = <c128*>&tv[0, 0]
     ctx.solve.z = <c128*>&zv[0, 0]
-    ctx.solve.f = <c128*>&fv[0, 0]
-    ctx.solve.p = <c128*>&pv[0, 0]
+    ctx.solve.f = &fv[0, 0]
+    ctx.solve.p = &pv[0, 0]
     ctx.solve.eig = <c128*>&eigv[0]
     ctx.solve.A = &Av[0, 0]
     ctx.solve.B = &Bv[0, 0]
@@ -597,8 +595,8 @@ def obj_unscented_base(
     s = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     t = np.empty((n_var, n_var), dtype=np.complex128, order="F")
     z = np.empty((n_var, n_var), dtype=np.complex128, order="F")
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     x0 = np.zeros(n_var, dtype=np.float64)
     A = np.empty((n_var, n_var), dtype=np.float64)
@@ -606,8 +604,6 @@ def obj_unscented_base(
 
     # Second-order scratch.
     f_xx = np.empty((n_var, n2, n2), dtype=np.float64)
-    hx_real = np.empty((n_state, n_state), dtype=np.float64)
-    gx_real = np.empty((n_ctrl, n_state), dtype=np.float64)
     bx = np.empty((n_state, n_exog), dtype=np.float64)
     gxx = np.empty((n_ctrl, n_state, n_state), dtype=np.float64)
     hxx = np.empty((n_state, n_state, n_state), dtype=np.float64)
@@ -632,16 +628,14 @@ def obj_unscented_base(
     cdef double complex[::1, :] sv = s
     cdef double complex[::1, :] tv = t
     cdef double complex[::1, :] zv = z
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     cdef double[::1] x0v = x0
     cdef double[:, ::1] Av = A
     cdef double[:, ::1] Bv = B
 
     cdef double[:, :, ::1] fxxv = f_xx
-    cdef double[:, ::1] hxrv = hx_real
-    cdef double[:, ::1] gxrv = gx_real
     cdef double[:, ::1] bxv = bx
     cdef double[:, ::1] etav = eta
     cdef double[:, :, ::1] gxxv = gxx
@@ -724,15 +718,13 @@ def obj_unscented_base(
     ctx.solve.s = <c128*>&sv[0, 0]
     ctx.solve.t = <c128*>&tv[0, 0]
     ctx.solve.z = <c128*>&zv[0, 0]
-    ctx.solve.f = <c128*>&fv[0, 0]
-    ctx.solve.p = <c128*>&pv[0, 0]
+    ctx.solve.f = &fv[0, 0]
+    ctx.solve.p = &pv[0, 0]
     ctx.solve.eig = <c128*>&eigv[0]
     ctx.solve.A = &Av[0, 0]
     ctx.solve.B = &Bv[0, 0]
 
     ctx.solve2.f_xx = &fxxv[0, 0, 0]
-    ctx.solve2.hx_real = &hxrv[0, 0]
-    ctx.solve2.gx_real = &gxrv[0, 0]
     ctx.solve2.bx = &bxv[0, 0]
     ctx.solve2.eta = &etav[0, 0]
     ctx.solve2.gxx = &gxxv[0, 0, 0]
@@ -906,14 +898,14 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     cdef double complex[::1, :] sv = s
     cdef double complex[::1, :] tv = t
     cdef double complex[::1, :] zv = z
-    f = np.empty((n_ctrl, n_state), dtype=np.complex128)
-    p = np.empty((n_state, n_state), dtype=np.complex128)
+    f = np.empty((n_ctrl, n_state), dtype=np.float64)
+    p = np.empty((n_state, n_state), dtype=np.float64)
     eig = np.empty(n_var, dtype=np.complex128)
     nc.keep.append(f)
     nc.keep.append(p)
     nc.keep.append(eig)
-    cdef double complex[:, ::1] fv = f
-    cdef double complex[:, ::1] pv = p
+    cdef double[:, ::1] fv = f
+    cdef double[:, ::1] pv = p
     cdef double complex[::1] eigv = eig
     A = np.empty((n_var, n_var), dtype=np.float64)
     B = np.empty((n_var, n_exog), dtype=np.float64)
@@ -930,8 +922,6 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
 
     # Unscented-only second-order scratch (allocated in that branch).
     cdef double[:, :, ::1] fxxv
-    cdef double[:, ::1] hxrv
-    cdef double[:, ::1] gxrv
     cdef double[:, ::1] bxv
     cdef double[:, :, ::1] gxxv
     cdef double[:, :, ::1] hxxv
@@ -1224,8 +1214,8 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
     s1.s = <c128*>&sv[0, 0]
     s1.t = <c128*>&tv[0, 0]
     s1.z = <c128*>&zv[0, 0]
-    s1.f = <c128*>&fv[0, 0]
-    s1.p = <c128*>&pv[0, 0]
+    s1.f = &fv[0, 0]
+    s1.p = &pv[0, 0]
     s1.eig = <c128*>&eigv[0]
     s1.A = &Av[0, 0]
     s1.B = &Bv[0, 0]
@@ -1236,8 +1226,6 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
         nc.lctx.d = &dv[0]
     elif mode == "unscented":
         f_xx = np.empty((n_var, n2, n2), dtype=np.float64)
-        hx_real = np.empty((n_state, n_state), dtype=np.float64)
-        gx_real = np.empty((n_ctrl, n_state), dtype=np.float64)
         bx = np.empty((n_state, n_exog), dtype=np.float64)
         gxx = np.empty((n_ctrl, n_state, n_state), dtype=np.float64)
         hxx = np.empty((n_state, n_state, n_state), dtype=np.float64)
@@ -1251,12 +1239,9 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
                 np.asarray(qs.constant, dtype=np.float64).reshape(n_exog, n_exog)
             )
         z0 = np.ascontiguousarray(ctx_dto.z0, dtype=np.float64)
-        for _a in (f_xx, hx_real, gx_real, bx, gxx, hxx,
-                   gss, hss, eta, z0):
+        for _a in (f_xx, bx, gxx, hxx, gss, hss, eta, z0):
             nc.keep.append(_a)
         fxxv = f_xx
-        hxrv = hx_real
-        gxrv = gx_real
         bxv = bx
         gxxv = gxx
         hxxv = hxx
@@ -1265,8 +1250,6 @@ cdef _NativeCtx _build_native_ctx(object ctx_dto, str mode):
         etav = eta
         z0v = z0
         nc.uctx.solve2.f_xx = &fxxv[0, 0, 0]
-        nc.uctx.solve2.hx_real = &hxrv[0, 0]
-        nc.uctx.solve2.gx_real = &gxrv[0, 0]
         nc.uctx.solve2.bx = &bxv[0, 0]
         nc.uctx.solve2.eta = &etav[0, 0]
         nc.uctx.solve2.gxx = &gxxv[0, 0, 0]

--- a/SymbolicDSGE/_ckernels/estimation/estimation.c
+++ b/SymbolicDSGE/_ckernels/estimation/estimation.c
@@ -336,8 +336,8 @@ f64 sdsge_obj_unscented(sdsge_unscented_ctx *ctx,
 
   f64 ll = 0.0;
   ukf_inputs in = {.meas = b->meas,
-                   .hx = s2->hx_real,
-                   .gx = s2->gx_real,
+                   .hx = s->p,
+                   .gx = s->f,
                    .bx = s2->bx,
                    .hxx = s2->hxx,
                    .gxx = s2->gxx,

--- a/SymbolicDSGE/_ckernels/kalman/kalman.h
+++ b/SymbolicDSGE/_ckernels/kalman/kalman.h
@@ -6,8 +6,8 @@
 
 /* ERROR CODES */
 
+/* -1 is unassigned: it was a complex-matrix rejection no kernel ever returned. */
 #define KF_OK 0
-#define KF_ERR_COMPLEX_MATRIX -1
 #define KF_ERR_SHAPE_MISMATCH -2
 #define KF_ERR_MATRIX_CONDITION -3
 #define KF_ERR_SINGULAR_MATRIX -4

--- a/SymbolicDSGE/core/solved_model.py
+++ b/SymbolicDSGE/core/solved_model.py
@@ -161,7 +161,7 @@ class SolvedModel:
                 raise ValueError(
                     f"x0 must have length {n_state} or {n}, got {raw.shape[0]}."
                 )
-        x0_arr[n_state:] = x0_arr[:n_state] @ np.real_if_close(self.policy.f.T)
+        x0_arr[n_state:] = x0_arr[:n_state] @ self.policy.f.T
         return x0_arr
 
     @staticmethod
@@ -912,8 +912,8 @@ def _simulate_order1(
     )
     X = np.empty((T, model.A.shape[0]), dtype=float64)
     simulate_linear_states_into(
-        asarray(model.A, dtype=float64),
-        asarray(model.B, dtype=float64),
+        model.A,
+        model.B,
         x0_arr,
         shock_mat,
         X,
@@ -921,7 +921,7 @@ def _simulate_order1(
     return X
 
 
-def _policy_array(policy: Any, name: str) -> NDF:
+def _second_order_array(policy: Any, name: str) -> NDF:
     value = getattr(policy, name, None)
     if value is None:
         raise ValueError(f"Second order simulation requires policy.{name}.")
@@ -939,14 +939,14 @@ def _simulate_order2(
     n = model.A.shape[0]
     ny = n - n_state
     policy = model.policy
-    ss = _policy_array(policy, "steady_state")
+    ss = policy.steady_state
     ss_state = ss[:n_state]
 
     if x0 is None:
         x0_state = ss_state
     else:
         x0_state = model._simulation_initial_state(x0)[:n_state]
-    x0_dev = asarray(x0_state - ss_state, dtype=float64)
+    x0_dev = x0_state - ss_state
     shock_mat = model._simulation_shock_matrix(
         T=T,
         shocks=shocks,
@@ -954,13 +954,13 @@ def _simulate_order2(
     )
 
     x_path, y_path = simulate_second_order_pruned(
-        asarray(np.real_if_close(policy.p), dtype=float64),
-        asarray(np.real_if_close(policy.f), dtype=float64),
-        asarray(model.B[:n_state, :], dtype=float64),
-        _policy_array(policy, "hxx"),
-        _policy_array(policy, "gxx"),
-        _policy_array(policy, "hss"),
-        _policy_array(policy, "gss"),
+        policy.p,
+        policy.f,
+        model.B[:n_state, :],
+        _second_order_array(policy, "hxx"),
+        _second_order_array(policy, "gxx"),
+        _second_order_array(policy, "hss"),
+        _second_order_array(policy, "gss"),
         x0_dev,
         shock_mat,
     )

--- a/SymbolicDSGE/core/solver_backend.py
+++ b/SymbolicDSGE/core/solver_backend.py
@@ -18,9 +18,10 @@ NDC = NDArray[complex128]
 class KleinSolution:
     """Solution of ``a E[y_{t+1}] = b y_t``: ``u_t = f s_t``, ``s_{t+1} = p s_t``.
 
-    ``p``/``f`` are complex (the imaginary parts are ~1e-16 roundoff from the
-    complex Schur form; the caller collapses them via ``real_if_close``). Stored
-    as ``SolvedModel.policy``; downstream reads only ``.f`` and ``.stab``.
+    ``p``/``f`` are real: the Schur form they come from is complex, but its
+    imaginary parts are roundoff on a real pencil and the native solve projects
+    them once. ``eig`` stays complex, where the imaginary part is the signal.
+    Stored as ``SolvedModel.policy``; downstream reads only ``.f`` and ``.stab``.
 
     ``steady_state`` is the Newton-resolved steady state the solve linearized at
     (the seed after convergence), so second-order and measurement callers reuse
@@ -31,8 +32,8 @@ class KleinSolution:
     way to ``p``/``f`` rather than as a separate step.
     """
 
-    p: NDC
-    f: NDC
+    p: NDF
+    f: NDF
     stab: int
     eig: NDC
     steady_state: NDF
@@ -60,8 +61,8 @@ class PerturbationSolution:
     ``steady_state`` is the (nonlinear) expansion point the tensors are taken at.
     """
 
-    p: NDC
-    f: NDC
+    p: NDF
+    f: NDF
     stab: int
     eig: NDC
     order: int

--- a/SymbolicDSGE/kalman/errors.py
+++ b/SymbolicDSGE/kalman/errors.py
@@ -4,12 +4,6 @@ import numpy as np
 from typing import Any
 
 
-class ComplexMatrixError(Exception):
-    def __init__(self, *args: Any) -> None:
-        message = f"Matrix '{args[0]}' has significant imaginary parts (max abs imag: {args[1]})."
-        super().__init__(message)
-
-
 class ShapeMismatchError(Exception):
     def __init__(self, *args: Any) -> None:
         message = f"Matrix '{args[0]}' has incompatible shape. Expected: {args[1]}, got: {args[2]}."
@@ -29,8 +23,10 @@ class MemoryAllocationError(Exception):
 
 
 class ErrorCode(IntEnum):
+    """Mirrors the KF_* codes in _ckernels/kalman/kalman.h. -1 is unassigned:
+    it was a complex-matrix rejection the kernel never raised."""
+
     SUCCESS = 0
-    COMPLEX_MATRIX = -1
     SHAPE_MISMATCH = -2
     MATRIX_CONDITION = -3
     LINALG_ERROR = -4
@@ -38,9 +34,7 @@ class ErrorCode(IntEnum):
 
 
 def get_error_constructor(code: ErrorCode) -> type[Exception]:
-    if code == ErrorCode.COMPLEX_MATRIX:
-        return ComplexMatrixError
-    elif code == ErrorCode.SHAPE_MISMATCH:
+    if code == ErrorCode.SHAPE_MISMATCH:
         return ShapeMismatchError
     elif code == ErrorCode.MATRIX_CONDITION:
         return MatrixConditionError

--- a/SymbolicDSGE/kalman/filter.py
+++ b/SymbolicDSGE/kalman/filter.py
@@ -1,7 +1,6 @@
 from .._ckernels.kalman import kalman_hot_loop, ukf_hot_loop, ekf_hot_loop
 from .errors import (
     ErrorCode,
-    ComplexMatrixError,
     ShapeMismatchError,
     get_error_constructor,
 )
@@ -10,17 +9,14 @@ from numba import njit
 import numpy as np
 from numpy import (
     float64,
-    complex128,
     eye,
     zeros,
-    real_if_close,
 )
 from numpy.typing import NDArray
 
 from typing import Tuple, NamedTuple
 
 NDF = NDArray[float64]
-NDC = NDArray[complex128]
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,16 +120,6 @@ def _unscented_filter_result_from_raw(
     )
 
 
-def _get_real(mat: NDC | NDF, name: str, tol: float = 1e8) -> NDF:
-    """
-    Convert a complex matrix to a real matrix if the imaginary parts are negligible.
-    """
-    res = real_if_close(mat, tol=tol)
-    if np.iscomplexobj(res):
-        raise ComplexMatrixError(name, np.max(np.abs(res.imag)))  # pyright: ignore
-    return res
-
-
 def _shape_validate(
     A: NDF,
     B: NDF,
@@ -168,18 +154,17 @@ def _sym(P: NDF) -> NDF:
 
 # Static & Parametrized Kalman Filter (written to act with SolvedModel object attributes)
 class KalmanFilter:
-    _get_real = staticmethod(_get_real)
     _shape_validate = staticmethod(_shape_validate)
 
     @staticmethod
     def run_raw(
-        A: NDF | NDC,
-        B: NDF | NDC,
-        C: NDF | NDC,
-        d: NDF | NDC,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
+        A: NDF,
+        B: NDF,
+        C: NDF,
+        d: NDF,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
         x0: NDF | None = None,
         P0: NDF | None = None,
         return_shocks: bool = False,
@@ -188,17 +173,6 @@ class KalmanFilter:
         _store_history: bool = True,
         _raise_on_error: bool = True,
     ) -> FilterRawResult:
-
-        # Get reals if needed
-        A = _get_real(A, "A")
-        B = _get_real(B, "B")
-        C = _get_real(C, "C")
-
-        d = _get_real(d, "d").reshape(-1)
-        Q = _get_real(Q, "Q")
-        R = _get_real(R, "R")
-
-        y = _get_real(y, "y")
 
         T, m = y.shape  # T: time steps, m: obs dim
         n = A.shape[0]  # n: state dim
@@ -214,16 +188,8 @@ class KalmanFilter:
             nmk=(n, m, k),
         )
 
-        x_prev = (
-            _get_real(x0, "x0").reshape(n)
-            if x0 is not None
-            else np.zeros((n,), dtype=float64)
-        )
-        P_prev = (
-            _get_real(P0, "P0").reshape(n, n)
-            if P0 is not None
-            else eye(n, dtype=float64) * 1e2
-        )
+        x_prev = x0.reshape(n) if x0 is not None else np.zeros((n,), dtype=float64)
+        P_prev = P0.reshape(n, n) if P0 is not None else eye(n, dtype=float64) * 1e2
 
         if symmetrize:
             P_prev = _sym(P_prev)
@@ -279,13 +245,13 @@ class KalmanFilter:
 
     @staticmethod
     def run(
-        A: NDF | NDC,
-        B: NDF | NDC,
-        C: NDF | NDC,
-        d: NDF | NDC,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
+        A: NDF,
+        B: NDF,
+        C: NDF,
+        d: NDF,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
         x0: NDF | None = None,
         P0: NDF | None = None,
         return_shocks: bool = False,
@@ -293,6 +259,7 @@ class KalmanFilter:
         jitter: float = 0.0,
         _store_history: bool = True,
     ) -> FilterResult:
+
         return _filter_result_from_raw(
             KalmanFilter.run_raw(
                 A=A,
@@ -314,20 +281,20 @@ class KalmanFilter:
     @staticmethod
     def run_unscented_raw(
         meas_addr: int,
-        hx: NDF | NDC,
-        gx: NDF | NDC,
-        bx: NDF | NDC,
-        hxx: NDF | NDC,
-        gxx: NDF | NDC,
-        hss: NDF | NDC,
-        gss: NDF | NDC,
-        steady_state: NDF | NDC,
-        calib_params: NDF | NDC,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
-        z0: NDF | NDC,
-        P0: NDF | NDC,
+        hx: NDF,
+        gx: NDF,
+        bx: NDF,
+        hxx: NDF,
+        gxx: NDF,
+        hss: NDF,
+        gss: NDF,
+        steady_state: NDF,
+        calib_params: NDF,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
+        z0: NDF,
+        P0: NDF,
         alpha: float = 1.0,
         beta: float = 2.0,
         kappa: float = 1.0,
@@ -338,22 +305,6 @@ class KalmanFilter:
     ) -> UnscentedFilterRawResult:
         if meas_addr == 0:
             raise ValueError("meas_addr must be a nonzero measurement cfunc address.")
-
-        hx = _get_real(hx, "hx")
-        bx = _get_real(bx, "bx")
-        hxx = _get_real(hxx, "hxx")
-        hss = _get_real(hss, "hss").reshape(-1)
-        steady_state = _get_real(steady_state, "steady_state").reshape(-1)
-        calib_params = _get_real(calib_params, "calib_params").reshape(-1)
-        Q_real: NDF = _get_real(Q, "Q")  # narrow for mypy
-        R_real: NDF = _get_real(R, "R")  # narrow for mypy
-        y = _get_real(y, "y")
-        z0 = _get_real(z0, "z0").reshape(-1)
-        P0_real: NDF = _get_real(P0, "P0")  # narrow for mypy
-
-        gx = _get_real(gx, "gx")
-        gxx = _get_real(gxx, "gxx")
-        gss = _get_real(gss, "gss").reshape(-1)
 
         if hx.ndim != 2 or hx.shape[0] != hx.shape[1]:
             raise ShapeMismatchError("hx", "(n_state, n_state)", str(hx.shape))
@@ -402,9 +353,9 @@ class KalmanFilter:
             raise ShapeMismatchError("P0", f"({n_z}, {n_z})", str(P0.shape))
 
         if symmetrize:
-            Q_real = _sym(Q)  # pyright: ignore
-            R_real = _sym(R)  # pyright: ignore
-            P0_real = _sym(P0)  # pyright: ignore
+            Q = _sym(Q)  # pyright: ignore
+            R = _sym(R)  # pyright: ignore
+            P0 = _sym(P0)  # pyright: ignore
 
         err, out = ukf_hot_loop(
             meas_addr,
@@ -417,11 +368,11 @@ class KalmanFilter:
             gss,
             steady_state,
             calib_params,
-            Q_real,
-            R_real,
+            Q,
+            R,
             y,
             z0,
-            P0_real,
+            P0,
             alpha,
             beta,
             kappa,
@@ -472,20 +423,20 @@ class KalmanFilter:
     @staticmethod
     def run_unscented(
         meas_addr: int,
-        hx: NDF | NDC,
-        gx: NDF | NDC,
-        bx: NDF | NDC,
-        hxx: NDF | NDC,
-        gxx: NDF | NDC,
-        hss: NDF | NDC,
-        gss: NDF | NDC,
-        steady_state: NDF | NDC,
-        calib_params: NDF | NDC,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
-        z0: NDF | NDC,
-        P0: NDF | NDC,
+        hx: NDF,
+        gx: NDF,
+        bx: NDF,
+        hxx: NDF,
+        gxx: NDF,
+        hss: NDF,
+        gss: NDF,
+        steady_state: NDF,
+        calib_params: NDF,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
+        z0: NDF,
+        P0: NDF,
         alpha: float = 1.0,
         beta: float = 2.0,
         kappa: float = 1.0,
@@ -523,12 +474,12 @@ class KalmanFilter:
     def run_extended_raw(
         meas_addr: int,
         jac_addr: int,
-        A: NDF | NDC,
-        B: NDF | NDC,
+        A: NDF,
+        B: NDF,
         calib_params: NDF,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
         x0: NDF | None = None,
         P0: NDF | None = None,
         return_shocks: bool = False,
@@ -555,10 +506,10 @@ class KalmanFilter:
             - Process noise is in "shock space": Q is (k, k), B is (n, k)
 
         :param A: State transition matrix with shape (n, n).
-        :type A: NDF | NDC
+        :type A: NDF
 
         :param B: Shock loading matrix with shape (n, k).
-        :type B: NDF | NDC
+        :type B: NDF
 
         :param h: Nonlinear measurement function. Accepts (x, t) and returns y_pred with shape (m,).
         :type h: Callable[[NDF, int], NDF]
@@ -567,13 +518,13 @@ class KalmanFilter:
         :type H_jac: Callable[[NDF, int], NDF]
 
         :param Q: Shock covariance matrix with shape (k, k).
-        :type Q: NDF | NDC
+        :type Q: NDF
 
         :param R: Measurement-noise covariance matrix with shape (m, m).
-        :type R: NDF | NDC
+        :type R: NDF
 
         :param y: Observations array with shape (T, m).
-        :type y: NDF | NDC
+        :type y: NDF
 
         :param x0: Optional initial state mean x_{0|0} with shape (n,). Defaults to zeros.
         :type x0: NDF | None
@@ -595,13 +546,6 @@ class KalmanFilter:
         :type compute_y_filt: bool
         """
 
-        # Real-ify numeric inputs
-        A = _get_real(A, "A")
-        B = _get_real(B, "B")
-        Q = _get_real(Q, "Q")
-        R = _get_real(R, "R")
-        y = _get_real(y, "y")
-
         _, m = y.shape
         n = A.shape[0]
         k = B.shape[1]
@@ -617,16 +561,8 @@ class KalmanFilter:
             nmk=(n, m, k),
         )
 
-        x0 = (
-            _get_real(x0, "x0").reshape(n)
-            if x0 is not None
-            else zeros((n,), dtype=float64)
-        )
-        P0 = (
-            _get_real(P0, "P0").reshape(n, n)
-            if P0 is not None
-            else eye(n, dtype=float64) * 1e2
-        )
+        x0 = x0.reshape(n) if x0 is not None else zeros((n,), dtype=float64)
+        P0 = P0.reshape(n, n) if P0 is not None else eye(n, dtype=float64) * 1e2
         if symmetrize:
             P0 = _sym(P0)
 
@@ -684,12 +620,12 @@ class KalmanFilter:
     def run_extended(
         meas_addr: int,
         jac_addr: int,
-        A: NDF | NDC,
-        B: NDF | NDC,
+        A: NDF,
+        B: NDF,
         calib_params: NDF,
-        Q: NDF | NDC,
-        R: NDF | NDC,
-        y: NDF | NDC,
+        Q: NDF,
+        R: NDF,
+        y: NDF,
         x0: NDF | None = None,
         P0: NDF | None = None,
         return_shocks: bool = False,

--- a/SymbolicDSGE/kalman/interface.py
+++ b/SymbolicDSGE/kalman/interface.py
@@ -631,11 +631,11 @@ class KalmanInterface(KalmanFilter):
         z0[:n_state] = x0_state
         return z0
 
-    def _policy_array(self, name: str) -> NDF:
-        value = getattr(self.model.policy, name, None)
+    def _ukf_array(self, name: str) -> NDF:
+        value: NDF | None = getattr(self.model.policy, name, None)
         if value is None:
             raise ValueError(f"Unscented filtering requires policy.{name}.")
-        return asarray(np.real_if_close(value), dtype=float64)
+        return value
 
     @cached_property
     def _obs_idx(self) -> dict[str, int]:
@@ -691,14 +691,14 @@ class KalmanInterface(KalmanFilter):
         n_state = self.model.compiled.n_state
         return {
             "meas_addr": self.meas_addr,
-            "hx": self._policy_array("p"),
-            "gx": self._policy_array("f"),
-            "bx": asarray(self.B[:n_state, :], dtype=float64),
-            "hxx": self._policy_array("hxx"),
-            "gxx": self._policy_array("gxx"),
-            "hss": self._policy_array("hss"),
-            "gss": self._policy_array("gss"),
-            "steady_state": self._policy_array("steady_state"),
+            "hx": self.model.policy.p,
+            "gx": self.model.policy.f,
+            "bx": self.B[:n_state, :],
+            "hxx": self._ukf_array("hxx"),
+            "gxx": self._ukf_array("gxx"),
+            "hss": self._ukf_array("hss"),
+            "gss": self._ukf_array("gss"),
+            "steady_state": self.model.policy.steady_state,
             "calib_params": self.calib_params,
             "Q": self.Q,
             "R": self.R,

--- a/SymbolicDSGE/kalman/validator.py
+++ b/SymbolicDSGE/kalman/validator.py
@@ -105,9 +105,18 @@ def validate_kf_inputs(
         ("Q", Q, 2),
         ("R", R, 2),
         ("y", y, 2),
+        ("x0", x0, 1),
+        ("P0", P0, 2),
     ]:
+        if M is None:
+            continue
+
         if not isinstance(M, np.ndarray):
             raise TypeError(f"{name} must be a numpy ndarray, got {type(M).__name__}.")
+
+        if M.dtype != np.float64:
+            raise TypeError(f"{name} must be float64, got {M.dtype}.")
+
         if M.ndim != nd:
             raise ValueError(f"{name} must be {nd}D, got shape {M.shape}.")
 
@@ -131,11 +140,15 @@ def validate_kf_inputs(
 
         if not isinstance(C, np.ndarray):
             raise TypeError(f"C must be a numpy ndarray, got {type(C).__name__}.")
+        if C.dtype != np.float64:
+            raise TypeError(f"C must be float64, got {C.dtype}.")
         if C.ndim != 2:
             raise ValueError(f"C must be 2D, got shape {C.shape}.")
 
         if not isinstance(d, np.ndarray):
             raise TypeError(f"d must be a numpy ndarray, got {type(d).__name__}.")
+        if d.dtype != np.float64:
+            raise TypeError(f"d must be float64, got {d.dtype}.")
         if d.ndim not in (1, 2):
             raise ValueError(f"d must be 1D or 2D, got shape {d.shape}.")
 
@@ -322,6 +335,8 @@ def validate_ukf_inputs(
             continue
         if not isinstance(M, np.ndarray):
             raise TypeError(f"{name} must be a numpy ndarray, got {type(M).__name__}.")
+        if M.dtype != np.float64:
+            raise TypeError(f"{name} must be float64, got {M.dtype}.")
         if M.ndim != 2 or M.shape[0] != M.shape[1]:
             raise ValueError(f"{name} must be a square 2D matrix. Got shape {M.shape}.")
         if not np.isfinite(M).all():

--- a/SymbolicDSGE/monte_carlo/native_lowering/diagnostics.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/diagnostics.py
@@ -20,7 +20,6 @@ from ..mc_constructs import MCStep
 from .utils import (
     NDF,
     FloatInputBinding,
-    _array_f64,
     _selected_shape,
     _source_binding,
 )
@@ -141,7 +140,7 @@ def _lower_wald_step(
 
 
 def _wald_target(value: object, q: int, kind: int) -> NDF:
-    target = _array_f64(np.asarray(value, dtype=np.float64))
+    target = np.asarray(value, dtype=np.float64)
     if kind == 0:
         if target.ndim != 1 or target.shape[0] != q:
             raise ValueError("Wald mean target must have one value per source column.")

--- a/SymbolicDSGE/monte_carlo/native_lowering/filters.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/filters.py
@@ -23,7 +23,7 @@ from .utils import (
     NDF,
     NDI,
     FloatInputBinding,
-    _f64,
+    _flat_f64,
     _model_params,
     _static_binding,
 )
@@ -87,12 +87,12 @@ def lower_filter_step(
         C, d = interface._get_C_d()
         x0 = _filter_x0(step.kwargs["x0"], n_var)
         before_y = (
-            _f64(interface.A),
-            _f64(interface.B),
-            _f64(C),
-            _f64(d),
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.A),
+            _flat_f64(interface.B),
+            _flat_f64(C),
+            _flat_f64(d),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -114,11 +114,11 @@ def lower_filter_step(
         x0 = _filter_x0(step.kwargs["x0"], n_var)
         params = _model_params(reference)
         before_y = (
-            _f64(interface.A),
-            _f64(interface.B),
+            _flat_f64(interface.A),
+            _flat_f64(interface.B),
             params,
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -153,17 +153,17 @@ def lower_filter_step(
         params = _model_params(reference)
         z0 = interface._build_unscented_z0(step.kwargs["x0"])
         before_y = (
-            _f64(policy.p),
-            _f64(policy.f),
-            _f64(reference.B[:n_state, :]),
-            _f64(policy.hxx),
-            _f64(policy.gxx),
-            _f64(policy.hss),
-            _f64(policy.gss),
-            _f64(policy.steady_state),
+            _flat_f64(policy.p),
+            _flat_f64(policy.f),
+            _flat_f64(reference.B[:n_state, :]),
+            _flat_f64(policy.hxx),
+            _flat_f64(policy.gxx),
+            _flat_f64(policy.hss),
+            _flat_f64(policy.gss),
+            _flat_f64(policy.steady_state),
             params,
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -236,7 +236,7 @@ def _filter_source_columns(
 def _filter_x0(value: ArrayLike | None, n_var: int) -> NDF:
     if value is None:
         return np.zeros(n_var, dtype=np.float64)
-    x0 = _f64(np.asarray(value, dtype=np.float64))
+    x0 = _flat_f64(np.asarray(value, dtype=np.float64))
     if x0.size != n_var:
         raise ValueError(f"Filter x0 must have length {n_var}.")
     return x0
@@ -272,7 +272,7 @@ def _filter_bindings(
     bindings: list[FloatInputBinding] = []
     offset = 0
     for values in before_y:
-        flattened = _f64(values)
+        flattened = _flat_f64(values)
         if flattened.size:
             bindings.append(_static_binding(flattened, offset))
         offset += flattened.size
@@ -281,7 +281,7 @@ def _filter_bindings(
     bindings.append(y_binding)
     offset += y_binding.n_rows * y_binding.target_row_stride
     for values in after_y:
-        flattened = _f64(values)
+        flattened = _flat_f64(values)
         if flattened.size:
             bindings.append(_static_binding(flattened, offset))
         offset += flattened.size

--- a/SymbolicDSGE/monte_carlo/native_lowering/simulation.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/simulation.py
@@ -18,7 +18,7 @@ from ..shock_native import build_native_plan, validate_shock_specs
 from .utils import (
     NDF,
     FloatInputBinding,
-    _f64,
+    _flat_f64,
     _model_params,
     _static_binding,
 )
@@ -86,7 +86,7 @@ def lower_simulation_step(
             n_obs,
             drawn,
         )
-        steady_state = _f64(model.policy.steady_state)
+        steady_state = _flat_f64(model.policy.steady_state)
         initial_state = model._simulation_initial_state(step.kwargs["x0"])
         x0_deviation = initial_state[:n_state] - steady_state[:n_state]
         return native_step, _order2_bindings(
@@ -112,7 +112,7 @@ def _order1_bindings(
     n_exog = model.compiled.n_exog
     bindings: list[FloatInputBinding] = []
     offset = 0
-    for values in (_f64(model.A), _f64(model.B), _f64(x0)):
+    for values in (_flat_f64(model.A), _flat_f64(model.B), _flat_f64(x0)):
         if values.size:
             bindings.append(_static_binding(values, offset))
         offset += values.size
@@ -138,15 +138,15 @@ def _order2_bindings(
         raise ValueError("Native simulation order 2 requires a perturbation solution.")
     n_exog = model.compiled.n_exog
     values_by_layout = (
-        _f64(policy.p),
-        _f64(policy.f),
-        _f64(model.B[: model.compiled.n_state, :]),
-        _f64(policy.hxx),
-        _f64(policy.gxx),
-        _f64(policy.hss),
-        _f64(policy.gss),
-        _f64(steady_state),
-        _f64(x0_deviation),
+        _flat_f64(policy.p),
+        _flat_f64(policy.f),
+        _flat_f64(model.B[: model.compiled.n_state, :]),
+        _flat_f64(policy.hxx),
+        _flat_f64(policy.gxx),
+        _flat_f64(policy.hss),
+        _flat_f64(policy.gss),
+        _flat_f64(steady_state),
+        _flat_f64(x0_deviation),
     )
     bindings: list[FloatInputBinding] = []
     offset = 0

--- a/SymbolicDSGE/monte_carlo/native_lowering/utils.py
+++ b/SymbolicDSGE/monte_carlo/native_lowering/utils.py
@@ -21,7 +21,6 @@ _FILL_COLUMNS = np.zeros(1, dtype=np.int64)
 _STATIC_SOURCE_STEP = -2
 
 NDF = NDArray[np.float64]
-NDC = NDArray[np.complex128]
 NDI = NDArray[np.int64]
 
 
@@ -67,17 +66,13 @@ class RegressionResultSpec:
 
 def _model_params(model: SolvedModel) -> NDF:
     parameters = model.config.calibration.parameters
-    return _f64(
+    return _flat_f64(
         np.asarray([parameters[param] for param in model.compiled.calib_params])
     )
 
 
-def _f64(values: NDF | NDC) -> NDF:
-    return _array_f64(values).reshape(-1)
-
-
-def _array_f64(values: NDF | NDC) -> NDF:
-    return np.ascontiguousarray(np.real_if_close(values), dtype=np.float64)
+def _flat_f64(values: NDF) -> NDF:
+    return values.reshape(-1)
 
 
 def _selected_shape(

--- a/SymbolicDSGE/utils/dhm.py
+++ b/SymbolicDSGE/utils/dhm.py
@@ -781,7 +781,7 @@ class DenHaanMarcet:
                 )
 
         n_state = self.solved.compiled.n_state
-        state0[n_state:] = state0[:n_state] @ np.real_if_close(self.solved.policy.f.T)
+        state0[n_state:] = state0[:n_state] @ self.solved.policy.f.T
         return np.ascontiguousarray(state0, dtype=np.float64)
 
     def _prepare_shock_matrix(

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -108,7 +108,7 @@ Eigenvalues:  [0.28018451+0.j 0.83      +0.j 0.85      +0.j 2.60451546+0.j
  1.18546572+0.j] (1)
 ```
 </div>
-1. Complex numbers are an artifact of the ordered Schur solve. All relevant matrices are cast to reals with `#!python np.real_if_close`
+1. Eigenvalues stay complex because the ordered Schur solve makes the imaginary part meaningful here. The policy matrices are not: `#!python sol.policy.p` and `#!python sol.policy.f` are real, projected once inside the solve.
 
 ## Inspecting Model Dynamics
 
@@ -254,9 +254,9 @@ plt.tight_layout()
 
 This guide covers the basic capabilities and usage of `SymbolicDSGE`. Further tools include:
 
-- `SymbolicDSGE.FRED` for easy U.S. macro data retrieval
-- `SymbolicDSGE.math_utils` for basic detrending, HP filters, etc.
-- `SymbolicDSGE.KalmanFilter` for a one-sided Kalman Filter implementation. (standalone as of now but easy model integration interface will be developed)
+- `SymbolicDSGE.utils.FRED` for easy U.S. macro data retrieval
+- `SymbolicDSGE.utils.math_utils` for basic detrending, HP filters, etc.
+- `SymbolicDSGE.kalman` (integrated with `SolvedModel` via `SolvedModel.kalman`) for state estimation and filtering through KF, EKF, and UKF methods.
 
 If you've read to this point and would like to inspect/interact with the code this guide refers to, you can visit [this](../assets/guide_notebook.ipynb) link to the file.
 

--- a/tests/_oracles/monte_carlo/native_lowering/core.py
+++ b/tests/_oracles/monte_carlo/native_lowering/core.py
@@ -27,7 +27,6 @@ _FILL_COLUMNS = np.zeros(1, dtype=np.int64)
 _STATIC_SOURCE_STEP = -2
 
 NDF = NDArray[np.float64]
-NDC = NDArray[np.complex128]
 NDI = NDArray[np.int64]
 
 
@@ -171,17 +170,13 @@ def _lower_step(
 
 def _model_params(model: SolvedModel) -> NDF:
     parameters = model.config.calibration.parameters
-    return _f64(
+    return _flat_f64(
         np.asarray([parameters[param] for param in model.compiled.calib_params])
     )
 
 
-def _f64(values: NDF | NDC) -> NDF:
-    return _array_f64(values).reshape(-1)
-
-
-def _array_f64(values: NDF | NDC) -> NDF:
-    return np.ascontiguousarray(np.real_if_close(values), dtype=np.float64)
+def _flat_f64(values: NDF) -> NDF:
+    return values.reshape(-1)
 
 
 def _selected_shape(

--- a/tests/_oracles/monte_carlo/native_lowering/diagnostics.py
+++ b/tests/_oracles/monte_carlo/native_lowering/diagnostics.py
@@ -20,7 +20,6 @@ from ..mc_constructs import MCStep
 from .core import (
     NDF,
     FloatInputBinding,
-    _array_f64,
     _selected_shape,
     _source_binding,
 )
@@ -152,7 +151,7 @@ def _lower_wald_step(
 
 
 def _wald_target(value: object, q: int, kind: int) -> NDF:
-    target = _array_f64(np.asarray(value, dtype=np.float64))
+    target = np.asarray(value, dtype=np.float64)
     if kind == 0:
         if target.ndim != 1 or target.shape[0] != q:
             raise ValueError("Wald mean target must have one value per source column.")

--- a/tests/_oracles/monte_carlo/native_lowering/filters.py
+++ b/tests/_oracles/monte_carlo/native_lowering/filters.py
@@ -21,7 +21,7 @@ from .core import (
     NDF,
     NDI,
     FloatInputBinding,
-    _f64,
+    _flat_f64,
     _model_params,
     _static_binding,
 )
@@ -85,12 +85,12 @@ def lower_filter_step(
         C, d = interface._get_C_d()
         x0 = _filter_x0(step.kwargs["x0"], n_var)
         before_y = (
-            _f64(interface.A),
-            _f64(interface.B),
-            _f64(C),
-            _f64(d),
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.A),
+            _flat_f64(interface.B),
+            _flat_f64(C),
+            _flat_f64(d),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -112,11 +112,11 @@ def lower_filter_step(
         x0 = _filter_x0(step.kwargs["x0"], n_var)
         params = _model_params(reference)
         before_y = (
-            _f64(interface.A),
-            _f64(interface.B),
+            _flat_f64(interface.A),
+            _flat_f64(interface.B),
             params,
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -150,17 +150,17 @@ def lower_filter_step(
         params = _model_params(reference)
         z0 = interface._build_unscented_z0(step.kwargs["x0"])
         before_y = (
-            _f64(policy.p),
-            _f64(policy.f),
-            _f64(reference.B[:n_state, :]),
-            _f64(policy.hxx),
-            _f64(policy.gxx),
-            _f64(policy.hss),
-            _f64(policy.gss),
-            _f64(policy.steady_state),
+            _flat_f64(policy.p),
+            _flat_f64(policy.f),
+            _flat_f64(reference.B[:n_state, :]),
+            _flat_f64(policy.hxx),
+            _flat_f64(policy.gxx),
+            _flat_f64(policy.hss),
+            _flat_f64(policy.gss),
+            _flat_f64(policy.steady_state),
             params,
-            _f64(interface.Q),
-            _f64(interface.R),
+            _flat_f64(interface.Q),
+            _flat_f64(interface.R),
         )
         binding = _filter_y_binding(
             source_layout, T, source_columns, sum(v.size for v in before_y), n_obs
@@ -236,7 +236,7 @@ def _filter_source_columns(
 def _filter_x0(value: ArrayLike | None, n_var: int) -> NDF:
     if value is None:
         return np.zeros(n_var, dtype=np.float64)
-    x0 = _f64(np.asarray(value, dtype=np.float64))
+    x0 = _flat_f64(np.asarray(value, dtype=np.float64))
     if x0.size != n_var:
         raise ValueError(f"Filter x0 must have length {n_var}.")
     return x0
@@ -272,7 +272,7 @@ def _filter_bindings(
     bindings: list[FloatInputBinding] = []
     offset = 0
     for values in before_y:
-        flattened = _f64(values)
+        flattened = _flat_f64(values)
         if flattened.size:
             bindings.append(_static_binding(flattened, offset))
         offset += flattened.size
@@ -281,7 +281,7 @@ def _filter_bindings(
     bindings.append(y_binding)
     offset += y_binding.n_rows * y_binding.target_row_stride
     for values in after_y:
-        flattened = _f64(values)
+        flattened = _flat_f64(values)
         if flattened.size:
             bindings.append(_static_binding(flattened, offset))
         offset += flattened.size

--- a/tests/_oracles/monte_carlo/native_lowering/simulation.py
+++ b/tests/_oracles/monte_carlo/native_lowering/simulation.py
@@ -18,7 +18,7 @@ from ..operations.utils import _clone_or_pass_shocks
 from .core import (
     NDF,
     FloatInputBinding,
-    _f64,
+    _flat_f64,
     _model_params,
     _static_binding,
 )
@@ -78,7 +78,7 @@ def lower_simulation_step(
             n_par,
             n_obs,
         )
-        steady_state = _f64(model.policy.steady_state)
+        steady_state = _flat_f64(model.policy.steady_state)
         initial_state = model._simulation_initial_state(step.kwargs["x0"])
         x0_deviation = initial_state[:n_state] - steady_state[:n_state]
         return native_step, _order2_bindings(
@@ -103,7 +103,7 @@ def _order1_bindings(
     T = shocks.shape[-2]
     bindings: list[FloatInputBinding] = []
     offset = 0
-    for values in (_f64(model.A), _f64(model.B), _f64(x0)):
+    for values in (_flat_f64(model.A), _flat_f64(model.B), _flat_f64(x0)):
         if values.size:
             bindings.append(_static_binding(values, offset))
         offset += values.size
@@ -129,15 +129,15 @@ def _order2_bindings(
     n_exog = model.compiled.n_exog
     T = shocks.shape[-2]
     values_by_layout = (
-        _f64(policy.p),
-        _f64(policy.f),
-        _f64(model.B[: model.compiled.n_state, :]),
-        _f64(policy.hxx),
-        _f64(policy.gxx),
-        _f64(policy.hss),
-        _f64(policy.gss),
-        _f64(steady_state),
-        _f64(x0_deviation),
+        _flat_f64(policy.p),
+        _flat_f64(policy.f),
+        _flat_f64(model.B[: model.compiled.n_state, :]),
+        _flat_f64(policy.hxx),
+        _flat_f64(policy.gxx),
+        _flat_f64(policy.hss),
+        _flat_f64(policy.gss),
+        _flat_f64(steady_state),
+        _flat_f64(x0_deviation),
     )
     bindings: list[FloatInputBinding] = []
     offset = 0

--- a/tests/ckernels/test_klein_solve1.py
+++ b/tests/ckernels/test_klein_solve1.py
@@ -57,7 +57,9 @@ def _staged(compiled, par, seed):
     A, B = assemble_state_space(
         p, f, compiled.n_state, n_eq - compiled.n_state, compiled.n_exog
     )
-    return ss, a, b, f, p, stab, eig, A, B
+    # The solve reports f/p real but assembles A/B from the complex pair, whose
+    # cross term Re(f)Re(p) would drop. Project after assembling, as it does.
+    return ss, a, b, np.real(f), np.real(p), stab, eig, A, B
 
 
 def _assert_same(got, want):
@@ -109,6 +111,26 @@ def test_python_wrapper_carries_the_native_outputs(path):
         sol.B,
     )
     _assert_same(got, _staged(compiled, par, seed))
+
+
+@pytest.mark.parametrize("path", MODELS)
+def test_policy_is_real(path):
+    """``f``/``p`` leave the solve projected, so no caller collapses them again."""
+    from SymbolicDSGE.core.solver_backend import klein_solve
+
+    compiled, par, seed = _model(path)
+    cfunc = compiled.construct_objective_cfunc()
+
+    _, _, _, f, p, _, _, _, _ = klein_solve1(
+        cfunc.address, seed, par, compiled.n_state, compiled.n_exog
+    )
+    assert f.dtype == np.float64
+    assert p.dtype == np.float64
+
+    sol = klein_solve(cfunc, par, seed, compiled.n_state, n_exog=compiled.n_exog)
+    assert sol.f.dtype == np.float64
+    assert sol.p.dtype == np.float64
+    assert sol.eig.dtype == np.complex128
 
 
 def test_reports_stab_instead_of_raising():

--- a/tests/ckernels/test_klein_solve2.py
+++ b/tests/ckernels/test_klein_solve2.py
@@ -54,7 +54,7 @@ def _staged(compiled, par, seed, eta):
     ss, a, b, f, p, stab, eig, A, B = klein_solve1(
         addr, seed, par, n_state, compiled.n_exog
     )
-    gx, hx = np.real(f), np.real(p)
+    gx, hx = f, p  # klein_solve1 already projects
     f_xx = bicomplex_hessian(bc_addr, ss, par, n_eq)
     gxx, hxx = second_order(a, b, f_xx, gx, hx, n_state)
     gss, hss = second_order_risk(a, b, f_xx, gx, gxx, eta, n_state)

--- a/tests/core/test_second_order_rbc.py
+++ b/tests/core/test_second_order_rbc.py
@@ -130,7 +130,7 @@ def test_rbc_second_order_matches_dynare():
     a, b = klein_preprocess(cf.address, ss, par, n_eq)
     sol = klein_solve(cf, par, ss, n_state)
     assert sol.stab == 0
-    gx, hx = np.real(sol.f), np.real(sol.p)
+    gx, hx = sol.f, sol.p
     f_xx = bicomplex_hessian(cf_bc.address, ss, par, n_eq)
     gxx, hxx = second_order(a, b, f_xx, gx, hx, n_state)
 

--- a/tests/kalman/test_filter.py
+++ b/tests/kalman/test_filter.py
@@ -9,7 +9,6 @@ from sympy import Symbol
 
 from SymbolicDSGE.kalman.config import make_R
 from SymbolicDSGE.kalman.errors import (
-    ComplexMatrixError,
     ErrorCode,
     MatrixConditionError,
     ShapeMismatchError,
@@ -104,27 +103,12 @@ def test_make_r_builds_covariance_from_std_and_corr_maps():
 
 
 def test_error_code_dispatch_maps_known_errors_and_rejects_unknown():
-    assert get_error_constructor(ErrorCode.COMPLEX_MATRIX) is ComplexMatrixError
     assert get_error_constructor(ErrorCode.SHAPE_MISMATCH) is ShapeMismatchError
     assert get_error_constructor(ErrorCode.MATRIX_CONDITION) is MatrixConditionError
     assert get_error_constructor(ErrorCode.LINALG_ERROR) is np.linalg.LinAlgError
 
     with pytest.raises(ValueError, match="Unknown error code"):
         get_error_constructor(ErrorCode.SUCCESS)
-
-
-def test_get_real_accepts_nearly_real_complex():
-    mat = np.array([[1.0 + 1e-14j, 2.0 - 1e-14j]], dtype=np.complex128)
-    out = KalmanFilter._get_real(mat, "M")
-
-    assert out.dtype == float64
-    assert np.allclose(out, np.array([[1.0, 2.0]], dtype=float64))
-
-
-def test_get_real_rejects_significant_imaginary_parts():
-    mat = np.array([[1.0 + 0.5j]], dtype=np.complex128)
-    with pytest.raises(ComplexMatrixError):
-        KalmanFilter._get_real(mat, "bad")
 
 
 def test_shape_validate_raises_on_bad_A_shape():
@@ -238,20 +222,11 @@ def test_run_linear_can_skip_history_storage_for_loglik_only_path():
     assert minimal.eps_hat is None
 
 
-def test_run_linear_return_shocks_and_complex_inputs():
+def test_run_linear_return_shocks():
     A, B, C, d, Q, R = _linear_system_1d()
     y = np.zeros((4, 1), dtype=float64)
 
-    out = KalmanFilter.run(
-        A.astype(np.complex128),
-        B.astype(np.complex128),
-        C.astype(np.complex128),
-        d.astype(np.complex128),
-        Q.astype(np.complex128),
-        R.astype(np.complex128),
-        y.astype(np.complex128),
-        return_shocks=True,
-    )
+    out = KalmanFilter.run(A, B, C, d, Q, R, y, return_shocks=True)
 
     assert out.eps_hat is not None
     assert out.eps_hat.shape == (4, 1)


### PR DESCRIPTION
Project Klein solve policy matrices `f` and `p` to real values at the native boundary and thread those real buffers through second-order, simulation, and Kalman paths. Remove the unused complex-matrix rejection path and update docs/tests to match the new real-valued policy contract.