### PR TITLE
Add native OccBin recursion and solve kernel APIs with tests

### DIFF
--- a/SymbolicDSGE/_ckernels/_common/sdsge_common.h
+++ b/SymbolicDSGE/_ckernels/_common/sdsge_common.h
@@ -46,6 +46,25 @@ static inline arena_size make_sizer(i64 n_float, i64 n_int) {
   return (arena_size){.n_float = n_float, .n_int = n_int};
 }
 
+/* Flat buffer `any(x[i] == 0)` and `any(x[i] != 0)` checks. Returns 1 if the
+ * respective condition is satisfied for any element, 0 otherwise. */
+static inline i8 sdsge_any_zero(const f64 *x, i64 n) {
+  for (i64 i = 0; i < n; ++i) {
+    if (x[i] == 0.0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static inline i8 sdsge_any_nonzero(const f64 *x, i64 n) {
+  for (i64 i = 0; i < n; ++i) {
+    if (x[i] != 0.0) {
+      return 1;
+    }
+  }
+  return 0;
+}
 /* Portable `restrict`. */
 #if defined(__GNUC__) || defined(__clang__)
 #define SDSGE_RESTRICT __restrict__

--- a/SymbolicDSGE/_ckernels/occbin/__init__.py
+++ b/SymbolicDSGE/_ckernels/occbin/__init__.py
@@ -8,6 +8,7 @@ from ._occbin import (
     MAX_CONSTRAINTS,
     constraint_path,
     occbin_recursion,
+    occbin_recursion_arena_size,
     regime_pencil,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "MAX_CONSTRAINTS",
     "constraint_path",
     "occbin_recursion",
+    "occbin_recursion_arena_size",
     "regime_pencil",
 ]

--- a/SymbolicDSGE/_ckernels/occbin/__init__.py
+++ b/SymbolicDSGE/_ckernels/occbin/__init__.py
@@ -7,15 +7,21 @@ built, importing this module (and the library) raises ``ImportError``.
 from ._occbin import (
     MAX_CONSTRAINTS,
     constraint_path,
+    occbin_forward,
     occbin_recursion,
     occbin_recursion_arena_size,
+    occbin_solve,
+    occbin_solve_arena_size,
     regime_pencil,
 )
 
 __all__ = [
     "MAX_CONSTRAINTS",
     "constraint_path",
+    "occbin_forward",
     "occbin_recursion",
     "occbin_recursion_arena_size",
+    "occbin_solve",
+    "occbin_solve_arena_size",
     "regime_pencil",
 ]

--- a/SymbolicDSGE/_ckernels/occbin/__init__.py
+++ b/SymbolicDSGE/_ckernels/occbin/__init__.py
@@ -1,13 +1,19 @@
-"""Native OccBin kernels: the regime latch over a path, and per-regime pencils.
+"""Native OccBin kernels: the regime latch, per-regime pencils, and the solve.
 
 Re-exports the compiled ``_occbin`` extension, which is mandatory: if it is not
 built, importing this module (and the library) raises ``ImportError``.
 """
 
-from ._occbin import MAX_CONSTRAINTS, constraint_path, regime_pencil
+from ._occbin import (
+    MAX_CONSTRAINTS,
+    constraint_path,
+    occbin_recursion,
+    regime_pencil,
+)
 
 __all__ = [
     "MAX_CONSTRAINTS",
     "constraint_path",
+    "occbin_recursion",
     "regime_pencil",
 ]

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -70,3 +70,55 @@ def occbin_recursion(
     first, with the constant in the last column. ``f_ref`` is ``(n_ctrl,
     n_state)`` and closes the recursion past the last date.
     """
+
+def occbin_forward(rule: _F64, x0: _F64, out: _F64 | None = ...) -> _F64:
+    """(T, n_var) path in deviations <- a rule stack and an initial state.
+
+    Row ``t`` is ``[x_t; u_t]``, the state half from date ``t - 1``'s block and
+    the control half from date ``t``'s.
+    """
+
+def occbin_solve_arena_size(
+    n_var: int,
+    n_state: int,
+    n_ctrl: int,
+    T_cap: int,
+    max_iter: int,
+) -> tuple[int, int]:
+    """(n_float, n_int) scratch ``occbin_solve`` needs for a shape."""
+
+def occbin_solve(
+    a: _F64,
+    b: _F64,
+    c: _F64,
+    f_ref: _F64,
+    ss: _F64,
+    par: _F64,
+    cond_addr: int,
+    n_constraint: int,
+    inclusive: int,
+    shocks: _F64,
+    x_init: _F64,
+    *,
+    T0: int,
+    T_cap: int = ...,
+    n_periods: int | None = ...,
+    max_iter: int = ...,
+    init_regime: _I8 | None = ...,
+    periodic_solution: bool = ...,
+    periodic_threshold: int = ...,
+    periodic_strict: bool = ...,
+    curb_retrench: bool = ...,
+    reset_regime: bool = ...,
+    reset_check_ahead: bool = ...,
+    algo_truncation: int = ...,
+) -> tuple[_F64, _I8, dict[str, _F64 | _I8 | _I64]]:
+    """(out, regimes, diag) <- pencils, a constraint and a shock sequence.
+
+    ``out`` is the ``(n_periods, n_var)`` piecewise path in deviations,
+    ``regimes`` the ``(S, T_cap)`` accepted guess per shock period, and ``diag``
+    holds ``T_used``, ``iters``, ``max_err`` and ``periodic``, one entry per
+    period. The pencil stack must cover every mask over ``n_constraint``
+    constraints. The keywords past ``max_iter`` are Dynare's ``occbin.simul``
+    options at their own defaults.
+    """

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -43,3 +43,18 @@ def regime_pencil(
     ``pencil_addr`` of 0 is the reference regime: the copy alone, ``c`` zero.
     ``c`` is ``(n_var,)`` and zero off ``rows``.
     """
+
+def occbin_recursion(
+    a: _F64,
+    b: _F64,
+    c: _F64,
+    mask: _I8,
+    f_ref: _F64,
+    out: _F64 | None = ...,
+) -> _F64:
+    """(T, n_var, n_state + 1) rules <- pencils stacked by bitmask and a guess.
+
+    Block ``t`` is the affine map from ``x_t`` to ``[x_{t+1}; u_t]``, state rows
+    first, with the constant in the last column. ``f_ref`` is ``(n_ctrl,
+    n_state)`` and closes the recursion past the last date.
+    """

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -22,12 +22,15 @@ def constraint_path(
     par: _F64,
     regime_in: _I8,
     n_constraint: int,
+    inclusive: int,
     out: _I8 | None = ...,
-) -> tuple[_I8, int]:
-    """(regime_out, changed) <- latched regime mask over a (T, n_var) level path.
+) -> tuple[_I8, int, float]:
+    """(regime_out, changed, max_err) <- latched mask over a (T, n_var) path.
 
     ``out`` may alias ``regime_in`` to latch in place; ``changed`` counts the
-    periods whose mask moved.
+    periods whose mask moved and ``max_err`` is the largest distance that moved
+    one. ``inclusive`` is ``ConstraintFunc.inclusive``, which decides a distance
+    of exactly zero.
     """
 
 def regime_pencil(

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyi
@@ -44,6 +44,13 @@ def regime_pencil(
     ``c`` is ``(n_var,)`` and zero off ``rows``.
     """
 
+def occbin_recursion_arena_size(
+    n_var: int,
+    n_state: int,
+    n_ctrl: int,
+) -> tuple[int, int]:
+    """(n_float, n_int) scratch ``occbin_recursion`` needs for a shape."""
+
 def occbin_recursion(
     a: _F64,
     b: _F64,
@@ -51,6 +58,8 @@ def occbin_recursion(
     mask: _I8,
     f_ref: _F64,
     out: _F64 | None = ...,
+    arena: _F64 | None = ...,
+    iarena: _I64 | None = ...,
 ) -> _F64:
     """(T, n_var, n_state + 1) rules <- pencils stacked by bitmask and a guess.
 

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -17,15 +17,7 @@ cdef extern from "../_common/sdsge_common.h" nogil:
         int64_t n_int
 
 
-cdef extern from "occbin.h" nogil:
-    ctypedef void (*sdsge_constraint_fn)(
-        double *cur, double *par, int8_t *flags) noexcept
-    int64_t sdsge_constraint_path(
-        sdsge_constraint_fn cond, double *path, double *par,
-        const int8_t *regime_in, int8_t *regime_out,
-        int64_t T, int64_t n_var, int64_t n_constraint)
-
-
+# regime_pencil.h first: occbin.h includes it and occbin_ctx holds a regime_ctx.
 cdef extern from "regime_pencil.h" nogil:
     ctypedef void (*sdsge_regime_pencil_fn)(
         const double *cur, const double *par, double *out) noexcept
@@ -43,9 +35,31 @@ cdef extern from "regime_pencil.h" nogil:
         int64_t n_var, double *arena)
 
 
+cdef extern from "occbin.h" nogil:
+    ctypedef void (*sdsge_constraint_fn)(
+        double *cur, double *par, int8_t *flags) noexcept
+    int64_t sdsge_constraint_path(
+        sdsge_constraint_fn cond, double *path, double *par,
+        const int8_t *regime_in, int8_t *regime_out,
+        int64_t T, int64_t n_var, int64_t n_constraint)
+    ctypedef struct occbin_ctx:
+        const regime_ctx *table
+        const double *f_ref
+        int64_t n_var
+        int64_t n_state
+        int64_t n_ctrl
+    arena_size sdsge_occbin_recursion_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl)
+    int64_t sdsge_occbin_recursion(
+        const occbin_ctx *ctx, const int8_t *mask, int64_t T, double *out,
+        int64_t *singular_date, double *arena, int64_t *iarena)
+    int64_t SDSGE_OCCBIN_RECURSION_OK
+
+
 #: Constraints the native flag buffer is sized for (``i8 flags[4]`` in occbin.c,
 #: two slots per constraint). Mirrors the OccBin cap in model_parser.
 MAX_CONSTRAINTS = 2
+MAX_REGIME = 4
 
 
 def constraint_path(size_t cond_addr, path, par, regime_in,
@@ -177,3 +191,117 @@ def regime_pencil(size_t pencil_addr, rows, ss, par, a_ref, b_ref):
             &ctx, ss_ptr, par_ptr, a_ptr, b_ptr, n_var, arena_ptr
         )
     return a, b, c
+
+
+def occbin_recursion(a, b, c, mask, f_ref, out=None):
+    """Piecewise-linear decision rules ``(T, n_var, n_state + 1)`` for a guess.
+
+    ``a``, ``b`` and ``c`` are the regime pencils stacked by bitmask, shaped
+    ``(n_regime, n_var, n_var)``, ``(n_regime, n_var, n_var)`` and
+    ``(n_regime, n_var)``. Slot ``m`` is what ``regime_pencil`` returns for mask
+    ``m`` and slot 0 is the reference, so ``mask`` indexes the stack directly.
+
+    ``f_ref`` is the reference control rule ``(n_ctrl, n_state)``, which closes
+    the recursion past the last date, and fixes ``n_state`` and ``n_ctrl``.
+
+    ``out`` is an optional C-contiguous ``(T, n_var, n_state + 1)`` float64
+    buffer written in place. At date ``t`` the block is the affine map from
+    ``x_t`` to ``[x_{t+1}; u_t]``: ``out[t, :, :n_state] @ x_t + out[t, :,
+    n_state]``, state rows first. Raises ``RuntimeError`` naming the date if a
+    date's pencil is singular.
+    """
+    cdef double[:, :, ::1] av = np.ascontiguousarray(a, dtype=np.float64)
+    cdef double[:, :, ::1] bv = np.ascontiguousarray(b, dtype=np.float64)
+    cdef double[:, ::1] cv = np.ascontiguousarray(c, dtype=np.float64)
+    cdef double[:, ::1] fv = np.ascontiguousarray(f_ref, dtype=np.float64)
+    cdef const int8_t[::1] mv = np.ascontiguousarray(mask, dtype=np.int8)
+
+    cdef int64_t n_regime = av.shape[0]
+    cdef int64_t n_var = av.shape[1]
+    cdef int64_t n_ctrl = fv.shape[0]
+    cdef int64_t n_state = fv.shape[1]
+    cdef int64_t T = mv.shape[0]
+    cdef int64_t n_rhs = n_state + 1
+    cdef int64_t i
+
+    if n_regime < 1:
+        raise ValueError("a must hold at least the reference regime.")
+    if n_regime > MAX_REGIME:
+        raise ValueError(f"a holds {n_regime} regimes, at most {MAX_REGIME}.")
+    if av.shape[2] != n_var:
+        raise ValueError(
+            f"a[0] is {av.shape[1]}x{av.shape[2]}, expected square."
+        )
+    if bv.shape[0] != n_regime or bv.shape[1] != n_var or bv.shape[2] != n_var:
+        raise ValueError(
+            f"b is {bv.shape[0]}x{bv.shape[1]}x{bv.shape[2]}, expected "
+            f"{n_regime}x{n_var}x{n_var} to match a."
+        )
+    if cv.shape[0] != n_regime or cv.shape[1] != n_var:
+        raise ValueError(
+            f"c is {cv.shape[0]}x{cv.shape[1]}, expected {n_regime}x{n_var} "
+            f"to match a."
+        )
+    if n_state + n_ctrl != n_var:
+        raise ValueError(
+            f"f_ref is {n_ctrl}x{n_state}, so n_state + n_ctrl is "
+            f"{n_state + n_ctrl}, expected {n_var} to match a."
+        )
+    # The kernel indexes table[mask[t]] without a bound check.
+    for i in range(T):
+        if not 0 <= mv[i] < n_regime:
+            raise ValueError(
+                f"mask[{i}] is {mv[i]}, outside 0..{n_regime - 1}."
+            )
+
+    if out is None:
+        out = np.empty((T, n_var, n_rhs), dtype=np.float64)
+    cdef double[:, :, ::1] ov = out
+    if ov.shape[0] != T or ov.shape[1] != n_var or ov.shape[2] != n_rhs:
+        raise ValueError(
+            f"out is {ov.shape[0]}x{ov.shape[1]}x{ov.shape[2]}, expected "
+            f"{T}x{n_var}x{n_rhs}."
+        )
+
+    cdef arena_size sz = sdsge_occbin_recursion_arena_size(
+        n_var, n_state, n_ctrl
+    )
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iav = iarena
+
+    cdef const int8_t *mask_ptr = &mv[0] if T > 0 else NULL
+    cdef double *out_ptr = &ov[0, 0, 0] if (T * n_var * n_rhs) > 0 else NULL
+    cdef double *arena_ptr = &arv[0] if arv.shape[0] > 0 else NULL
+    cdef int64_t *iarena_ptr = &iav[0] if iav.shape[0] > 0 else NULL
+
+    cdef occbin_ctx ctx
+    cdef regime_ctx table[4]  # MAX_REGIME
+    cdef int64_t singular_date = -1
+    cdef int64_t status
+
+    for i in range(n_regime):
+        table[i].pencil = NULL
+        table[i].n_row = 0
+        table[i].rows = NULL
+        table[i].a = &av[i, 0, 0]
+        table[i].b = &bv[i, 0, 0]
+        table[i].c = &cv[i, 0]
+
+    ctx.table = table
+    ctx.f_ref = &fv[0, 0] if (n_ctrl * n_state) > 0 else NULL
+    ctx.n_var = n_var
+    ctx.n_state = n_state
+    ctx.n_ctrl = n_ctrl
+
+    with nogil:
+        status = sdsge_occbin_recursion(
+            &ctx, mask_ptr, T, out_ptr, &singular_date, arena_ptr, iarena_ptr
+        )
+
+    if status != SDSGE_OCCBIN_RECURSION_OK:
+        raise RuntimeError(
+            f"occbin_recursion: singular pencil at date {singular_date}."
+        )
+    return out

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -49,16 +49,58 @@ cdef extern from "occbin.h" nogil:
         int64_t n_var
         int64_t n_state
         int64_t n_ctrl
+    ctypedef struct occbin_opts:
+        int64_t periodic_solution
+        int64_t periodic_threshold
+        int64_t periodic_strict
+        int64_t curb_retrench
+        int64_t reset_regime
+        int64_t reset_check_ahead
+        int64_t algo_truncation
+    ctypedef struct occbin_run_ctx:
+        const occbin_ctx *model
+        sdsge_constraint_fn cond
+        double *par
+        const double *ss
+        int64_t inclusive
+        int64_t n_constraint
+        int64_t max_iter
+        int64_t T0
+        int64_t T_cap
+        occbin_opts opts
+    ctypedef struct occbin_diag:
+        int64_t *iters
+        double *max_err
+        int8_t *periodic
+        int64_t fail_period
+        int64_t singular_date
     arena_size sdsge_occbin_recursion_arena_size(
         int64_t n_var, int64_t n_state, int64_t n_ctrl)
     int64_t sdsge_occbin_recursion(
         const occbin_ctx *ctx, const int8_t *mask, int64_t T, double *out,
         int64_t *singular_date, double *arena, int64_t *iarena)
+    void sdsge_occbin_forward(
+        const double *rule, const double *x0, int64_t T, int64_t n_var,
+        int64_t n_state, double *path)
+    arena_size sdsge_occbin_solve_arena_size(
+        int64_t n_var, int64_t n_state, int64_t n_ctrl, int64_t T_cap,
+        int64_t max_iter)
+    int64_t sdsge_occbin_solve(
+        const occbin_run_ctx *run, const double *shocks, int64_t S,
+        int64_t n_periods, const double *x_init, const int8_t *init_mask,
+        double *out, int8_t *regimes, int64_t *T_used, occbin_diag *diag,
+        double *rule, double *path, int8_t *mask, double *arena,
+        int64_t *iarena)
     int64_t SDSGE_OCCBIN_RECURSION_OK
+    int64_t SDSGE_OCCBIN_RECURSION_SINGULAR
+    int64_t SDSGE_OCCBIN_PERIOD_OK
+    int64_t SDSGE_OCCBIN_PERIODIC
+    int64_t SDSGE_OCCBIN_PERIODIC_LOOP
+    int64_t SDSGE_OCCBIN_MAXITER
 
 
-#: Constraints the native flag buffer is sized for (``i8 flags[4]`` in occbin.c,
-#: two slots per constraint). Mirrors the OccBin cap in model_parser.
+#: Constraints the native distance buffer is sized for (``f64 err[4]`` in
+#: occbin.c, two slots per constraint). Mirrors the OccBin cap in model_parser.
 MAX_CONSTRAINTS = 2
 MAX_REGIME = 4
 
@@ -201,6 +243,58 @@ def regime_pencil(size_t pencil_addr, rows, ss, par, a_ref, b_ref):
     return a, b, c
 
 
+cdef _check_pencils(double[:, :, ::1] av, double[:, :, ::1] bv,
+                    double[:, ::1] cv, double[:, ::1] fv):
+    """``(n_regime, n_var, n_state, n_ctrl)`` for stacked pencils and ``f_ref``.
+
+    The kernels index the stack and partition the rows without a bound check,
+    so every shape relation they assume is settled here.
+    """
+    cdef int64_t n_regime = av.shape[0]
+    cdef int64_t n_var = av.shape[1]
+    cdef int64_t n_ctrl = fv.shape[0]
+    cdef int64_t n_state = fv.shape[1]
+
+    if n_regime < 1:
+        raise ValueError("a must hold at least the reference regime.")
+    if n_regime > MAX_REGIME:
+        raise ValueError(f"a holds {n_regime} regimes, at most {MAX_REGIME}.")
+    if av.shape[2] != n_var:
+        raise ValueError(
+            f"a[0] is {av.shape[1]}x{av.shape[2]}, expected square."
+        )
+    if bv.shape[0] != n_regime or bv.shape[1] != n_var or bv.shape[2] != n_var:
+        raise ValueError(
+            f"b is {bv.shape[0]}x{bv.shape[1]}x{bv.shape[2]}, expected "
+            f"{n_regime}x{n_var}x{n_var} to match a."
+        )
+    if cv.shape[0] != n_regime or cv.shape[1] != n_var:
+        raise ValueError(
+            f"c is {cv.shape[0]}x{cv.shape[1]}, expected {n_regime}x{n_var} "
+            f"to match a."
+        )
+    if n_state + n_ctrl != n_var:
+        raise ValueError(
+            f"f_ref is {n_ctrl}x{n_state}, so n_state + n_ctrl is "
+            f"{n_state + n_ctrl}, expected {n_var} to match a."
+        )
+    return n_regime, n_var, n_state, n_ctrl
+
+
+cdef void _fill_table(regime_ctx *table, double[:, :, ::1] av,
+                      double[:, :, ::1] bv, double[:, ::1] cv,
+                      int64_t n_regime) noexcept nogil:
+    """Point a stack-allocated table at the stacked pencils, slot by slot."""
+    cdef int64_t i
+    for i in range(n_regime):
+        table[i].pencil = NULL
+        table[i].n_row = 0
+        table[i].rows = NULL
+        table[i].a = &av[i, 0, 0]
+        table[i].b = &bv[i, 0, 0]
+        table[i].c = &cv[i, 0]
+
+
 def occbin_recursion_arena_size(int64_t n_var, int64_t n_state,
                                 int64_t n_ctrl):
     """``(n_float, n_int)`` scratch ``occbin_recursion`` needs for a shape."""
@@ -236,37 +330,13 @@ def occbin_recursion(a, b, c, mask, f_ref, out=None, arena=None, iarena=None):
     cdef double[:, ::1] fv = np.ascontiguousarray(f_ref, dtype=np.float64)
     cdef const int8_t[::1] mv = np.ascontiguousarray(mask, dtype=np.int8)
 
-    cdef int64_t n_regime = av.shape[0]
-    cdef int64_t n_var = av.shape[1]
-    cdef int64_t n_ctrl = fv.shape[0]
-    cdef int64_t n_state = fv.shape[1]
+    cdef int64_t n_regime, n_var, n_state, n_ctrl
+    n_regime, n_var, n_state, n_ctrl = _check_pencils(av, bv, cv, fv)
+
     cdef int64_t T = mv.shape[0]
     cdef int64_t n_rhs = n_state + 1
     cdef int64_t i
 
-    if n_regime < 1:
-        raise ValueError("a must hold at least the reference regime.")
-    if n_regime > MAX_REGIME:
-        raise ValueError(f"a holds {n_regime} regimes, at most {MAX_REGIME}.")
-    if av.shape[2] != n_var:
-        raise ValueError(
-            f"a[0] is {av.shape[1]}x{av.shape[2]}, expected square."
-        )
-    if bv.shape[0] != n_regime or bv.shape[1] != n_var or bv.shape[2] != n_var:
-        raise ValueError(
-            f"b is {bv.shape[0]}x{bv.shape[1]}x{bv.shape[2]}, expected "
-            f"{n_regime}x{n_var}x{n_var} to match a."
-        )
-    if cv.shape[0] != n_regime or cv.shape[1] != n_var:
-        raise ValueError(
-            f"c is {cv.shape[0]}x{cv.shape[1]}, expected {n_regime}x{n_var} "
-            f"to match a."
-        )
-    if n_state + n_ctrl != n_var:
-        raise ValueError(
-            f"f_ref is {n_ctrl}x{n_state}, so n_state + n_ctrl is "
-            f"{n_state + n_ctrl}, expected {n_var} to match a."
-        )
     # The kernel indexes table[mask[t]] without a bound check.
     for i in range(T):
         if not 0 <= mv[i] < n_regime:
@@ -308,13 +378,7 @@ def occbin_recursion(a, b, c, mask, f_ref, out=None, arena=None, iarena=None):
     cdef int64_t singular_date = -1
     cdef int64_t status
 
-    for i in range(n_regime):
-        table[i].pencil = NULL
-        table[i].n_row = 0
-        table[i].rows = NULL
-        table[i].a = &av[i, 0, 0]
-        table[i].b = &bv[i, 0, 0]
-        table[i].c = &cv[i, 0]
+    _fill_table(table, av, bv, cv, n_regime)
 
     ctx.table = table
     ctx.f_ref = &fv[0, 0] if (n_ctrl * n_state) > 0 else NULL
@@ -332,3 +396,280 @@ def occbin_recursion(a, b, c, mask, f_ref, out=None, arena=None, iarena=None):
             f"occbin_recursion: singular pencil at date {singular_date}."
         )
     return out
+
+
+def occbin_forward(rule, x0, out=None):
+    """``(T, n_var)`` path in deviations, from decision rules and a state.
+
+    ``rule`` is a stack of blocks as ``occbin_recursion`` returns them, ``(T,
+    n_var, n_state + 1)``, and ``x0`` the ``(n_state,)`` state entering date 0.
+
+    Row ``t`` is ``[x_t; u_t]``: the state half comes from date ``t - 1``'s
+    block and the control half from date ``t``'s, which is the pairing a
+    constraint on period ``t`` reads. The state the last block implies falls off
+    the end. ``out`` is an optional C-contiguous buffer written in place.
+    """
+    cdef double[:, :, ::1] rv = np.ascontiguousarray(rule, dtype=np.float64)
+    cdef double[::1] xv = np.ascontiguousarray(x0, dtype=np.float64)
+
+    cdef int64_t T = rv.shape[0]
+    cdef int64_t n_var = rv.shape[1]
+    cdef int64_t n_state = rv.shape[2] - 1
+
+    if n_state < 0 or n_state > n_var:
+        raise ValueError(
+            f"rule is {T}x{n_var}x{rv.shape[2]}, expected a last axis in "
+            f"1..{n_var + 1}."
+        )
+    if xv.shape[0] != n_state:
+        raise ValueError(
+            f"x0 has length {xv.shape[0]}, expected {n_state} to match rule."
+        )
+
+    if out is None:
+        out = np.empty((T, n_var), dtype=np.float64)
+    cdef double[:, ::1] ov = out
+    if ov.shape[0] != T or ov.shape[1] != n_var:
+        raise ValueError(
+            f"out is {ov.shape[0]}x{ov.shape[1]}, expected {T}x{n_var}."
+        )
+
+    cdef const double *rule_ptr = &rv[0, 0, 0] if T * n_var > 0 else NULL
+    cdef const double *x_ptr = &xv[0] if n_state > 0 else NULL
+    cdef double *out_ptr = &ov[0, 0] if T * n_var > 0 else NULL
+    with nogil:
+        sdsge_occbin_forward(rule_ptr, x_ptr, T, n_var, n_state, out_ptr)
+    return out
+
+
+def occbin_solve_arena_size(int64_t n_var, int64_t n_state, int64_t n_ctrl,
+                            int64_t T_cap, int64_t max_iter):
+    """``(n_float, n_int)`` scratch ``occbin_solve`` needs for a shape."""
+    cdef arena_size sz = sdsge_occbin_solve_arena_size(
+        n_var, n_state, n_ctrl, T_cap, max_iter
+    )
+    return sz.n_float, sz.n_int
+
+
+def occbin_solve(a, b, c, f_ref, ss, par, size_t cond_addr,
+                 int64_t n_constraint, int64_t inclusive, shocks, x_init,
+                 *, int64_t T0, int64_t T_cap=-1, n_periods=None,
+                 int64_t max_iter=30, init_regime=None,
+                 bint periodic_solution=False, int64_t periodic_threshold=1,
+                 bint periodic_strict=True, bint curb_retrench=False,
+                 bint reset_regime=False, bint reset_check_ahead=False,
+                 int64_t algo_truncation=1):
+    """Piecewise path ``(n_periods, n_var)`` for a sequence of unforeseen shocks.
+
+    ``a``, ``b``, ``c`` and ``f_ref`` are the pencils and reference rule
+    ``occbin_recursion`` takes, except that the stack must be complete: the latch
+    produces every mask in ``0..2 ** n_constraint - 1``, so all of them must be
+    slots. ``ss`` is the ``(n_var,)`` reference steady state, which turns the
+    path into the levels the constraint @cfunc at ``cond_addr`` reads.
+
+    ``shocks`` is ``(S, n_state)`` in state slots, added to the carried state at
+    the head of each period. A period whose row is all zero is not re-solved:
+    the previous guess and the path it implies, both shifted forward one period,
+    already describe it. Period 0 always solves.
+
+    ``T0`` is the horizon a guess starts at and ``T_cap`` the most it may grow
+    to, one date at a time, whenever a guess still binds at its last date;
+    ``T_cap`` defaults to ``T0``, which forbids growth and forces the last date
+    relaxed instead. ``n_periods`` defaults to ``S`` and any excess is filled
+    from the tail of the last path solved. ``init_regime`` is a ``(T0,)`` guess
+    to start period 0 from, all relaxed by default.
+
+    The remaining keywords are Dynare's ``occbin.simul`` options at their own
+    defaults. ``periodic_solution`` accepts the best guess of a cycle instead of
+    failing; ``periodic_threshold`` is how far a guess may move and still count
+    as a two-cycle rather than a loop; ``periodic_strict`` refuses to weigh a
+    loop that is not one; ``curb_retrench`` relaxes one date per pass;
+    ``reset_regime`` starts every period from the relaxed guess, dropping a
+    grown horizon too when ``reset_check_ahead`` is set; and a ``max_iter`` at
+    or below ``algo_truncation`` accepts whatever the last pass produced.
+
+    Returns ``(out, regimes, diag)``. ``out`` is in deviations, ``regimes`` is
+    the ``(S, T_cap)`` accepted guess per period, and ``diag`` carries
+    ``T_used``, ``iters``, ``max_err`` and ``periodic``, one entry per period.
+    ``periodic`` is nonzero where a period was accepted under
+    ``periodic_solution``, carrying the code it would otherwise have raised.
+    Raises ``RuntimeError`` naming the period that failed to converge.
+    """
+    cdef double[:, :, ::1] av = np.ascontiguousarray(a, dtype=np.float64)
+    cdef double[:, :, ::1] bv = np.ascontiguousarray(b, dtype=np.float64)
+    cdef double[:, ::1] cv = np.ascontiguousarray(c, dtype=np.float64)
+    cdef double[:, ::1] fv = np.ascontiguousarray(f_ref, dtype=np.float64)
+
+    cdef int64_t n_regime, n_var, n_state, n_ctrl
+    n_regime, n_var, n_state, n_ctrl = _check_pencils(av, bv, cv, fv)
+
+    if n_state < 1:
+        raise ValueError("f_ref must hold at least one state; the solve "
+                         "carries the path forward through the states.")
+    if not 0 < n_constraint <= MAX_CONSTRAINTS:
+        raise ValueError(
+            f"n_constraint must be in 1..{MAX_CONSTRAINTS}, got {n_constraint}."
+        )
+    # The latch emits every mask over n_constraint bits and the kernel indexes
+    # table[mask[t]] with it, so a partial stack would read past the table.
+    if n_regime != 1 << n_constraint:
+        raise ValueError(
+            f"a holds {n_regime} regimes, expected {1 << n_constraint} to "
+            f"cover every mask over {n_constraint} constraints."
+        )
+
+    if T_cap < 0:
+        T_cap = T0
+    if T0 < 2:
+        raise ValueError(f"T0 is {T0}, expected at least 2.")
+    if T_cap < T0:
+        raise ValueError(f"T_cap is {T_cap}, expected at least T0 of {T0}.")
+    if max_iter < 1:
+        raise ValueError(f"max_iter is {max_iter}, expected at least 1.")
+
+    cdef int8_t[::1] imv
+    cdef const int8_t *im = NULL
+    if init_regime is not None:
+        imv = np.ascontiguousarray(init_regime, dtype=np.int8)
+        if imv.shape[0] != T0:
+            raise ValueError(
+                f"init_regime has length {imv.shape[0]}, expected T0 of {T0}."
+            )
+        if np.any(np.asarray(imv) >= (1 << n_constraint)) or np.any(
+            np.asarray(imv) < 0
+        ):
+            raise ValueError(
+                f"init_regime holds a mask outside 0..{(1 << n_constraint) - 1}."
+            )
+        im = &imv[0]
+
+    cdef double[::1] ssv = np.ascontiguousarray(ss, dtype=np.float64)
+    cdef double[::1] parv = np.ascontiguousarray(par, dtype=np.float64)
+    cdef double[:, ::1] shv = np.ascontiguousarray(shocks, dtype=np.float64)
+    cdef double[::1] xv = np.ascontiguousarray(x_init, dtype=np.float64)
+    cdef int64_t S = shv.shape[0]
+
+    if ssv.shape[0] != n_var:
+        raise ValueError(
+            f"ss has length {ssv.shape[0]}, expected {n_var} to match a."
+        )
+    if S < 1:
+        raise ValueError("shocks must hold at least one period.")
+    if shv.shape[1] != n_state:
+        raise ValueError(
+            f"shocks is {S}x{shv.shape[1]}, expected {S}x{n_state} to match "
+            f"f_ref."
+        )
+    if xv.shape[0] != n_state:
+        raise ValueError(
+            f"x_init has length {xv.shape[0]}, expected {n_state} to match "
+            f"f_ref."
+        )
+
+    cdef int64_t P = S if n_periods is None else n_periods
+    if P < S:
+        raise ValueError(f"n_periods is {P}, expected at least S of {S}.")
+    # The tail is read off one path, which is only T0 long to start with.
+    if P - S > T0:
+        raise ValueError(
+            f"n_periods is {P}, at most S + T0 of {S + T0} for a tail the "
+            f"last path can fill."
+        )
+
+    out = np.empty((P, n_var), dtype=np.float64)
+    regimes = np.zeros((S, T_cap), dtype=np.int8)
+    T_used = np.zeros(S, dtype=np.int64)
+    iters = np.zeros(S, dtype=np.int64)
+    max_err = np.zeros(S, dtype=np.float64)
+    periodic = np.zeros(S, dtype=np.int8)
+    cdef double[:, ::1] ov = out
+    cdef int8_t[:, ::1] rgv = regimes
+    cdef int64_t[::1] tuv = T_used
+    cdef int64_t[::1] itv = iters
+    cdef double[::1] mev = max_err
+    cdef int8_t[::1] pev = periodic
+
+    rule = np.empty((T_cap, n_var, n_state + 1), dtype=np.float64)
+    path = np.empty((T_cap, n_var), dtype=np.float64)
+    mask = np.empty(T_cap, dtype=np.int8)
+    cdef double[:, :, ::1] rulev = rule
+    cdef double[:, ::1] pathv = path
+    cdef int8_t[::1] maskv = mask
+
+    cdef arena_size sz = sdsge_occbin_solve_arena_size(
+        n_var, n_state, n_ctrl, T_cap, max_iter
+    )
+    arena = np.empty(sz.n_float, dtype=np.float64)
+    iarena = np.empty(sz.n_int, dtype=np.int64)
+    cdef double[::1] arv = arena
+    cdef int64_t[::1] iav = iarena
+
+    cdef occbin_ctx model
+    cdef regime_ctx table[4]  # MAX_REGIME
+    _fill_table(table, av, bv, cv, n_regime)
+    model.table = table
+    model.f_ref = &fv[0, 0] if n_ctrl * n_state > 0 else NULL
+    model.n_var = n_var
+    model.n_state = n_state
+    model.n_ctrl = n_ctrl
+
+    cdef occbin_run_ctx run
+    run.model = &model
+    run.cond = <sdsge_constraint_fn><void*>cond_addr
+    run.par = &parv[0] if parv.shape[0] > 0 else NULL
+    run.ss = &ssv[0] if n_var > 0 else NULL
+    run.inclusive = inclusive
+    run.n_constraint = n_constraint
+    run.max_iter = max_iter
+    run.T0 = T0
+    run.T_cap = T_cap
+    run.opts.periodic_solution = periodic_solution
+    run.opts.periodic_threshold = periodic_threshold
+    run.opts.periodic_strict = periodic_strict
+    run.opts.curb_retrench = curb_retrench
+    run.opts.reset_regime = reset_regime
+    run.opts.reset_check_ahead = reset_check_ahead
+    run.opts.algo_truncation = algo_truncation
+
+    cdef occbin_diag diag
+    diag.iters = &itv[0]
+    diag.max_err = &mev[0]
+    diag.periodic = &pev[0]
+    diag.fail_period = -1
+    diag.singular_date = -1
+
+    cdef int64_t status
+    with nogil:
+        status = sdsge_occbin_solve(
+            &run, &shv[0, 0], S, P, &xv[0], im, &ov[0, 0], &rgv[0, 0], &tuv[0],
+            &diag, &rulev[0, 0, 0], &pathv[0, 0], &maskv[0], &arv[0], &iav[0]
+        )
+
+    if status != SDSGE_OCCBIN_PERIOD_OK:
+        raise RuntimeError(_solve_error(status, &diag, max_iter))
+    return out, regimes, {
+        "T_used": T_used,
+        "iters": iters,
+        "max_err": max_err,
+        "periodic": periodic,
+    }
+
+
+cdef _solve_error(int64_t status, occbin_diag *diag, int64_t max_iter):
+    """Dynare's error code for a period that never settled, as a message."""
+    cdef int64_t s = diag.fail_period
+    if status == SDSGE_OCCBIN_RECURSION_SINGULAR:
+        return (
+            f"occbin_solve: singular pencil at date {diag.singular_date} of "
+            f"shock period {s}."
+        )
+    if status == SDSGE_OCCBIN_PERIODIC:
+        return f"occbin_solve: shock period {s} loops between two regimes."
+    if status == SDSGE_OCCBIN_PERIODIC_LOOP:
+        return f"occbin_solve: shock period {s} loops over guess regimes."
+    if status == SDSGE_OCCBIN_MAXITER:
+        return (
+            f"occbin_solve: shock period {s} did not converge in {max_iter} "
+            f"iterations."
+        )
+    return f"occbin_solve: shock period {s} failed with status {status}."

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -193,7 +193,16 @@ def regime_pencil(size_t pencil_addr, rows, ss, par, a_ref, b_ref):
     return a, b, c
 
 
-def occbin_recursion(a, b, c, mask, f_ref, out=None):
+def occbin_recursion_arena_size(int64_t n_var, int64_t n_state,
+                                int64_t n_ctrl):
+    """``(n_float, n_int)`` scratch ``occbin_recursion`` needs for a shape."""
+    cdef arena_size sz = sdsge_occbin_recursion_arena_size(
+        n_var, n_state, n_ctrl
+    )
+    return sz.n_float, sz.n_int
+
+
+def occbin_recursion(a, b, c, mask, f_ref, out=None, arena=None, iarena=None):
     """Piecewise-linear decision rules ``(T, n_var, n_state + 1)`` for a guess.
 
     ``a``, ``b`` and ``c`` are the regime pencils stacked by bitmask, shaped
@@ -209,6 +218,9 @@ def occbin_recursion(a, b, c, mask, f_ref, out=None):
     ``x_t`` to ``[x_{t+1}; u_t]``: ``out[t, :, :n_state] @ x_t + out[t, :,
     n_state]``, state rows first. Raises ``RuntimeError`` naming the date if a
     date's pencil is singular.
+
+    ``arena`` and ``iarena`` are optional scratch buffers, at least as long as
+    ``occbin_recursion_arena_size`` reports; both are allocated if omitted.
     """
     cdef double[:, :, ::1] av = np.ascontiguousarray(a, dtype=np.float64)
     cdef double[:, :, ::1] bv = np.ascontiguousarray(b, dtype=np.float64)
@@ -266,10 +278,17 @@ def occbin_recursion(a, b, c, mask, f_ref, out=None):
     cdef arena_size sz = sdsge_occbin_recursion_arena_size(
         n_var, n_state, n_ctrl
     )
-    arena = np.empty(sz.n_float, dtype=np.float64)
-    iarena = np.empty(sz.n_int, dtype=np.int64)
+    if arena is None:
+        arena = np.empty(sz.n_float, dtype=np.float64)
+    if iarena is None:
+        iarena = np.empty(sz.n_int, dtype=np.int64)
     cdef double[::1] arv = arena
     cdef int64_t[::1] iav = iarena
+    if arv.shape[0] < sz.n_float or iav.shape[0] < sz.n_int:
+        raise ValueError(
+            f"arena is {arv.shape[0]}/{iav.shape[0]} floats/ints, needs "
+            f"{sz.n_float}/{sz.n_int}."
+        )
 
     cdef const int8_t *mask_ptr = &mv[0] if T > 0 else NULL
     cdef double *out_ptr = &ov[0, 0, 0] if (T * n_var * n_rhs) > 0 else NULL

--- a/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
+++ b/SymbolicDSGE/_ckernels/occbin/_occbin.pyx
@@ -37,11 +37,12 @@ cdef extern from "regime_pencil.h" nogil:
 
 cdef extern from "occbin.h" nogil:
     ctypedef void (*sdsge_constraint_fn)(
-        double *cur, double *par, int8_t *flags) noexcept
+        double *cur, double *par, double *err) noexcept
     int64_t sdsge_constraint_path(
         sdsge_constraint_fn cond, double *path, double *par,
         const int8_t *regime_in, int8_t *regime_out,
-        int64_t T, int64_t n_var, int64_t n_constraint)
+        int64_t inclusive, double *max_err, int64_t T,
+        int64_t n_var, int64_t n_constraint)
     ctypedef struct occbin_ctx:
         const regime_ctx *table
         const double *f_ref
@@ -63,7 +64,7 @@ MAX_REGIME = 4
 
 
 def constraint_path(size_t cond_addr, path, par, regime_in,
-                    int64_t n_constraint, out=None):
+                    int64_t n_constraint, int64_t inclusive, out=None):
     """Latched regime mask ``(T,)`` from a constraint @cfunc over a path.
 
     ``path`` is ``(T, n_var)`` in cur-variable order and in levels, not
@@ -71,10 +72,15 @@ def constraint_path(size_t cond_addr, path, par, regime_in,
     ``(T,)`` mask over declaration-ordered constraints, which the latch carries
     across guess-and-verify iterations at a fixed period; periods never interact.
 
+    The cfunc writes signed distances, so ``inclusive``
+    (``ConstraintFunc.inclusive``) is what decides a distance of exactly zero,
+    which is where a condition written against the steady state starts.
+
     ``out`` is an optional C-contiguous int8 buffer written in place, and may be
     ``regime_in`` itself to latch in place. Other inputs are coerced. Returns
-    ``(out, changed)``, where ``changed`` counts the periods whose mask moved and
-    so is 0 exactly at a fixed point.
+    ``(out, changed, max_err)``: ``changed`` counts the periods whose mask moved
+    and so is 0 exactly at a fixed point, and ``max_err`` is the largest
+    distance that moved one, which ranks iterations that cycle.
     """
     if not 0 < n_constraint <= MAX_CONSTRAINTS:
         raise ValueError(
@@ -88,6 +94,7 @@ def constraint_path(size_t cond_addr, path, par, regime_in,
     cdef int64_t n_var = pv.shape[1]
     cdef int8_t[::1] ov
     cdef int64_t changed
+    cdef double max_err = 0.0
 
     if inv.shape[0] != T:
         raise ValueError(
@@ -108,9 +115,10 @@ def constraint_path(size_t cond_addr, path, par, regime_in,
     cdef sdsge_constraint_fn fn = <sdsge_constraint_fn><void*>cond_addr
     with nogil:
         changed = sdsge_constraint_path(
-            fn, path_ptr, par_ptr, in_ptr, out_ptr, T, n_var, n_constraint
+            fn, path_ptr, par_ptr, in_ptr, out_ptr, inclusive, &max_err,
+            T, n_var, n_constraint,
         )
-    return out, changed
+    return out, changed, max_err
 
 
 def regime_pencil(size_t pencil_addr, rows, ss, par, a_ref, b_ref):

--- a/SymbolicDSGE/_ckernels/occbin/occbin.c
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.c
@@ -1,5 +1,6 @@
 #include "occbin.h"
 #include "../_common/sdsge_linalg.h"
+#include <string.h>
 
 i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
                           f64 *SDSGE_RESTRICT par, const i8 *regime_in,
@@ -101,4 +102,208 @@ i64 sdsge_occbin_recursion(const occbin_ctx *ctx, const i8 *SDSGE_RESTRICT mask,
     u_next = rule + n_state * n_rhs;
   }
   return SDSGE_OCCBIN_RECURSION_OK;
+}
+
+void sdsge_occbin_forward(const f64 *SDSGE_RESTRICT rule,
+                          const f64 *SDSGE_RESTRICT x0, i64 T, i64 n_var,
+                          i64 n_state, f64 *SDSGE_RESTRICT path) {
+  const i64 n_rhs = n_state + 1;
+
+  for (i64 j = 0; j < n_state; ++j) {
+    path[j] = x0[j];
+  }
+
+  for (i64 t = 0; t < T; ++t) {
+    const f64 *r = rule + t * n_var * n_rhs;
+    const f64 *x = path + t * n_var;
+    f64 *u = path + t * n_var + n_state;
+
+    for (i64 i = n_state; i < n_var; ++i) { // n_ctrl
+      f64 acc = r[i * n_rhs + n_state];
+      for (i64 j = 0; j < n_state; ++j) {
+        acc += r[i * n_rhs + j] * x[j];
+      }
+      u[i - n_state] = acc;
+    }
+    if (t == T - 1) {
+      break;
+    }
+
+    f64 *xn = path + (t + 1) * n_var;
+    for (i64 i = 0; i < n_state; ++i) {
+      f64 acc = r[i * n_rhs + n_state];
+      for (i64 j = 0; j < n_state; ++j) {
+        acc += r[i * n_rhs + j] * x[j];
+      }
+      xn[i] = acc;
+    }
+  }
+}
+
+arena_size sdsge_occbin_period_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                          i64 T_cap, i64 max_iter) {
+  const arena_size rec =
+      sdsge_occbin_recursion_arena_size(n_var, n_state, n_ctrl);
+  const i64 bytes = (max_iter + 1) * T_cap; // hist and next
+  return make_sizer(T_cap * n_var + rec.n_float,
+                    rec.n_int + max_iter + (bytes + 7) / 8);
+}
+
+i64 sdsge_occbin_period(const occbin_run_ctx *run,
+                        const f64 *SDSGE_RESTRICT x0, i8 *mask, i64 *T,
+                        f64 *rule, f64 *path, occbin_diag *diag, i64 s,
+                        f64 *arena, i64 *iarena) {
+  const i64 n_var = run->model->n_var;
+  const i64 n_state = run->model->n_state;
+
+  f64 *lev = arena;                    // (T_cap, n_var) levels
+  f64 *rec = lev + run->T_cap * n_var; // recursion scratch
+  i64 *hist_len = iarena + n_var;      // (max_iter,)
+  i8 *next = (i8 *)(hist_len + run->max_iter); // (T_cap,)
+  i8 *hist = next + run->T_cap;                // (max_iter, T_cap)
+
+  f64 *max_err = &diag->max_err[s];
+  i64 changed = 1;
+  i64 iter = 0;
+
+  while (changed && iter < run->max_iter) {
+    if (mask[*T - 1] != 0 && *T < run->T_cap) {
+      // last period is binding, append a relaxing regime at the end.
+      mask[*T] = 0;
+      ++(*T);
+    } else if (mask[*T - 1] != 0) {
+      // binding at the cap, clip the last period to a relaxing regime.
+      mask[*T - 1] = 0;
+    }
+
+    memcpy(hist + iter * run->T_cap, mask, *T);
+    hist_len[iter] = *T;
+    ++iter;
+
+    i64 status = sdsge_occbin_recursion(run->model, mask, *T, rule,
+                                        &diag->singular_date, rec, iarena);
+    if (status != SDSGE_OCCBIN_RECURSION_OK) {
+      diag->iters[s] = iter;
+      return status;
+    }
+
+    sdsge_occbin_forward(rule, x0, *T, n_var, n_state, path);
+
+    for (i64 t = 0; t < *T; ++t) {
+      for (i64 i = 0; i < n_var; ++i) {
+        lev[t * n_var + i] = path[t * n_var + i] + run->ss[i];
+      }
+    }
+
+    *max_err = 0.0;
+    changed = sdsge_constraint_path(run->cond, lev, run->par, mask, next,
+                                    run->inclusive, max_err, *T, n_var,
+                                    run->n_constraint);
+    memcpy(mask, next, *T);
+
+    // A guess seen before is a cycle; the newest match dates its length. The
+    // guess entering this iteration cannot match, `changed` says it moved.
+    if (changed) {
+      for (i64 k = iter - 2; k >= 0; --k) {
+        if (hist_len[k] == *T && memcmp(hist + k * run->T_cap, mask, *T) == 0) {
+          diag->iters[s] = iter;
+          return (k == iter - 2) ? SDSGE_OCCBIN_PERIODIC
+                                 : SDSGE_OCCBIN_PERIODIC_LOOP;
+        }
+      }
+    }
+  }
+  diag->iters[s] = iter;
+  return changed ? SDSGE_OCCBIN_MAXITER : SDSGE_OCCBIN_PERIOD_OK;
+}
+
+/* Extend a relaxed path by one date: x_T = p x_{T-1}, then u_T = f x_T. Kept
+   as two loops so the control rows read `next` through `next` itself. */
+static void sdsge_occbin_reference_step(const f64 *SDSGE_RESTRICT ref,
+                                        const f64 *SDSGE_RESTRICT prev,
+                                        i64 n_var, i64 n_state,
+                                        f64 *SDSGE_RESTRICT next) {
+  const i64 n_rhs = n_state + 1;
+
+  for (i64 i = 0; i < n_state; ++i) {
+    f64 acc = ref[i * n_rhs + n_state];
+    for (i64 j = 0; j < n_state; ++j) {
+      acc += ref[i * n_rhs + j] * prev[j];
+    }
+    next[i] = acc;
+  }
+  for (i64 i = n_state; i < n_var; ++i) {
+    f64 acc = ref[i * n_rhs + n_state];
+    for (i64 j = 0; j < n_state; ++j) {
+      acc += ref[i * n_rhs + j] * next[j];
+    }
+    next[i] = acc;
+  }
+}
+
+arena_size sdsge_occbin_solve_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                         i64 T_cap, i64 max_iter) {
+  const arena_size per = sdsge_occbin_period_arena_size(n_var, n_state, n_ctrl,
+                                                        T_cap, max_iter);
+  return make_sizer(n_state + per.n_float, per.n_int);
+}
+
+i64 sdsge_occbin_solve(const occbin_run_ctx *run, const f64 *shocks, i64 S,
+                       i64 n_periods, const f64 *x_init, f64 *out, i8 *regimes,
+                       i64 *T_used, occbin_diag *diag, f64 *rule, f64 *path,
+                       i8 *mask, f64 *arena, i64 *iarena) {
+  const i64 n_var = run->model->n_var;
+  const i64 n_state = run->model->n_state;
+  const i64 n_rhs = n_state + 1;
+  i64 T = run->T0;
+
+  f64 *x = arena; // (n_state,) state entering the current shock period
+  f64 *period_arena = x + n_state;
+
+  diag->fail_period = -1;
+  diag->singular_date = -1;
+
+  memset(mask, 0, T);
+  memset(path, 0, T * n_var * sizeof(f64));
+  memcpy(x, x_init, n_state * sizeof(f64));
+
+  for (i64 s = 0; s < S; ++s) {
+    for (i64 j = 0; j < n_state; ++j) {
+      x[j] += shocks[s * n_state + j];
+    }
+
+    if (s == 0 || sdsge_any_nonzero(shocks + s * n_state, n_state)) {
+      i64 status = sdsge_occbin_period(run, x, mask, &T, rule, path, diag, s,
+                                       period_arena, iarena);
+      if (status != SDSGE_OCCBIN_PERIOD_OK) {
+        diag->fail_period = s;
+        return status;
+      }
+    } else {
+      // No shock: the previous guess and the path it implies, both already
+      // shifted onto this period, still describe it.
+      diag->iters[s] = 0;
+      diag->max_err[s] = 0.0;
+    }
+
+    memcpy(out + s * n_var, path, n_var * sizeof(f64));
+    memcpy(regimes + s * run->T_cap, mask, T);
+    T_used[s] = T;
+
+    // Advance a period: guess, path and carry shift together. A converged
+    // guess is relaxed at its last date, so that block is the reference rule.
+    memmove(path, path + n_var, (T - 1) * n_var * sizeof(f64));
+    sdsge_occbin_reference_step(rule + (T - 1) * n_var * n_rhs,
+                                path + (T - 2) * n_var, n_var, n_state,
+                                path + (T - 1) * n_var);
+    memmove(mask, mask + 1, T - 1);
+    mask[T - 1] = 0; // last period is relaxing by default
+    memcpy(x, path, n_state * sizeof(f64));
+  }
+
+  // The tail is what the last solved path still had left to run.
+  for (i64 t = S; t < n_periods; ++t) {
+    memcpy(out + t * n_var, path + (t - S) * n_var, n_var * sizeof(f64));
+  }
+  return SDSGE_OCCBIN_SOLVE_OK;
 }

--- a/SymbolicDSGE/_ckernels/occbin/occbin.c
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.c
@@ -1,4 +1,5 @@
 #include "occbin.h"
+#include "../_common/sdsge_linalg.h"
 
 i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
                           f64 *SDSGE_RESTRICT par, const i8 *regime_in,
@@ -19,4 +20,77 @@ i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
     changed += (next != prev);
   }
   return changed; // No status code, call can't fail
+}
+
+arena_size sdsge_occbin_recursion_arena_size(i64 n_var, i64 n_state,
+                                             i64 n_ctrl) {
+  const i64 n_rhs = n_state + 1;
+  return make_sizer(n_var * n_var + n_var * n_rhs + n_ctrl * n_rhs, n_var);
+}
+
+i64 sdsge_occbin_recursion(const occbin_ctx *ctx, const i8 *SDSGE_RESTRICT mask,
+                           i64 T, f64 *SDSGE_RESTRICT out,
+                           i64 *SDSGE_RESTRICT singular_date,
+                           f64 *SDSGE_RESTRICT arena,
+                           i64 *SDSGE_RESTRICT iarena) {
+  const i64 n_var = ctx->n_var;
+  const i64 n_state = ctx->n_state;
+  const i64 n_ctrl = ctx->n_ctrl;
+  const i64 n_rhs = n_state + 1;
+
+  f64 *m = arena;
+  f64 *rhs = m + n_var * n_var;
+  f64 *seed = rhs + n_var * n_rhs;
+  i64 *piv = iarena;
+
+  *singular_date = -1;
+
+  /* Date T closes on the reference rule, restrided to match a solved block. */
+  for (i64 l = 0; l < n_ctrl; ++l) {
+    for (i64 j = 0; j < n_state; ++j) {
+      seed[l * n_rhs + j] = ctx->f_ref[l * n_state + j];
+    }
+    seed[l * n_rhs + n_state] = 0.0;
+  }
+  const f64 *u_next = seed;
+
+  for (i64 t = T - 1; t >= 0; --t) {
+    const regime_ctx *reg = &ctx->table[mask[t]];
+
+    for (i64 i = 0; i < n_var; ++i) {
+      const f64 *a_row = reg->a + i * n_var;
+      const f64 *b_row = reg->b + i * n_var;
+      f64 *m_row = m + i * n_var;
+      f64 *r_row = rhs + i * n_rhs;
+      f64 rc = reg->c[i];
+
+      for (i64 j = 0; j < n_state; ++j) {
+        m_row[j] = a_row[j];
+        r_row[j] = b_row[j];
+      }
+      for (i64 j = 0; j < n_ctrl; ++j) {
+        m_row[n_state + j] = -b_row[n_state + j];
+      }
+
+      for (i64 l = 0; l < n_ctrl; ++l) {
+        const f64 a_ul = a_row[n_state + l];
+        const f64 *u_row = u_next + l * n_rhs;
+        for (i64 j = 0; j < n_state; ++j) {
+          m_row[j] += a_ul * u_row[j];
+        }
+        rc += a_ul * u_row[n_state];
+      }
+      r_row[n_state] = -rc;
+    }
+
+    if (sdsge_lu_factor_inplace(m, piv, n_var) != SDSGE_LU_SUCCESS) {
+      *singular_date = t;
+      return SDSGE_OCCBIN_RECURSION_SINGULAR;
+    }
+
+    f64 *rule = out + t * n_var * n_rhs;
+    sdsge_lu_solve(m, piv, rhs, rule, n_var, n_rhs);
+    u_next = rule + n_state * n_rhs;
+  }
+  return SDSGE_OCCBIN_RECURSION_OK;
 }

--- a/SymbolicDSGE/_ckernels/occbin/occbin.c
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.c
@@ -3,18 +3,26 @@
 
 i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
                           f64 *SDSGE_RESTRICT par, const i8 *regime_in,
-                          i8 *regime_out, i64 T, i64 n_var, i64 n_constraint) {
-  i8 flags[4]; // 2 * MAX_CONSTRAINTS (a constraint is a relax/bind pair)
+                          i8 *regime_out, i64 inclusive,
+                          f64 *SDSGE_RESTRICT max_err, i64 T, i64 n_var,
+                          i64 n_constraint) {
+  f64 err[4]; // 2 * MAX_CONSTRAINTS (a constraint is a relax/bind pair)
   i64 changed = 0;
 
   for (i64 t = 0; t < T; ++t) {
-    cond(&path[t * n_var], par, flags);
+    cond(&path[t * n_var], par, err);
     const i8 prev = regime_in[t];
     i8 next = 0;
     for (i64 i = 0; i < n_constraint; ++i) {
       // If the previous regime was binding, check if it should relax; if it was
       // relaxing, check if it should bind
-      next |= (((prev >> i) & 1) ? !flags[2 * i + 1] : flags[2 * i]) << i;
+      const i64 slot = ((prev >> i) & 1) ? 2 * i + 1 : 2 * i;
+      const f64 e = err[slot];
+      const int fired = (e > 0.0) || (e == 0.0 && ((inclusive >> slot) & 1));
+      next |= (((prev >> i) & 1) ? !fired : fired) << i;
+      if (fired && e > *max_err) {
+        *max_err = e;
+      }
     }
     regime_out[t] = next;
     changed += (next != prev);

--- a/SymbolicDSGE/_ckernels/occbin/occbin.c
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.c
@@ -1,5 +1,6 @@
 #include "occbin.h"
 #include "../_common/sdsge_linalg.h"
+#include <stddef.h> // NULL
 #include <string.h>
 
 i64 sdsge_constraint_path(sdsge_constraint_fn cond, f64 *SDSGE_RESTRICT path,
@@ -109,6 +110,9 @@ void sdsge_occbin_forward(const f64 *SDSGE_RESTRICT rule,
                           i64 n_state, f64 *SDSGE_RESTRICT path) {
   const i64 n_rhs = n_state + 1;
 
+  if (T < 1) {
+    return; // the seed below already needs a row to write into
+  }
   for (i64 j = 0; j < n_state; ++j) {
     path[j] = x0[j];
   }
@@ -140,13 +144,95 @@ void sdsge_occbin_forward(const f64 *SDSGE_RESTRICT rule,
   }
 }
 
+/* Largest signed move any one constraint makes between two guesses: dates that
+   left the binding regime less dates that entered it. Dynare ranks a guess by
+   this, per constraint, and weighs the worst one. */
+static i64 sdsge_occbin_regime_move(const i8 *prev, const i8 *next, i64 T,
+                                    i64 n_constraint) {
+  i64 worst = 0;
+
+  for (i64 i = 0; i < n_constraint; ++i) {
+    i64 move = 0;
+    for (i64 t = 0; t < T; ++t) {
+      move += ((prev[t] >> i) & 1) - ((next[t] >> i) & 1);
+    }
+    if (i == 0 || move > worst) {
+      worst = move;
+    }
+  }
+  return worst;
+}
+
+/* Whether any date wants to enter the binding regime, on any constraint. */
+static i64 sdsge_occbin_binds_more(const i8 *prev, const i8 *next, i64 T) {
+  for (i64 t = 0; t < T; ++t) {
+    if (~prev[t] & next[t]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/* Gauss-Seidel damping: adopt every date the latch wants binding, but let only
+   the last date that wants to relax actually relax, and only when no date the
+   guess had binding outlasts the relax condition. `stay` carries the relax
+   condition at every date, with a set bit meaning the date stays binding. */
+static void sdsge_occbin_retrench(i8 *mask, const i8 *next, const i8 *stay,
+                                  i64 T, i64 n_constraint) {
+  for (i64 i = 0; i < n_constraint; ++i) {
+    const i8 bit = (i8)(1 << i);
+    i64 last_relax = -1;
+    i64 last_bind = -1;
+    i64 target = -1;
+
+    for (i64 t = 0; t < T; ++t) {
+      const int relaxes = !((stay[t] >> i) & 1);
+      if (relaxes) {
+        last_relax = t;
+      }
+      if (mask[t] & bit) {
+        last_bind = t;
+        if (relaxes) {
+          target = t;
+        }
+      }
+    }
+    if (last_relax < last_bind) {
+      target = -1;
+    }
+
+    for (i64 t = 0; t < T; ++t) {
+      const int keep = (next[t] & bit) || ((mask[t] & bit) && t != target);
+      mask[t] = (i8)((mask[t] & ~bit) | (keep ? bit : 0));
+    }
+  }
+}
+
+/* Dynare's gate for treating a repeated guess as periodic anyway: some pass
+   that wanted no new binding date moved the guess by little enough. The
+   comparison is `<=` in the one-constraint file and `<` in the two-constraint
+   one, and both are kept. */
+static i64 sdsge_occbin_promotable(const i64 *move, const i8 *binds, i64 iter,
+                                   i64 threshold, i64 n_constraint) {
+  for (i64 k = 0; k < iter; ++k) {
+    if (binds[k]) {
+      continue;
+    }
+    if (n_constraint > 1 ? move[k] < threshold : move[k] <= threshold) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 arena_size sdsge_occbin_period_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
                                           i64 T_cap, i64 max_iter) {
   const arena_size rec =
       sdsge_occbin_recursion_arena_size(n_var, n_state, n_ctrl);
-  const i64 bytes = (max_iter + 1) * T_cap; // hist and next
-  return make_sizer(T_cap * n_var + rec.n_float,
-                    rec.n_int + max_iter + (bytes + 7) / 8);
+  // hist, and next, all_bind and stay beside it
+  const i64 bytes = (max_iter + 3) * T_cap + max_iter;
+  return make_sizer(T_cap * n_var + max_iter + rec.n_float,
+                    rec.n_int + 2 * max_iter + (bytes + 7) / 8);
 }
 
 i64 sdsge_occbin_period(const occbin_run_ctx *run,
@@ -156,27 +242,47 @@ i64 sdsge_occbin_period(const occbin_run_ctx *run,
   const i64 n_var = run->model->n_var;
   const i64 n_state = run->model->n_state;
 
-  f64 *lev = arena;                    // (T_cap, n_var) levels
-  f64 *rec = lev + run->T_cap * n_var; // recursion scratch
-  i64 *hist_len = iarena + n_var;      // (max_iter,)
-  i8 *next = (i8 *)(hist_len + run->max_iter); // (T_cap,)
-  i8 *hist = next + run->T_cap;                // (max_iter, T_cap)
+  const i64 T_cap = run->T_cap;
+  const i64 max_iter = run->max_iter;
 
-  f64 *max_err = &diag->max_err[s];
+  f64 *lev = arena;                          // (T_cap, n_var) levels
+  f64 *err_hist = lev + T_cap * n_var;       // (max_iter,)
+  f64 *rec = err_hist + max_iter;            // recursion scratch
+  i64 *hist_len = iarena + n_var;            // (max_iter,)
+  i64 *move_hist = hist_len + max_iter;      // (max_iter,)
+  i8 *next = (i8 *)(move_hist + max_iter);   // (T_cap,)
+  i8 *hist = next + T_cap;                   // (max_iter, T_cap)
+  i8 *binds_hist = hist + max_iter * T_cap;  // (max_iter,)
+  i8 *all_bind = binds_hist + max_iter;      // (T_cap,)
+  i8 *stay = all_bind + T_cap;               // (T_cap,)
+
   i64 changed = 1;
   i64 iter = 0;
+  i64 grew = 0;
+  i64 cycle = -1; // iteration whose guess the updated one repeats
 
-  while (changed && iter < run->max_iter) {
-    if (mask[*T - 1] != 0 && *T < run->T_cap) {
+  if (run->opts.reset_regime) {
+    if (run->opts.reset_check_ahead) {
+      *T = run->T0;
+    }
+    memset(mask, 0, *T);
+  }
+  if (run->opts.curb_retrench) {
+    memset(all_bind, (1 << run->n_constraint) - 1, T_cap);
+  }
+
+  while (changed && iter < max_iter) {
+    if (mask[*T - 1] != 0 && *T < T_cap) {
       // last period is binding, append a relaxing regime at the end.
       mask[*T] = 0;
       ++(*T);
+      grew = 1; // Dynare stops looking for cycles in a period that grew
     } else if (mask[*T - 1] != 0) {
       // binding at the cap, clip the last period to a relaxing regime.
       mask[*T - 1] = 0;
     }
 
-    memcpy(hist + iter * run->T_cap, mask, *T);
+    memcpy(hist + iter * T_cap, mask, *T);
     hist_len[iter] = *T;
     ++iter;
 
@@ -195,26 +301,120 @@ i64 sdsge_occbin_period(const occbin_run_ctx *run,
       }
     }
 
-    *max_err = 0.0;
+    err_hist[iter - 1] = 0.0;
     changed = sdsge_constraint_path(run->cond, lev, run->par, mask, next,
-                                    run->inclusive, max_err, *T, n_var,
-                                    run->n_constraint);
-    memcpy(mask, next, *T);
+                                    run->inclusive, &err_hist[iter - 1], *T,
+                                    n_var, run->n_constraint);
+    move_hist[iter - 1] =
+        sdsge_occbin_regime_move(mask, next, *T, run->n_constraint);
+    binds_hist[iter - 1] = (i8)sdsge_occbin_binds_more(mask, next, *T);
+
+    if (run->opts.curb_retrench) {
+      // Reading every date as binding makes the latch report the relax
+      // condition everywhere, which the real sweep never sees at a date the
+      // guess already has relaxed.
+      f64 ignored = 0.0;
+      sdsge_constraint_path(run->cond, lev, run->par, all_bind, stay,
+                            run->inclusive, &ignored, *T, n_var,
+                            run->n_constraint);
+      sdsge_occbin_retrench(mask, next, stay, *T, run->n_constraint);
+    } else {
+      memcpy(mask, next, *T);
+    }
 
     // A guess seen before is a cycle; the newest match dates its length. The
     // guess entering this iteration cannot match, `changed` says it moved.
-    if (changed) {
+    if (changed && !grew) {
       for (i64 k = iter - 2; k >= 0; --k) {
-        if (hist_len[k] == *T && memcmp(hist + k * run->T_cap, mask, *T) == 0) {
-          diag->iters[s] = iter;
-          return (k == iter - 2) ? SDSGE_OCCBIN_PERIODIC
-                                 : SDSGE_OCCBIN_PERIODIC_LOOP;
+        if (hist_len[k] == *T && memcmp(hist + k * T_cap, mask, *T) == 0) {
+          cycle = k;
+          break;
         }
+      }
+      if (cycle >= 0) {
+        break;
       }
     }
   }
+
   diag->iters[s] = iter;
-  return changed ? SDSGE_OCCBIN_MAXITER : SDSGE_OCCBIN_PERIOD_OK;
+  diag->max_err[s] = err_hist[iter - 1];
+  diag->periodic[s] = 0;
+
+  i64 code = SDSGE_OCCBIN_PERIOD_OK;
+  if (cycle >= 0) {
+    // Only a two-cycle whose guess barely moved is periodic; every other
+    // repeat is an ordinary loop over guesses.
+    const i64 two =
+        cycle == iter - 2 &&
+        sdsge_occbin_regime_move(hist + (iter - 1) * T_cap, mask, *T,
+                                 run->n_constraint) <=
+            run->opts.periodic_threshold;
+    code = two ? SDSGE_OCCBIN_PERIODIC : SDSGE_OCCBIN_PERIODIC_LOOP;
+  } else if (changed) {
+    code = SDSGE_OCCBIN_MAXITER;
+  }
+  if (code == SDSGE_OCCBIN_PERIOD_OK) {
+    return code;
+  }
+
+  if (max_iter <= run->opts.algo_truncation) {
+    // Truncated on purpose: rule and path already belong to the last guess.
+    *T = hist_len[iter - 1];
+    memcpy(mask, hist + (iter - 1) * T_cap, *T);
+    return SDSGE_OCCBIN_PERIOD_OK;
+  }
+  if (!run->opts.periodic_solution) {
+    return code;
+  }
+
+  // A strict two-cycle weighs only the pair that repeats. A loop is weighed
+  // over every guess, and only when the strictness flag lets it through.
+  i64 lo;
+  if (code == SDSGE_OCCBIN_PERIODIC) {
+    lo = iter - 2;
+  } else if (!run->opts.periodic_strict &&
+             sdsge_occbin_promotable(move_hist, binds_hist, iter,
+                                     run->opts.periodic_threshold,
+                                     run->n_constraint)) {
+    lo = 0;
+  } else {
+    return code;
+  }
+
+  // Passes that wanted no new binding date are preferred outright, and a
+  // promoted loop then ranks them by how little the guess moved.
+  i64 clean = 0;
+  for (i64 k = lo; k < iter; ++k) {
+    clean |= !binds_hist[k];
+  }
+  const i64 by_move = code != SDSGE_OCCBIN_PERIODIC && clean;
+
+  i64 best = -1;
+  for (i64 k = lo; k < iter; ++k) {
+    if (clean && binds_hist[k]) {
+      continue;
+    }
+    if (best < 0 || (by_move ? move_hist[k] < move_hist[best]
+                             : err_hist[k] < err_hist[best])) {
+      best = k;
+    }
+  }
+
+  *T = hist_len[best];
+  memcpy(mask, hist + best * T_cap, *T);
+  if (best != iter - 1) {
+    // rule and path still describe the last guess tried, not this one.
+    i64 status = sdsge_occbin_recursion(run->model, mask, *T, rule,
+                                        &diag->singular_date, rec, iarena);
+    if (status != SDSGE_OCCBIN_RECURSION_OK) {
+      return status;
+    }
+    sdsge_occbin_forward(rule, x0, *T, n_var, n_state, path);
+  }
+  diag->max_err[s] = err_hist[best];
+  diag->periodic[s] = (i8)code;
+  return SDSGE_OCCBIN_PERIOD_OK;
 }
 
 /* Extend a relaxed path by one date: x_T = p x_{T-1}, then u_T = f x_T. Kept
@@ -249,9 +449,10 @@ arena_size sdsge_occbin_solve_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
 }
 
 i64 sdsge_occbin_solve(const occbin_run_ctx *run, const f64 *shocks, i64 S,
-                       i64 n_periods, const f64 *x_init, f64 *out, i8 *regimes,
-                       i64 *T_used, occbin_diag *diag, f64 *rule, f64 *path,
-                       i8 *mask, f64 *arena, i64 *iarena) {
+                       i64 n_periods, const f64 *x_init, const i8 *init_mask,
+                       f64 *out, i8 *regimes, i64 *T_used, occbin_diag *diag,
+                       f64 *rule, f64 *path, i8 *mask, f64 *arena,
+                       i64 *iarena) {
   const i64 n_var = run->model->n_var;
   const i64 n_state = run->model->n_state;
   const i64 n_rhs = n_state + 1;
@@ -263,7 +464,11 @@ i64 sdsge_occbin_solve(const occbin_run_ctx *run, const f64 *shocks, i64 S,
   diag->fail_period = -1;
   diag->singular_date = -1;
 
-  memset(mask, 0, T);
+  if (init_mask != NULL) {
+    memcpy(mask, init_mask, T);
+  } else {
+    memset(mask, 0, T);
+  }
   memset(path, 0, T * n_var * sizeof(f64));
   memcpy(x, x_init, n_state * sizeof(f64));
 
@@ -284,6 +489,7 @@ i64 sdsge_occbin_solve(const occbin_run_ctx *run, const f64 *shocks, i64 S,
       // shifted onto this period, still describe it.
       diag->iters[s] = 0;
       diag->max_err[s] = 0.0;
+      diag->periodic[s] = 0;
     }
 
     memcpy(out + s * n_var, path, n_var * sizeof(f64));

--- a/SymbolicDSGE/_ckernels/occbin/occbin.h
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.h
@@ -4,15 +4,16 @@
 #include "../_common/sdsge_common.h"
 #include "regime_pencil.h"
 
-typedef void (*sdsge_constraint_fn)(f64 *cur, f64 *par, i8 *flags);
+typedef void (*sdsge_constraint_fn)(f64 *cur, f64 *par, f64 *err);
 
 i64 sdsge_constraint_path(sdsge_constraint_fn cond,
                           f64 *SDSGE_RESTRICT path, // (T, n_var)
                           f64 *SDSGE_RESTRICT par,  // (n_par,)
                           const i8 *regime_in,      // (T,)
                           i8 *regime_out,           // (T,)
-                          i64 T, i64 n_var, i64 n_constraint);
-
+                          i64 inclusive, // Bitmask for inequality strictness
+                          f64 *SDSGE_RESTRICT max_err, i64 T, i64 n_var,
+                          i64 n_constraint);
 typedef struct {
   const regime_ctx *table;
   const f64 *f_ref;

--- a/SymbolicDSGE/_ckernels/occbin/occbin.h
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.h
@@ -23,6 +23,16 @@ typedef struct {
 } occbin_ctx;
 
 typedef struct {
+  i64 periodic_solution;  // accept the best iteration instead of failing
+  i64 periodic_threshold; // largest signed move in binding dates still a cycle
+  i64 periodic_strict;    // a repeat that is not a two-cycle is a failure
+  i64 curb_retrench;      // relax one date per pass instead of all of them
+  i64 reset_regime;       // start each shock period from the relaxed guess
+  i64 reset_check_ahead;  // a reset drops an endogenously grown horizon to T0
+  i64 algo_truncation;    // a max_iter at or below this accepts the last guess
+} occbin_opts;
+
+typedef struct {
   const occbin_ctx *model;
   sdsge_constraint_fn cond;
   f64 *par;
@@ -33,11 +43,13 @@ typedef struct {
   i64 T0; // Check ahead + 1 (additional period to append a relaxing regime if T
           // terminates in a binding regime)
   i64 T_cap;
+  occbin_opts opts;
 } occbin_run_ctx;
 
 typedef struct {
   i64 *iters;
   f64 *max_err;
+  i8 *periodic;
   i64 fail_period;
   i64 singular_date;
 } occbin_diag;
@@ -60,6 +72,7 @@ arena_size sdsge_occbin_period_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
                                           i64 T_cap, i64 max_iter);
 
 // `mask`, `T` and `path` are updated in place; `diag` is written at slot `s`.
+// Requires `max_iter >= 1`: the guess is read once before anything is weighed.
 i64 sdsge_occbin_period(const occbin_run_ctx *run,
                         const f64 *SDSGE_RESTRICT x0, // (n_state,)
                         i8 *mask,                     // (T_cap,)
@@ -69,15 +82,17 @@ i64 sdsge_occbin_period(const occbin_run_ctx *run,
 arena_size sdsge_occbin_solve_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
                                          i64 T_cap, i64 max_iter);
 
-// Requires `T0 >= 2` and `n_periods - S <= T0`.
+// Requires `T0 >= 2` and `n_periods - S <= T0`. `init_mask` is a `(T0,)` guess
+// for the first period, or NULL to start relaxed.
 i64 sdsge_occbin_solve(const occbin_run_ctx *run,
                        const f64 *shocks, // (S, n_state)
                        i64 S, i64 n_periods,
                        const f64 *x_init, // (n_state,)
+                       const i8 *init_mask,
                        f64 *out,          // (n_periods, n_var)
                        i8 *regimes,       // (S, T_cap)
                        i64 *T_used,       // (S,)
-                       occbin_diag *diag, // iters and max_err are (S,)
+                       occbin_diag *diag, // per-period arrays are (S,)
                        f64 *rule,         // (T_cap, n_var, n_state + 1) scratch
                        f64 *path,         // (T_cap, n_var) scratch
                        i8 *mask,          // (T_cap,) scratch
@@ -86,11 +101,11 @@ i64 sdsge_occbin_solve(const occbin_run_ctx *run,
 #define SDSGE_OCCBIN_RECURSION_OK 0
 #define SDSGE_OCCBIN_RECURSION_SINGULAR -2 // match code to LU factorization
 
-// return codes matching Dynare's
+// return codes (mapped to Dynare's occbin codes)
 #define SDSGE_OCCBIN_PERIOD_OK 0
-#define SDSGE_OCCBIN_PERIODIC 310
-#define SDSGE_OCCBIN_PERIODIC_LOOP 313
-#define SDSGE_OCCBIN_MAXITER 311
+#define SDSGE_OCCBIN_PERIODIC 1      // 310 in Dynare
+#define SDSGE_OCCBIN_PERIODIC_LOOP 2 // 313 in Dynare
+#define SDSGE_OCCBIN_MAXITER 3       // 311 in Dynare
 
 #define SDSGE_OCCBIN_SOLVE_OK 0
 

--- a/SymbolicDSGE/_ckernels/occbin/occbin.h
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.h
@@ -2,6 +2,7 @@
 #define SDSGE_OCCBIN_H
 
 #include "../_common/sdsge_common.h"
+#include "regime_pencil.h"
 
 typedef void (*sdsge_constraint_fn)(f64 *cur, f64 *par, i8 *flags);
 
@@ -11,5 +12,26 @@ i64 sdsge_constraint_path(sdsge_constraint_fn cond,
                           const i8 *regime_in,      // (T,)
                           i8 *regime_out,           // (T,)
                           i64 T, i64 n_var, i64 n_constraint);
+
+typedef struct {
+  const regime_ctx *table;
+  const f64 *f_ref;
+  i64 n_var;
+  i64 n_state;
+  i64 n_ctrl;
+} occbin_ctx;
+
+arena_size sdsge_occbin_recursion_arena_size(i64 n_var, i64 n_state,
+                                             i64 n_ctrl);
+
+i64 sdsge_occbin_recursion(
+    const occbin_ctx *ctx, const i8 *SDSGE_RESTRICT mask, i64 T,
+    f64 *SDSGE_RESTRICT out, // (T, n_var, n_state + 1)
+    i64 *SDSGE_RESTRICT
+        singular_date, // `t` if the recursion is singular, -1 otherwise
+    f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena);
+
+#define SDSGE_OCCBIN_RECURSION_OK 0
+#define SDSGE_OCCBIN_RECURSION_SINGULAR -2 // match code to LU factorization
 
 #endif // SDSGE_OCCBIN_H

--- a/SymbolicDSGE/_ckernels/occbin/occbin.h
+++ b/SymbolicDSGE/_ckernels/occbin/occbin.h
@@ -22,6 +22,26 @@ typedef struct {
   i64 n_ctrl;
 } occbin_ctx;
 
+typedef struct {
+  const occbin_ctx *model;
+  sdsge_constraint_fn cond;
+  f64 *par;
+  const f64 *ss; // (n_var,) reference steady state; the cfunc reads levels
+  i64 inclusive;
+  i64 n_constraint;
+  i64 max_iter; // Dynare default == 30
+  i64 T0; // Check ahead + 1 (additional period to append a relaxing regime if T
+          // terminates in a binding regime)
+  i64 T_cap;
+} occbin_run_ctx;
+
+typedef struct {
+  i64 *iters;
+  f64 *max_err;
+  i64 fail_period;
+  i64 singular_date;
+} occbin_diag;
+
 arena_size sdsge_occbin_recursion_arena_size(i64 n_var, i64 n_state,
                                              i64 n_ctrl);
 
@@ -32,7 +52,46 @@ i64 sdsge_occbin_recursion(
         singular_date, // `t` if the recursion is singular, -1 otherwise
     f64 *SDSGE_RESTRICT arena, i64 *SDSGE_RESTRICT iarena);
 
+void sdsge_occbin_forward(const f64 *SDSGE_RESTRICT rule,
+                          const f64 *SDSGE_RESTRICT x0, i64 T, i64 n_var,
+                          i64 n_state, f64 *SDSGE_RESTRICT path);
+
+arena_size sdsge_occbin_period_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                          i64 T_cap, i64 max_iter);
+
+// `mask`, `T` and `path` are updated in place; `diag` is written at slot `s`.
+i64 sdsge_occbin_period(const occbin_run_ctx *run,
+                        const f64 *SDSGE_RESTRICT x0, // (n_state,)
+                        i8 *mask,                     // (T_cap,)
+                        i64 *T, f64 *rule, f64 *path, occbin_diag *diag, i64 s,
+                        f64 *arena, i64 *iarena);
+
+arena_size sdsge_occbin_solve_arena_size(i64 n_var, i64 n_state, i64 n_ctrl,
+                                         i64 T_cap, i64 max_iter);
+
+// Requires `T0 >= 2` and `n_periods - S <= T0`.
+i64 sdsge_occbin_solve(const occbin_run_ctx *run,
+                       const f64 *shocks, // (S, n_state)
+                       i64 S, i64 n_periods,
+                       const f64 *x_init, // (n_state,)
+                       f64 *out,          // (n_periods, n_var)
+                       i8 *regimes,       // (S, T_cap)
+                       i64 *T_used,       // (S,)
+                       occbin_diag *diag, // iters and max_err are (S,)
+                       f64 *rule,         // (T_cap, n_var, n_state + 1) scratch
+                       f64 *path,         // (T_cap, n_var) scratch
+                       i8 *mask,          // (T_cap,) scratch
+                       f64 *arena, i64 *iarena);
+
 #define SDSGE_OCCBIN_RECURSION_OK 0
 #define SDSGE_OCCBIN_RECURSION_SINGULAR -2 // match code to LU factorization
+
+// return codes matching Dynare's
+#define SDSGE_OCCBIN_PERIOD_OK 0
+#define SDSGE_OCCBIN_PERIODIC 310
+#define SDSGE_OCCBIN_PERIODIC_LOOP 313
+#define SDSGE_OCCBIN_MAXITER 311
+
+#define SDSGE_OCCBIN_SOLVE_OK 0
 
 #endif // SDSGE_OCCBIN_H

--- a/SymbolicDSGE/_symbolic_printers/constraint_printer.py
+++ b/SymbolicDSGE/_symbolic_printers/constraint_printer.py
@@ -1,4 +1,14 @@
-"""Constraint expression printers for native regime callbacks."""
+"""Constraint expression printers for native regime callbacks.
+
+A condition is printed as its signed distance to its own boundary, positive
+where the condition holds, rather than as a 0/1 flag. The native latch recovers
+the flag from the sign, so the two can never disagree, and the same number is
+the error the guess-and-verify loop ranks its iterations by.
+
+Only the boundary itself is lost that way: ``x < 0`` and ``x <= 0`` are the same
+distance and differ only at zero. That is static, so it travels once as
+``inclusive`` rather than per evaluation.
+"""
 
 from __future__ import annotations
 
@@ -14,61 +24,37 @@ from .measurement_printer import F64Ops
 
 
 class ConstraintOpTable(OpTable, Protocol):
-    """Op table extended with the comparisons and connectives conditions need."""
+    """Op table extended with the connectives a distance folds over."""
 
-    def lt(self, a: str, b: str) -> str: ...
-    def le(self, a: str, b: str) -> str: ...
-    def gt(self, a: str, b: str) -> str: ...
-    def ge(self, a: str, b: str) -> str: ...
-    def eq(self, a: str, b: str) -> str: ...
-    def ne(self, a: str, b: str) -> str: ...
-    def and_(self, a: str, b: str) -> str: ...
-    def or_(self, a: str, b: str) -> str: ...
-    def not_(self, a: str) -> str: ...
+    def min_(self, a: str, b: str) -> str: ...
+    def max_(self, a: str, b: str) -> str: ...
 
 
 class ConstraintOps(F64Ops, ConstraintOpTable):
-    """Real valued backend emitting 0/1 regime flags."""
+    """Real valued backend emitting the distance to each boundary."""
 
-    def lt(self, a: str, b: str) -> str:
-        return f"({a} < {b})"
+    def min_(self, a: str, b: str) -> str:
+        return f"min({a}, {b})"
 
-    def le(self, a: str, b: str) -> str:
-        return f"({a} <= {b})"
-
-    def gt(self, a: str, b: str) -> str:
-        return f"({a} > {b})"
-
-    def ge(self, a: str, b: str) -> str:
-        return f"({a} >= {b})"
-
-    def eq(self, a: str, b: str) -> str:
-        return f"({a} == {b})"
-
-    def ne(self, a: str, b: str) -> str:
-        return f"({a} != {b})"
-
-    def and_(self, a: str, b: str) -> str:
-        return f"({a} and {b})"
-
-    def or_(self, a: str, b: str) -> str:
-        return f"({a} or {b})"
-
-    def not_(self, a: str) -> str:
-        return f"(not {a})"
-
-    def store(self, buf: str, idx: int, expr: str) -> str:
-        return f"{buf}[{idx}] = 1 if {expr} else 0"
+    def max_(self, a: str, b: str) -> str:
+        return f"max({a}, {b})"
 
 
-#: Relational node types mapped to the op that renders them.
+#: Relational node types mapped to the op that renders their distance, oriented
+#: so that a satisfied condition is positive. An equality has no distance.
 _RELATIONAL_OPS: dict[type, Callable[[ConstraintOpTable, str, str], str]] = {
-    sp.StrictLessThan: lambda ops, a, b: ops.lt(a, b),
-    sp.LessThan: lambda ops, a, b: ops.le(a, b),
-    sp.StrictGreaterThan: lambda ops, a, b: ops.gt(a, b),
-    sp.GreaterThan: lambda ops, a, b: ops.ge(a, b),
-    sp.Equality: lambda ops, a, b: ops.eq(a, b),
-    sp.Unequality: lambda ops, a, b: ops.ne(a, b),
+    sp.StrictLessThan: lambda ops, a, b: ops.sub(b, a),
+    sp.LessThan: lambda ops, a, b: ops.sub(b, a),
+    sp.StrictGreaterThan: lambda ops, a, b: ops.sub(a, b),
+    sp.GreaterThan: lambda ops, a, b: ops.sub(a, b),
+}
+
+#: Whether each relational holds *at* its boundary, where the distance is zero.
+_RELATIONAL_INCLUSIVE: dict[type, bool] = {
+    sp.StrictLessThan: False,
+    sp.LessThan: True,
+    sp.StrictGreaterThan: False,
+    sp.GreaterThan: True,
 }
 
 
@@ -82,12 +68,13 @@ class ConstraintLayout:
     constraint_names: tuple[str, ...] = ()
 
     @property
-    def n_flag(self) -> int:
+    def n_cond(self) -> int:
+        """Distances written per call: bind then relax, per constraint."""
         return 2 * len(self.constraint_names)
 
     @property
     def n_expr(self) -> int:
-        return self.n_flag
+        return self.n_cond
 
     @classmethod
     def from_compiled(
@@ -113,7 +100,7 @@ class ConstraintPrinter(ExpressionPrinter):
 
     @property
     def allocated_dtype(self) -> str:
-        return "np.int8"
+        return "np.float64"
 
     @property
     def context_name(self) -> str:
@@ -124,12 +111,19 @@ class ConstraintPrinter(ExpressionPrinter):
         if render_op is not None:
             lhs, rhs = expr.args
             return render_op(self.cops, self.render(lhs), self.render(rhs))
+        # A connective is as satisfied as its least satisfied branch, or its
+        # most satisfied one, which is the same fold the flags would have taken.
         if isinstance(expr, sp.And):
-            return self._fold(expr.args, self.cops.and_)
+            return self._fold(expr.args, self.cops.min_)
         if isinstance(expr, sp.Or):
-            return self._fold(expr.args, self.cops.or_)
+            return self._fold(expr.args, self.cops.max_)
         if isinstance(expr, sp.Not):
-            return self.cops.not_(self.render(expr.args[0]))
+            return self.cops.neg(self.render(expr.args[0]))
+        if isinstance(expr, sp.Rel):
+            raise NotImplementedError(
+                f"constraint printer: {type(expr).__name__} has no distance to "
+                f"a boundary: {expr}"
+            )
         return super().render(expr)
 
     def _fold(self, args: Any, op: Callable[[str, str], str]) -> str:
@@ -139,15 +133,51 @@ class ConstraintPrinter(ExpressionPrinter):
         return result
 
 
+def constraint_inclusive(exprs: list[Any]) -> int:
+    """Bitmask of the conditions that hold at a distance of exactly zero.
+
+    Bit ``k`` is slot ``k`` of the distance buffer. A connective's branches must
+    agree, since either of them can be the one the fold selected.
+    """
+    mask = 0
+    for k, expr in enumerate(exprs):
+        mask |= int(_inclusive(expr)) << k
+    return mask
+
+
+def _inclusive(expr: Any) -> bool:
+    at_boundary = _RELATIONAL_INCLUSIVE.get(type(expr))
+    if at_boundary is not None:
+        return at_boundary
+    if isinstance(expr, (sp.And, sp.Or)):
+        branches = {_inclusive(arg) for arg in expr.args}
+        if len(branches) != 1:
+            raise NotImplementedError(
+                f"constraint printer: {type(expr).__name__} mixes strict and "
+                f"inclusive comparisons, so its boundary is ambiguous: {expr}"
+            )
+        return branches.pop()
+    if isinstance(expr, sp.Not):
+        return not _inclusive(expr.args[0])
+    raise NotImplementedError(
+        f"constraint printer: {type(expr).__name__} has no boundary: {expr}"
+    )
+
+
 def build_constraint_cfunc(
     exprs: list[Any], layout: ConstraintLayout, ops: ConstraintOpTable | None = None
-) -> Any:
+) -> tuple[Any, int]:
+    """``(cfunc, inclusive)`` for the conditions, in bind/relax slot order.
+
+    The cfunc writes ``layout.n_cond`` distances. ``inclusive`` carries the one
+    thing their sign cannot: which conditions hold when the distance is zero.
+    """
     table: ConstraintOpTable = ConstraintOps() if ops is None else ops
     body = ConstraintPrinter(table).emit(exprs, layout, allocate=False)
     preamble = [
         f"    cur = carray(cur_ptr, ({layout.n_var},))",
         f"    par = carray(par_ptr, ({layout.n_par},))",
-        f"    out = carray(out_ptr, ({layout.n_flag},))",
+        f"    out = carray(out_ptr, ({layout.n_cond},))",
     ]
     src = "\n".join(
         [
@@ -165,6 +195,6 @@ def build_constraint_cfunc(
     sig = types.void(
         types.CPointer(types.float64),
         types.CPointer(types.float64),
-        types.CPointer(types.int8),
+        types.CPointer(types.float64),
     )
-    return cfunc(sig)(ns["_constraint_cf"])
+    return cfunc(sig)(ns["_constraint_cf"]), constraint_inclusive(exprs)

--- a/SymbolicDSGE/core/compiled_model.py
+++ b/SymbolicDSGE/core/compiled_model.py
@@ -66,10 +66,16 @@ class VariableLayout:
 class ConstraintFunc:
     """Compiled regime conditions, and everything the native side needs to call them.
 
-    One cfunc evaluates every condition, writing ``2 * n_constraint`` int8 flags:
-    slot ``2i`` is constraint ``i`` binding, slot ``2i + 1`` is it relaxing. The
-    C caller selects with ``next = prev ? !relax : bind``, so both flags of a
-    constraint come from a single call and share their common subexpressions.
+    One cfunc evaluates every condition, writing ``2 * n_constraint`` signed
+    distances to their boundaries, positive where the condition holds: slot
+    ``2i`` is constraint ``i`` binding, slot ``2i + 1`` is it relaxing. The C
+    caller reads the sign of the one slot the incoming regime asks about, with
+    ``next = prev ? !relax : bind``, and takes the same number as the error that
+    ranks guess-and-verify iterations.
+
+    ``inclusive`` is the bitmask of slots that hold at a distance of exactly
+    zero, the only thing a sign cannot say and the reason ``x < 0`` and ``x <=
+    0`` are distinguishable at the steady state, where they are both zero.
 
     ``names`` is declaration order, which is the regime bit order.
     """
@@ -78,11 +84,12 @@ class ConstraintFunc:
     names: tuple[str, ...]
     n_var: int
     n_par: int
+    inclusive: int
 
     @property
     def address(self) -> int:
         """Entry point of
-        ``void (*)(const double *cur, const double *par, int8_t *flags)``."""
+        ``void (*)(const double *cur, const double *par, double *err)``."""
         return int(self.cfunc.address)
 
     @property
@@ -90,7 +97,7 @@ class ConstraintFunc:
         return len(self.names)
 
     @property
-    def n_flag(self) -> int:
+    def n_cond(self) -> int:
         return 2 * len(self.names)
 
     def bind_slot(self, name: str) -> int:
@@ -265,11 +272,13 @@ class CompiledModel:
         if not self.constraint_names:
             return None
         layout = ConstraintLayout.from_compiled(self, self.constraint_names)
+        cfunc, inclusive = build_constraint_cfunc(self.constraint_exprs, layout)
         return ConstraintFunc(
-            cfunc=build_constraint_cfunc(self.constraint_exprs, layout),
+            cfunc=cfunc,
             names=self.constraint_names,
             n_var=layout.n_var,
             n_par=layout.n_par,
+            inclusive=inclusive,
         )
 
     def construct_constraint_func(self) -> ConstraintFunc | None:

--- a/tests/ckernels/test_constraint_path.py
+++ b/tests/ckernels/test_constraint_path.py
@@ -73,36 +73,55 @@ def _path(compiled, rows):
     return out
 
 
-def _flags(cf, cur, par):
-    """The raw bind/relax flags, straight off the cfunc, bypassing the driver."""
+def _err(cf, cur, par):
+    """The raw bind/relax distances, straight off the cfunc, no driver."""
     fn = ctypes.CFUNCTYPE(
         None,
         ctypes.POINTER(ctypes.c_double),
         ctypes.POINTER(ctypes.c_double),
-        ctypes.POINTER(ctypes.c_int8),
+        ctypes.POINTER(ctypes.c_double),
     )(cf.address)
     cur = np.ascontiguousarray(cur, dtype=np.float64)
     par = np.ascontiguousarray(par, dtype=np.float64)
-    out = np.zeros(cf.n_flag, dtype=np.int8)
+    out = np.zeros(cf.n_cond, dtype=np.float64)
     fn(
         cur.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
         par.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        out.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+        out.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
     )
     return out
 
 
+def _holds(cf, slot, err):
+    """A distance decides its condition by sign; zero decides by strictness."""
+    return err > 0.0 or (err == 0.0 and bool((cf.inclusive >> slot) & 1))
+
+
+def _flags(cf, cur, par):
+    """The 0/1 conditions the latch reads off those distances."""
+    return [int(_holds(cf, k, e)) for k, e in enumerate(_err(cf, cur, par))]
+
+
 def _oracle(cf, path, par, regime_in):
-    """``next = prev ? !relax : bind``, per constraint, per period, in Python."""
+    """``next = prev ? !relax : bind``, per constraint, per period, in Python.
+
+    A bit moves exactly when the one condition its incoming state asks about
+    holds, so that condition's distance is the error the move is worth.
+    """
     out = np.empty(len(path), dtype=np.int8)
+    worst = 0.0
     for i, row in enumerate(path):
-        flags = _flags(cf, row, par)
+        err = _err(cf, row, par)
         prev, nxt = int(regime_in[i]), 0
         for c in range(cf.n_constraint):
-            on = (not flags[2 * c + 1]) if (prev >> c) & 1 else flags[2 * c]
-            nxt |= int(bool(on)) << c
+            binding = (prev >> c) & 1
+            slot = 2 * c + 1 if binding else 2 * c
+            fired = _holds(cf, slot, err[slot])
+            nxt |= int(not fired if binding else fired) << c
+            if fired:
+                worst = max(worst, abs(err[slot]))
         out[i] = nxt
-    return out
+    return out, worst
 
 
 def test_fixture_conditions_are_not_complements(compiled, par):
@@ -115,6 +134,41 @@ def test_fixture_conditions_are_not_complements(compiled, par):
 
     assert (dead[0], dead[1]) == (0, 0)
     assert (both[2], both[3]) == (1, 1)
+
+
+def test_a_strict_condition_misses_its_own_boundary(compiled, par):
+    # Every condition here is written strict, so a distance of exactly zero is
+    # a miss. Nothing but `inclusive` separates that from a hit.
+    cf = compiled.construct_constraint_func()
+    assert cf.inclusive == 0
+    row = _path(compiled, [(1.0, 1.0)])[0]
+
+    err = _err(cf, row, par)
+
+    # band relaxes on g > 1 and over binds on z < 1, both sitting on 1.0.
+    assert (err[1], err[2]) == (0.0, 0.0)
+    assert _flags(cf, row, par) == [0, 0, 0, 1]
+
+
+def test_max_err_is_the_distance_of_the_condition_that_moved(compiled, par):
+    # band relaxes on g > 1, so a period entering bound at g = 2.5 moves on a
+    # distance of 1.5. over is consulted on its bind condition and misses, so
+    # its own distance never enters.
+    cf = compiled.construct_constraint_func()
+    path = _path(compiled, [(2.5, OVER_OFF)])
+
+    out, changed, max_err = constraint_path(
+        cf.address,
+        path,
+        par,
+        np.array([BAND], dtype=np.int8),
+        cf.n_constraint,
+        cf.inclusive,
+    )
+
+    assert out.tolist() == [0b00]
+    assert changed == 1
+    assert max_err == 1.5
 
 
 @pytest.mark.parametrize(
@@ -131,8 +185,13 @@ def test_latch_resolves_each_incoming_bit(compiled, par, regime_in, expected):
     cf = compiled.construct_constraint_func()
     path = _path(compiled, [(BAND_DEAD, OVER_BOTH)])
 
-    out, changed = constraint_path(
-        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    out, changed, _ = constraint_path(
+        cf.address,
+        path,
+        par,
+        np.array([regime_in], dtype=np.int8),
+        cf.n_constraint,
+        cf.inclusive,
     )
 
     assert out.tolist() == [expected]
@@ -145,8 +204,13 @@ def test_deadband_holds_the_incoming_bit(compiled, par, regime_in):
     cf = compiled.construct_constraint_func()
     path = _path(compiled, [(BAND_DEAD, OVER_OFF)])
 
-    out, changed = constraint_path(
-        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    out, changed, _ = constraint_path(
+        cf.address,
+        path,
+        par,
+        np.array([regime_in], dtype=np.int8),
+        cf.n_constraint,
+        cf.inclusive,
     )
 
     assert out.tolist() == [regime_in]
@@ -159,8 +223,13 @@ def test_overlap_toggles_the_incoming_bit(compiled, par, regime_in, expected):
     cf = compiled.construct_constraint_func()
     path = _path(compiled, [(BAND_OFF, OVER_BOTH)])
 
-    out, changed = constraint_path(
-        cf.address, path, par, np.array([regime_in], dtype=np.int8), cf.n_constraint
+    out, changed, _ = constraint_path(
+        cf.address,
+        path,
+        par,
+        np.array([regime_in], dtype=np.int8),
+        cf.n_constraint,
+        cf.inclusive,
     )
 
     assert out.tolist() == [expected]
@@ -172,10 +241,14 @@ def test_fixed_point_reports_no_change(compiled, par):
     path = _path(compiled, [(BAND_ON, OVER_OFF)] * 6)
     regime_in = np.full(6, BAND, dtype=np.int8)
 
-    out, changed = constraint_path(cf.address, path, par, regime_in, cf.n_constraint)
+    out, changed, max_err = constraint_path(
+        cf.address, path, par, regime_in, cf.n_constraint, cf.inclusive
+    )
 
     assert out.tolist() == [BAND] * 6
     assert changed == 0
+    # Nothing moved, so no condition contributed a distance.
+    assert max_err == 0.0
 
 
 def test_changed_counts_only_the_periods_that_moved(compiled, par):
@@ -183,8 +256,13 @@ def test_changed_counts_only_the_periods_that_moved(compiled, par):
     rows = [(BAND_ON, OVER_OFF)] * 5 + [(BAND_OFF, OVER_OFF)] * 2
     regime_in = np.full(len(rows), BAND, dtype=np.int8)
 
-    out, changed = constraint_path(
-        cf.address, _path(compiled, rows), par, regime_in, cf.n_constraint
+    out, changed, _ = constraint_path(
+        cf.address,
+        _path(compiled, rows),
+        par,
+        regime_in,
+        cf.n_constraint,
+        cf.inclusive,
     )
 
     assert out.tolist() == [BAND] * 5 + [0b00] * 2
@@ -200,13 +278,14 @@ def test_matches_a_python_latch_over_random_paths(compiled, par):
         path = _path(compiled, rows)
         regime_in = rng.integers(0, 4, 40).astype(np.int8)
 
-        out, changed = constraint_path(
-            cf.address, path, par, regime_in, cf.n_constraint
+        out, changed, max_err = constraint_path(
+            cf.address, path, par, regime_in, cf.n_constraint, cf.inclusive
         )
-        want = _oracle(cf, path, par, regime_in)
+        want, want_err = _oracle(cf, path, par, regime_in)
 
         assert out.tolist() == want.tolist()
         assert changed == int((want != regime_in).sum())
+        assert max_err == want_err
 
 
 def test_latches_in_place_when_out_aliases_regime_in(compiled, par):
@@ -216,40 +295,49 @@ def test_latches_in_place_when_out_aliases_regime_in(compiled, par):
     path = _path(compiled, rows)
     regime_in = rng.integers(0, 4, 32).astype(np.int8)
 
-    fresh, fresh_changed = constraint_path(
-        cf.address, path, par, regime_in, cf.n_constraint
+    fresh, fresh_changed, fresh_err = constraint_path(
+        cf.address, path, par, regime_in, cf.n_constraint, cf.inclusive
     )
     buf = regime_in.copy()
-    same, same_changed = constraint_path(
-        cf.address, path, par, buf, cf.n_constraint, out=buf
+    same, same_changed, same_err = constraint_path(
+        cf.address, path, par, buf, cf.n_constraint, cf.inclusive, out=buf
     )
 
     assert same is buf
     assert same.tolist() == fresh.tolist()
     assert same_changed == fresh_changed
+    assert same_err == fresh_err
 
 
 def test_empty_path_is_a_no_op(compiled, par):
     cf = compiled.construct_constraint_func()
     path = np.zeros((0, len(compiled.var_names)), dtype=np.float64)
 
-    out, changed = constraint_path(
-        cf.address, path, par, np.zeros(0, dtype=np.int8), cf.n_constraint
+    out, changed, max_err = constraint_path(
+        cf.address, path, par, np.zeros(0, dtype=np.int8), cf.n_constraint, cf.inclusive
     )
 
     assert out.shape == (0,)
     assert changed == 0
+    assert max_err == 0.0
 
 
 @pytest.mark.parametrize("n_constraint", [0, -1, MAX_CONSTRAINTS + 1])
-def test_rejects_a_constraint_count_the_flag_buffer_cannot_hold(
+def test_rejects_a_constraint_count_the_distance_buffer_cannot_hold(
     compiled, par, n_constraint
 ):
     cf = compiled.construct_constraint_func()
     path = _path(compiled, [(0.0, 0.0)])
 
     with pytest.raises(ValueError, match="n_constraint"):
-        constraint_path(cf.address, path, par, np.zeros(1, dtype=np.int8), n_constraint)
+        constraint_path(
+            cf.address,
+            path,
+            par,
+            np.zeros(1, dtype=np.int8),
+            n_constraint,
+            cf.inclusive,
+        )
 
 
 def test_rejects_a_regime_length_that_does_not_match_the_path(compiled, par):
@@ -258,5 +346,10 @@ def test_rejects_a_regime_length_that_does_not_match_the_path(compiled, par):
 
     with pytest.raises(ValueError, match="regime_in has length"):
         constraint_path(
-            cf.address, path, par, np.zeros(2, dtype=np.int8), cf.n_constraint
+            cf.address,
+            path,
+            par,
+            np.zeros(2, dtype=np.int8),
+            cf.n_constraint,
+            cf.inclusive,
         )

--- a/tests/ckernels/test_occbin_recursion.py
+++ b/tests/ckernels/test_occbin_recursion.py
@@ -1,0 +1,277 @@
+# type: ignore
+"""Native ``occbin_recursion``: backward decision rules for a regime guess.
+
+The rules are checked against the pencils they were built from rather than
+against a stored path. Each block is the affine map from ``x_t`` to ``[x_{t+1};
+u_t]``, so substituting it back into ``a y_{t+1} = b y_t - c`` is an identity in
+``x_t``, which a residual on the ``(n_var, n_state + 1)`` block tests directly
+and without an oracle. The date-``T`` closure is the same substitution with
+``f_ref`` and a zero constant.
+
+The fixture is the levels RBC of ``test_regime_pencil``, whose binding regime
+carries a nonzero constant. A gap model would pass the constant column for free.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+
+import numpy as np
+import pytest
+import sympy as sp
+
+from SymbolicDSGE._ckernels.core import klein_solve1
+from SymbolicDSGE._ckernels.occbin import (
+    occbin_recursion,
+    occbin_recursion_arena_size,
+    regime_pencil,
+)
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from SymbolicDSGE.core.config import Constraint
+
+t = sp.Symbol("t", integer=True)
+
+LOW = 0b1
+
+# A binding run, a relapse, and a relaxed tail; the all-binding case is separate.
+MIXED = np.array([0, 1, 1, 1, 0, 1, 1, 0, 0, 0], dtype=np.int8)
+
+
+@pytest.fixture(scope="module")
+def compiled(rbc_second_order_test_model_path):
+    """Levels RBC where a bad-TFP regime shuts investment off."""
+    model, kalman = ModelParser(rbc_second_order_test_model_path).get_all()
+    conf = copy.deepcopy(model)
+    _, k, z = conf.variables.variables
+    delta = sp.Symbol("delta")
+
+    conf.equations.constraint = {"low": Constraint(bind=z(t) < 0, relax=z(t) >= 0)}
+    conf.equations.regime = {
+        frozenset({"low"}): {"euler": sp.Eq(k(t + 1), (1 - delta) * k(t))}
+    }
+    return DSGESolver(conf, kalman).compile()
+
+
+@pytest.fixture(scope="module")
+def par(compiled):
+    calib = compiled.config.calibration.parameters
+    return np.array([float(calib[p]) for p in compiled.calib_params])
+
+
+@pytest.fixture(scope="module")
+def solved(compiled, par):
+    """(ss, a_ref, b_ref, f_ref, p_ref) for the reference regime."""
+    seed = DSGESolver._resolve_ss_seed(None, compiled)
+    ss, a_ref, b_ref, f_ref, p_ref, *_ = klein_solve1(
+        compiled.construct_objective_cfunc().address,
+        seed,
+        par,
+        compiled.n_state,
+        compiled.n_exog,
+    )
+    # The whole point of a levels fixture: the expansion point is not the origin.
+    assert np.abs(ss).max() > 1.0
+    return ss, a_ref, b_ref, f_ref, p_ref
+
+
+@pytest.fixture(scope="module")
+def table(compiled, par, solved):
+    """(a, b, c) stacked by bitmask: slot 0 the reference, slot 1 the regime."""
+    ss, a_ref, b_ref, _, _ = solved
+    func = compiled.construct_regime_pencil_func()
+    a_low, b_low, c_low = regime_pencil(
+        func.address(LOW), func.rows[LOW], ss, par, a_ref, b_ref
+    )
+    # The regime is only a test of the constant path if it carries one.
+    assert np.abs(c_low).max() > 0.5
+
+    a = np.stack([a_ref, a_low])
+    b = np.stack([b_ref, b_low])
+    c = np.stack([np.zeros_like(c_low), c_low])
+    return a, b, c
+
+
+def _worst_residual(table, f_ref, mask, out):
+    """max |a y_{t+1} - b y_t + c| over dates, relative to the terms it cancels.
+
+    ``y`` is affine in ``[x_t; 1]``, so every quantity here is an ``(n_var,
+    n_state + 1)`` matrix and the residual is an identity, not a sample.
+    """
+    a, b, c = table
+    T, n_var, n_rhs = out.shape
+    n_state = n_rhs - 1
+    n_ctrl = n_var - n_state
+
+    cur_state = np.zeros((n_state, n_rhs))
+    cur_state[:, :n_state] = np.eye(n_state)
+
+    worst = 0.0
+    for date in range(T):
+        state, ctrl = out[date][:n_state], out[date][n_state:]
+        if date + 1 < T:
+            rule_next = out[date + 1][n_state:]
+        else:
+            rule_next = np.zeros((n_ctrl, n_rhs))
+            rule_next[:, :n_state] = f_ref
+
+        ctrl_next = rule_next[:, :n_state] @ state
+        ctrl_next[:, n_state] += rule_next[:, n_state]
+
+        m = mask[date]
+        lead = a[m] @ np.vstack([state, ctrl_next])
+        lag = b[m] @ np.vstack([cur_state, ctrl])
+        resid = lead - lag
+        resid[:, n_state] += c[m]
+
+        scale = max(np.abs(lead).max(), np.abs(lag).max(), 1.0)
+        worst = max(worst, np.abs(resid).max() / scale)
+    return worst
+
+
+def test_an_all_relaxed_guess_is_the_reference_rule(table, solved):
+    # f_ref seeds the recursion, so the reference rule is its fixed point and
+    # every date reproduces it: a partition or sign error moves this at once.
+    _, _, _, f_ref, p_ref = solved
+    a, b, c = table
+    n_state = f_ref.shape[1]
+
+    out = occbin_recursion(a, b, c, np.zeros(6, dtype=np.int8), f_ref)
+
+    for date in range(out.shape[0]):
+        np.testing.assert_allclose(out[date][:n_state, :n_state], p_ref, atol=1e-8)
+        np.testing.assert_allclose(out[date][n_state:, :n_state], f_ref, atol=1e-8)
+    # Exact: a zero constant column never leaves zero through the LU solve.
+    np.testing.assert_array_equal(out[:, :, n_state], np.zeros(out.shape[:2]))
+
+
+def test_every_block_solves_the_pencil_of_its_own_date(table, solved):
+    _, _, _, f_ref, _ = solved
+
+    out = occbin_recursion(*table, MIXED, f_ref)
+
+    assert _worst_residual(table, f_ref, MIXED, out) < 1e-9
+
+
+def test_a_binding_terminal_date_still_closes_on_the_reference_rule(table, solved):
+    # Nothing in the kernel forces the guess to relax before the horizon ends,
+    # and the seed is what the last date binds against.
+    _, _, _, f_ref, _ = solved
+    mask = np.ones(4, dtype=np.int8)
+
+    out = occbin_recursion(*table, mask, f_ref)
+
+    assert _worst_residual(table, f_ref, mask, out) < 1e-9
+
+
+def test_a_binding_date_moves_the_rule_off_the_reference(table, solved):
+    # Guards the residual check above from passing on a kernel that ignores the
+    # mask: the two rules would then agree everywhere.
+    _, _, _, f_ref, _ = solved
+    a, b, c = table
+
+    relaxed = occbin_recursion(a, b, c, np.zeros_like(MIXED), f_ref)
+    mixed = occbin_recursion(a, b, c, MIXED, f_ref)
+
+    binding = np.flatnonzero(MIXED)
+    assert np.abs(mixed[binding] - relaxed[binding]).max() > 1e-6
+    # The affine part is live only where a regime's constant reaches.
+    assert np.abs(mixed[:, :, -1]).max() > 1e-6
+
+
+def test_out_is_written_in_place(table, solved):
+    _, _, _, f_ref, _ = solved
+    a, b, c = table
+    n_var, n_rhs = a.shape[1], f_ref.shape[1] + 1
+    out = np.zeros((MIXED.size, n_var, n_rhs))
+
+    returned = occbin_recursion(a, b, c, MIXED, f_ref, out)
+
+    assert returned is out
+    np.testing.assert_array_equal(out, occbin_recursion(a, b, c, MIXED, f_ref))
+
+
+def test_an_empty_guess_returns_an_empty_stack(table, solved):
+    _, _, _, f_ref, _ = solved
+    a, _, _ = table
+
+    out = occbin_recursion(*table, np.empty(0, dtype=np.int8), f_ref)
+
+    assert out.shape == (0, a.shape[1], f_ref.shape[1] + 1)
+
+
+def test_the_arena_holds_the_pencil_the_rhs_and_the_seed(table, solved):
+    # Three blocks and the pivots. The sizer is the only statement of that
+    # layout the kernel does not make itself, so it is pinned here.
+    _, _, _, f_ref, _ = solved
+    n_ctrl, n_state = f_ref.shape
+    n_var = table[0].shape[1]
+    n_rhs = n_state + 1
+
+    n_float, n_int = occbin_recursion_arena_size(n_var, n_state, n_ctrl)
+
+    assert n_float == n_var * n_var + n_var * n_rhs + n_ctrl * n_rhs
+    assert n_int == n_var
+
+
+def test_the_recursion_stays_inside_its_arena(table, solved):
+    # Sized exactly and followed by sentinels: an overrun lands in the guard
+    # instead of in whatever the live path put after the arena.
+    _, _, _, f_ref, _ = solved
+    n_ctrl, n_state = f_ref.shape
+    n_float, n_int = occbin_recursion_arena_size(table[0].shape[1], n_state, n_ctrl)
+    guard, fill, ifill = 8, -1.5e300, -(2**60)
+
+    arena = np.full(n_float + guard, fill)
+    iarena = np.full(n_int + guard, ifill, dtype=np.int64)
+    out = occbin_recursion(*table, MIXED, f_ref, None, arena, iarena)
+
+    np.testing.assert_array_equal(arena[n_float:], np.full(guard, fill))
+    np.testing.assert_array_equal(iarena[n_int:], np.full(guard, ifill))
+    # Vacuous unless the buffers passed in are the ones the kernel scratched on.
+    assert np.any(arena[:n_float] != fill)
+    np.testing.assert_array_equal(out, occbin_recursion(*table, MIXED, f_ref))
+
+
+def test_a_short_arena_is_rejected(table, solved):
+    _, _, _, f_ref, _ = solved
+    n_ctrl, n_state = f_ref.shape
+    n_float, _ = occbin_recursion_arena_size(table[0].shape[1], n_state, n_ctrl)
+
+    with pytest.raises(ValueError, match="needs"):
+        occbin_recursion(*table, MIXED, f_ref, None, np.empty(n_float - 1))
+
+
+def test_a_singular_date_is_named(table, solved):
+    # The LU is the only failure the recursion can report, and the date is the
+    # single piece of information the caller cannot recover on its own.
+    _, _, _, f_ref, _ = solved
+    a, b, c = table
+    dead = (
+        np.concatenate([a, np.zeros_like(a[:1])]),
+        np.concatenate([b, np.zeros_like(b[:1])]),
+        np.concatenate([c, np.zeros_like(c[:1])]),
+    )
+    mask = np.array([0, 0, 2, 0], dtype=np.int8)
+
+    with pytest.raises(RuntimeError, match=r"singular pencil at date 2\."):
+        occbin_recursion(*dead, mask, f_ref)
+
+
+def test_a_mask_outside_the_table_is_rejected(table, solved):
+    # The kernel indexes table[mask[t]] unguarded, so an out-of-range bit reads
+    # past the regime array instead of raising.
+    _, _, _, f_ref, _ = solved
+    mask = np.array([0, 1, 2, 0], dtype=np.int8)
+
+    with pytest.raises(ValueError, match=re.escape("mask[2] is 2, outside 0..1")):
+        occbin_recursion(*table, mask, f_ref)
+
+
+def test_a_pencil_that_does_not_partition_is_rejected(table, solved):
+    # n_state and n_ctrl come from f_ref alone; if they miss n_var the kernel
+    # splits every row at the wrong column.
+    _, _, _, f_ref, _ = solved
+
+    with pytest.raises(ValueError, match="expected"):
+        occbin_recursion(*table, np.zeros(3, dtype=np.int8), f_ref[:, :-1])

--- a/tests/ckernels/test_occbin_solve.py
+++ b/tests/ckernels/test_occbin_solve.py
@@ -707,7 +707,9 @@ def test_a_reset_drops_a_grown_horizon_only_with_its_companion(table, solved, pa
     # A relaxed tail is the reference rule's own fixed point, so the horizon the
     # period is solved on cannot reach the dates it reports.
     np.testing.assert_array_equal(reset_out, plain_out)
-    np.testing.assert_array_equal(both_out, plain_out)
+    # ``both`` solves the same mask on the shorter horizon, so its relaxed tail
+    # is a few LU steps shorter and the two agree in exact arithmetic only.
+    np.testing.assert_allclose(both_out, plain_out, rtol=1e-12, atol=1e-12)
 
     np.testing.assert_array_equal(reset["T_used"], plain["T_used"])
     np.testing.assert_array_equal(both["T_used"], [plain["T_used"][0], SHORT])

--- a/tests/ckernels/test_occbin_solve.py
+++ b/tests/ckernels/test_occbin_solve.py
@@ -1,0 +1,729 @@
+# type: ignore
+"""Native ``occbin_forward`` and ``occbin_solve``: the path and the shock loop.
+
+The forward pass has an oracle, so it is checked against one. The solve is
+checked three ways here instead. The accepted mask must equal the condition read
+off the path that mask produced, which is what being a fixed point of the latch
+means. The path must equal ``occbin_forward`` over ``occbin_recursion`` on that
+same mask, which ties the driver to the two kernels it is built from. And a
+period with no shock must reproduce, bit for bit, what the period before it
+already projected for that date. Whether the fixed point is the same one Dynare
+lands on is ``tests/core/test_occbin_parity.py``.
+
+The fixture puts the threshold at a nonzero TFP level rather than at zero. With
+``z(t) < 0`` an AR(1) hit decays toward the boundary without ever crossing it,
+so a guess binds to the horizon cap and never settles; a threshold gives a spell
+whose length the model decides. That length is also knowable here: the regime
+replaces the Euler equation only, so TFP is exogenous to the regime and its path
+is the same under every guess.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+
+import numpy as np
+import pytest
+import sympy as sp
+from numba import carray, cfunc, types
+
+from SymbolicDSGE._ckernels.core import klein_solve1
+from SymbolicDSGE._ckernels.occbin import (
+    occbin_forward,
+    occbin_recursion,
+    occbin_solve,
+    occbin_solve_arena_size,
+    regime_pencil,
+)
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from SymbolicDSGE.core.config import Constraint
+
+t = sp.Symbol("t", integer=True)
+
+LOW = 0b1
+
+#: TFP level the regime switches on, and a hit that carries the path past it.
+THRESHOLD = -0.005
+SHOCK = -0.01
+
+#: Long enough that the spell ends well inside it, and a start that must grow.
+HORIZON = 30
+SHORT = 8
+
+# A binding run, a relapse, and a relaxed tail.
+MIXED = np.array([0, 1, 1, 1, 0, 1, 1, 0, 0, 0], dtype=np.int8)
+
+
+@pytest.fixture(scope="module")
+def compiled(rbc_second_order_test_model_path):
+    """Levels RBC where TFP below a threshold shuts investment off."""
+    model, kalman = ModelParser(rbc_second_order_test_model_path).get_all()
+    conf = copy.deepcopy(model)
+    _, k, z = conf.variables.variables
+    delta = sp.Symbol("delta")
+
+    conf.equations.constraint = {
+        "low": Constraint(bind=z(t) < THRESHOLD, relax=z(t) >= THRESHOLD)
+    }
+    conf.equations.regime = {
+        frozenset({"low"}): {"euler": sp.Eq(k(t + 1), (1 - delta) * k(t))}
+    }
+    return DSGESolver(conf, kalman).compile()
+
+
+@pytest.fixture(scope="module")
+def par(compiled):
+    calib = compiled.config.calibration.parameters
+    return np.array([float(calib[p]) for p in compiled.calib_params])
+
+
+@pytest.fixture(scope="module")
+def cf(compiled):
+    return compiled.construct_constraint_func()
+
+
+@pytest.fixture(scope="module")
+def solved(compiled, par):
+    """(ss, a_ref, b_ref, f_ref, p_ref) for the reference regime."""
+    seed = DSGESolver._resolve_ss_seed(None, compiled)
+    ss, a_ref, b_ref, f_ref, p_ref, *_ = klein_solve1(
+        compiled.construct_objective_cfunc().address,
+        seed,
+        par,
+        compiled.n_state,
+        compiled.n_exog,
+    )
+    return ss, a_ref, b_ref, f_ref, p_ref
+
+
+@pytest.fixture(scope="module")
+def table(compiled, par, solved):
+    """(a, b, c) stacked by bitmask: slot 0 the reference, slot 1 the regime."""
+    ss, a_ref, b_ref, _, _ = solved
+    func = compiled.construct_regime_pencil_func()
+    a_low, b_low, c_low = regime_pencil(
+        func.address(LOW), func.rows[LOW], ss, par, a_ref, b_ref
+    )
+    a = np.stack([a_ref, a_low])
+    b = np.stack([b_ref, b_low])
+    c = np.stack([np.zeros_like(c_low), c_low])
+    return a, b, c
+
+
+@pytest.fixture(scope="module")
+def z_pos(compiled):
+    """Where TFP sits in the current-variable vector the constraint reads."""
+    return compiled.layout.idx["z"]
+
+
+def _shocks(n_state, n_period, size=SHOCK):
+    """``(n_period, n_state)`` carrying one hit, in the leading shock state."""
+    out = np.zeros((n_period, n_state))
+    out[0, 0] = size
+    return out
+
+
+def _binding(out, solved, z_pos):
+    """The condition as the cfunc sees it: a level, not a deviation."""
+    ss = solved[0]
+    return (out[:, z_pos] + ss[z_pos] < THRESHOLD).astype(np.int8)
+
+
+def _solve(table, solved, par, cond_addr, n_constraint, inclusive, shocks, **kw):
+    a, b, c = table
+    ss, _, _, f_ref, _ = solved
+    return occbin_solve(
+        a,
+        b,
+        c,
+        f_ref,
+        ss,
+        par,
+        cond_addr,
+        n_constraint,
+        inclusive,
+        shocks,
+        np.zeros(f_ref.shape[1]),
+        **kw,
+    )
+
+
+def _run(table, solved, par, cf, shocks, **kw):
+    return _solve(
+        table, solved, par, cf.address, cf.n_constraint, cf.inclusive, shocks, **kw
+    )
+
+
+def test_the_path_pairs_each_state_with_its_own_dates_control(table, solved):
+    # Row t is [x_t; u_t]: the state half is what date t-1's block produced and
+    # the control half what date t's did, which is the pairing the latch reads.
+    a, b, c = table
+    _, _, _, f_ref, _ = solved
+    n_state = f_ref.shape[1]
+    rule = occbin_recursion(a, b, c, MIXED, f_ref)
+    x0 = np.arange(1.0, n_state + 1.0)
+
+    path = occbin_forward(rule, x0)
+
+    x = x0.copy()
+    for date in range(rule.shape[0]):
+        y = rule[date, :, :n_state] @ x + rule[date, :, n_state]
+        np.testing.assert_allclose(path[date, :n_state], x, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(
+            path[date, n_state:], y[n_state:], rtol=1e-9, atol=1e-11
+        )
+        x = y[:n_state]
+
+
+def test_an_all_relaxed_path_walks_the_reference_rule(table, solved):
+    a, b, c = table
+    _, _, _, f_ref, p_ref = solved
+    n_state = f_ref.shape[1]
+    rule = occbin_recursion(a, b, c, np.zeros(8, dtype=np.int8), f_ref)
+    x0 = np.arange(1.0, n_state + 1.0)
+
+    path = occbin_forward(rule, x0)
+
+    x = x0.copy()
+    for date in range(8):
+        np.testing.assert_allclose(path[date, :n_state], x, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(
+            path[date, n_state:], f_ref @ x, rtol=1e-9, atol=1e-11
+        )
+        x = p_ref @ x
+
+
+def test_forward_writes_out_in_place(table, solved):
+    a, b, c = table
+    _, _, _, f_ref, _ = solved
+    rule = occbin_recursion(a, b, c, MIXED, f_ref)
+    n_var = rule.shape[1]
+    buf = np.zeros((MIXED.size, n_var))
+
+    got = occbin_forward(rule, np.ones(f_ref.shape[1]), out=buf)
+
+    assert got is buf
+    assert np.abs(buf).max() > 0.0
+
+
+def test_forward_rejects_an_initial_state_of_the_wrong_width(table, solved):
+    a, b, c = table
+    _, _, _, f_ref, _ = solved
+    rule = occbin_recursion(a, b, c, MIXED, f_ref)
+
+    with pytest.raises(ValueError, match="expected"):
+        occbin_forward(rule, np.ones(f_ref.shape[1] + 1))
+
+
+def test_an_empty_rule_stack_is_a_no_op(table, solved):
+    # The seed writes into row 0 before the date loop runs, so a stack with no
+    # dates has to be turned away rather than seeded.
+    _, _, _, f_ref, _ = solved
+    n_state = f_ref.shape[1]
+    n_var = n_state + f_ref.shape[0]
+
+    path = occbin_forward(np.empty((0, n_var, n_state + 1)), np.ones(n_state))
+
+    assert path.shape == (0, n_var)
+
+
+def test_the_steady_state_is_a_fixed_point(table, solved, par, cf):
+    # Nothing moves, so the constraint is read at the steady state, where the
+    # distance is exactly zero and a strict condition does not fire.
+    n_state = solved[3].shape[1]
+
+    out, regimes, diag = _run(table, solved, par, cf, np.zeros((1, n_state)), T0=SHORT)
+
+    np.testing.assert_array_equal(out, np.zeros_like(out))
+    np.testing.assert_array_equal(regimes, np.zeros_like(regimes))
+    # One pass to read the path, none to correct it.
+    np.testing.assert_array_equal(diag["iters"], [1])
+    np.testing.assert_array_equal(diag["max_err"], [0.0])
+    np.testing.assert_array_equal(diag["T_used"], [SHORT])
+
+
+def test_the_mask_is_the_condition_read_off_its_own_path(table, solved, par, cf, z_pos):
+    # The accepted guess is a fixed point of the latch, so date by date it has
+    # to agree with the condition evaluated on the path it produced.
+    n_state = solved[3].shape[1]
+
+    out, regimes, diag = _run(
+        table,
+        solved,
+        par,
+        cf,
+        _shocks(n_state, 1),
+        T0=HORIZON,
+        n_periods=HORIZON,
+    )
+
+    binding = _binding(out, solved, z_pos)
+    # The spell has to start and end inside the horizon for this to say much.
+    assert 3 < binding.sum() < HORIZON
+    np.testing.assert_array_equal(regimes[0], binding)
+    np.testing.assert_array_equal(diag["T_used"], [HORIZON])
+    # TFP is exogenous to the regime, so the first latch already lands the
+    # answer and the second only confirms it.
+    np.testing.assert_array_equal(diag["iters"], [2])
+
+
+def test_the_path_is_the_forward_pass_of_the_accepted_guess(table, solved, par, cf):
+    a, b, c = table
+    _, _, _, f_ref, _ = solved
+    n_state = f_ref.shape[1]
+
+    out, regimes, diag = _run(
+        table,
+        solved,
+        par,
+        cf,
+        _shocks(n_state, 1),
+        T0=HORIZON,
+        n_periods=HORIZON,
+    )
+
+    used = int(diag["T_used"][0])
+    rule = occbin_recursion(a, b, c, regimes[0][:used], f_ref)
+    x0 = np.zeros(n_state)
+    x0[0] = SHOCK
+
+    # The same two kernels on the same inputs, so this is exact up to the LU.
+    np.testing.assert_allclose(out, occbin_forward(rule, x0), rtol=1e-13, atol=1e-13)
+
+
+def test_a_period_without_a_shock_shifts_instead_of_re_solving(table, solved, par, cf):
+    # Dynare's shockless branch. The previous guess and the path it implies
+    # already describe this period, so shifting must reproduce them exactly.
+    n_state = solved[3].shape[1]
+    periods = 5
+
+    many_out, many_reg, many_diag = _run(
+        table,
+        solved,
+        par,
+        cf,
+        _shocks(n_state, periods),
+        T0=HORIZON,
+        n_periods=periods,
+    )
+    one_out, one_reg, one_diag = _run(
+        table,
+        solved,
+        par,
+        cf,
+        _shocks(n_state, 1),
+        T0=HORIZON,
+        n_periods=periods,
+    )
+
+    # memmove only: no arithmetic stands between these two.
+    np.testing.assert_array_equal(many_out, one_out)
+    np.testing.assert_array_equal(
+        many_diag["iters"], [one_diag["iters"][0], 0, 0, 0, 0]
+    )
+    for s in range(periods):
+        np.testing.assert_array_equal(many_reg[s][: HORIZON - s], one_reg[0][s:])
+        np.testing.assert_array_equal(many_reg[s][HORIZON - s :], 0)
+
+
+def test_a_short_horizon_grows_into_the_same_answer(table, solved, par, cf, z_pos):
+    n_state = solved[3].shape[1]
+    shocks = _shocks(n_state, 1)
+
+    long_out, _, _ = _run(table, solved, par, cf, shocks, T0=HORIZON, n_periods=HORIZON)
+    short_out, _, short_diag = _run(
+        table, solved, par, cf, shocks, T0=SHORT, T_cap=HORIZON, n_periods=SHORT + 1
+    )
+
+    # Growth stops the first date the guess relaxes, and the spell runs from
+    # date 0, so the settled horizon is one past its length.
+    spell = int(_binding(long_out, solved, z_pos).sum())
+    assert SHORT < spell + 1 < HORIZON
+    np.testing.assert_array_equal(short_diag["T_used"], [spell + 1])
+    # A relaxed tail is the reference rule's own fixed point, so where the two
+    # horizons close does not reach the dates either of them reports.
+    np.testing.assert_allclose(
+        short_out, long_out[: short_out.shape[0]], rtol=1e-8, atol=1e-10
+    )
+
+
+_COND_SIG = types.void(
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+    types.CPointer(types.float64),
+)
+
+
+@cfunc(_COND_SIG)
+def _always_fires(cur, par, err):
+    """Every condition holds, so every date flips on every pass."""
+    e = carray(err, (2,))
+    e[0] = 1.0
+    e[1] = 1.0
+
+
+def test_a_guess_that_never_settles_reports_the_iteration_cap(table, solved, par):
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(RuntimeError, match="did not converge in 3 iterations"):
+        _solve(
+            table,
+            solved,
+            par,
+            _always_fires.address,
+            1,
+            0,
+            _shocks(n_state, 1),
+            T0=SHORT,
+            max_iter=3,
+        )
+
+
+def test_an_incomplete_pencil_stack_is_rejected(table, solved, par, cf):
+    # The latch emits every mask over its constraints and the kernel indexes the
+    # table with it, so a missing slot would be read past the end.
+    a, b, c = table
+    n_state = solved[3].shape[1]
+    reference_only = (a[:1], b[:1], c[:1])
+
+    with pytest.raises(ValueError, match=re.escape("cover every mask over 1")):
+        _run(reference_only, solved, par, cf, _shocks(n_state, 1), T0=SHORT)
+
+
+def test_a_horizon_of_one_is_rejected(table, solved, par, cf):
+    # The shift reads the date before the last to extend the path.
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(ValueError, match="expected at least 2"):
+        _run(table, solved, par, cf, _shocks(n_state, 1), T0=1)
+
+
+def test_a_tail_longer_than_the_path_is_rejected(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(ValueError, match="at most S"):
+        _run(
+            table,
+            solved,
+            par,
+            cf,
+            _shocks(n_state, 1),
+            T0=SHORT,
+            n_periods=SHORT + 2,
+        )
+
+
+def test_shocks_of_the_wrong_width_are_rejected(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(ValueError, match="to match f_ref"):
+        _run(table, solved, par, cf, np.zeros((1, n_state + 1)), T0=SHORT)
+
+
+def test_a_truncated_algorithm_accepts_the_guess_it_ran_out_on(table, solved, par):
+    # Dynare's algo_truncation. A max_iter at or below it means the caller
+    # asked for a truncated solve, so the last guess stands instead of raising.
+    n_state = solved[3].shape[1]
+
+    out, regimes, diag = _solve(
+        table,
+        solved,
+        par,
+        _always_fires.address,
+        1,
+        0,
+        _shocks(n_state, 1),
+        T0=SHORT,
+        max_iter=1,
+        algo_truncation=1,
+    )
+
+    # One pass, and the guess it entered on is the relaxed one it started from.
+    np.testing.assert_array_equal(diag["iters"], [1])
+    np.testing.assert_array_equal(diag["T_used"], [SHORT])
+    np.testing.assert_array_equal(regimes, np.zeros_like(regimes))
+    np.testing.assert_array_equal(diag["periodic"], [0])
+    assert np.abs(out).max() > 0.0
+
+
+def test_a_max_iter_above_the_truncation_still_raises(table, solved, par):
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(RuntimeError, match="did not converge in 1 iterations"):
+        _solve(
+            table,
+            solved,
+            par,
+            _always_fires.address,
+            1,
+            0,
+            _shocks(n_state, 1),
+            T0=SHORT,
+            max_iter=1,
+            algo_truncation=0,
+        )
+
+
+def test_seeding_the_answer_settles_in_one_pass(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+    shocks = _shocks(n_state, 1)
+    kw = {"T0": HORIZON, "n_periods": HORIZON}
+
+    out, regimes, diag = _run(table, solved, par, cf, shocks, **kw)
+    seeded_out, seeded_reg, seeded_diag = _run(
+        table, solved, par, cf, shocks, init_regime=regimes[0], **kw
+    )
+
+    np.testing.assert_array_equal(seeded_out, out)
+    np.testing.assert_array_equal(seeded_reg, regimes)
+    # The latch reads the seed back unchanged, so there is nothing to correct.
+    np.testing.assert_array_equal(diag["iters"], [2])
+    np.testing.assert_array_equal(seeded_diag["iters"], [1])
+
+
+def test_a_reset_regime_throws_the_seed_away(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+    shocks = _shocks(n_state, 1)
+    kw = {"T0": HORIZON, "n_periods": HORIZON}
+    _, regimes, _ = _run(table, solved, par, cf, shocks, **kw)
+
+    _, reset_reg, reset_diag = _run(
+        table, solved, par, cf, shocks, init_regime=regimes[0], reset_regime=True, **kw
+    )
+
+    np.testing.assert_array_equal(reset_reg, regimes)
+    # Back to reading the answer off the relaxed guess and confirming it.
+    np.testing.assert_array_equal(reset_diag["iters"], [2])
+
+
+def test_curb_retrench_gives_up_one_date_per_pass(table, solved, par, cf):
+    # Seeded with every date binding, the latch wants to relax the whole tail
+    # at once. Damping concedes the last date only, and lands the same answer.
+    n_state = solved[3].shape[1]
+    shocks = _shocks(n_state, 1)
+    kw = {"T0": HORIZON, "n_periods": HORIZON}
+    seed = np.ones(HORIZON, dtype=np.int8)
+
+    plain_out, plain_reg, plain_diag = _run(
+        table, solved, par, cf, shocks, init_regime=seed, **kw
+    )
+    curbed_out, curbed_reg, curbed_diag = _run(
+        table, solved, par, cf, shocks, init_regime=seed, curb_retrench=True, **kw
+    )
+
+    np.testing.assert_allclose(curbed_out, plain_out, rtol=1e-13, atol=1e-13)
+    np.testing.assert_array_equal(curbed_reg, plain_reg)
+    assert curbed_diag["iters"][0] > plain_diag["iters"][0]
+
+
+def test_an_initial_guess_of_the_wrong_length_is_rejected(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+
+    with pytest.raises(ValueError, match="expected T0"):
+        _run(
+            table,
+            solved,
+            par,
+            cf,
+            _shocks(n_state, 1),
+            T0=SHORT,
+            init_regime=np.zeros(SHORT + 1, dtype=np.int8),
+        )
+
+
+def test_an_initial_guess_outside_the_table_is_rejected(table, solved, par, cf):
+    n_state = solved[3].shape[1]
+    seed = np.zeros(SHORT, dtype=np.int8)
+    seed[0] = 2
+
+    with pytest.raises(ValueError, match=re.escape("outside 0..1")):
+        _run(table, solved, par, cf, _shocks(n_state, 1), T0=SHORT, init_regime=seed)
+
+
+#: A shock deep enough that the spell the flip condition wants is unambiguous,
+#: on a horizon short enough to read whole and capped so no guess can grow into
+#: a period that stops looking for cycles.
+CYCLE_SHOCK = -0.1
+CYCLE_HORIZON = 12
+
+#: Where ``_flip`` reads capital and TFP. A cfunc cannot close over a fixture,
+#: so the positions are baked in and ``flip_par`` checks the layout agrees.
+_K_POS = 4
+_Z_POS = 5
+
+
+@cfunc(_COND_SIG)
+def _flip(cur, par, err):
+    """Bind while TFP is low, relax once the regime has driven capital high.
+
+    Contrarian on purpose: the regime shuts investment off, which sends capital
+    up, which is what the relax condition reads. A date that binds then wants to
+    relax and a date that relaxes wants to bind, so the guess swings instead of
+    settling. The bind side reads TFP, which no regime touches, so the swing is
+    over a fixed set of leading dates and its width is the threshold's to pick.
+    """
+    lev = carray(cur, (_Z_POS + 1,))
+    p = carray(par, (2,))
+    e = carray(err, (2,))
+    e[0] = p[0] - lev[_Z_POS]
+    e[1] = lev[_K_POS] - p[1]
+
+
+@pytest.fixture(scope="module")
+def flip_par(compiled, table, solved):
+    """``m -> (bind, relax)``: the levels that make ``m`` leading dates bind."""
+    a, b, c = table
+    ss, _, _, f_ref, _ = solved
+    assert (compiled.layout.idx["k"], compiled.layout.idx["z"]) == (_K_POS, _Z_POS)
+
+    rule = occbin_recursion(a, b, c, np.zeros(CYCLE_HORIZON, dtype=np.int8), f_ref)
+    z = occbin_forward(rule, _cycle_state(f_ref))[:, _Z_POS] + ss[_Z_POS]
+
+    def par(m):
+        # Between date m - 1 and date m of a TFP path that only recovers, so
+        # exactly the first m dates read as low.
+        return np.array([0.5 * (z[m - 1] + z[m]), ss[_K_POS]])
+
+    return par
+
+
+def _cycle_state(f_ref):
+    """The state date 0 of the swinging period enters on."""
+    x0 = np.zeros(f_ref.shape[1])
+    x0[0] = CYCLE_SHOCK
+    return x0
+
+
+def _flip_run(table, solved, par, **kw):
+    return _solve(
+        table,
+        solved,
+        par,
+        _flip.address,
+        1,
+        0,
+        _shocks(solved[3].shape[1], 1, CYCLE_SHOCK),
+        T0=CYCLE_HORIZON,
+        T_cap=CYCLE_HORIZON,
+        **kw,
+    )
+
+
+def test_a_guess_that_swings_by_one_date_is_a_two_cycle(table, solved, flip_par):
+    # The relaxed guess wants date 0 binding, and binding it sends capital up,
+    # which is the relax condition, so the pass after hands the relaxed guess
+    # straight back.
+    with pytest.raises(RuntimeError, match="loops between two regimes"):
+        _flip_run(table, solved, flip_par(1))
+
+
+def test_a_guess_that_swings_by_more_is_a_loop_over_guesses(table, solved, flip_par):
+    # The same swing over three dates. A repeat counts as periodic only where
+    # the guess barely moved, and three dates is past the default of one.
+    with pytest.raises(RuntimeError, match="loops over guess regimes"):
+        _flip_run(table, solved, flip_par(3))
+
+
+def test_the_periodic_threshold_counts_dates(table, solved, flip_par):
+    # Not a distance the error is weighed against: raising it to the width of
+    # the swing is what turns that same loop back into a two-cycle.
+    with pytest.raises(RuntimeError, match="loops between two regimes"):
+        _flip_run(table, solved, flip_par(3), periodic_threshold=3)
+
+
+def test_periodic_solution_accepts_the_half_of_the_cycle_that_settles(
+    table, solved, flip_par
+):
+    # Of the two guesses that repeat, the one weighed is the pass that wanted no
+    # new binding date, which here is the one with date 0 already binding.
+    a, b, c = table
+    f_ref = solved[3]
+
+    out, regimes, diag = _flip_run(
+        table,
+        solved,
+        flip_par(1),
+        n_periods=CYCLE_HORIZON,
+        periodic_solution=True,
+    )
+
+    accepted = np.zeros(CYCLE_HORIZON, dtype=np.int8)
+    accepted[0] = 1
+    np.testing.assert_array_equal(regimes[0], accepted)
+    # Flagged with the code it would otherwise have raised: 1 is Dynare's 310.
+    np.testing.assert_array_equal(diag["periodic"], [1])
+    np.testing.assert_array_equal(diag["iters"], [2])
+
+    rule = occbin_recursion(a, b, c, accepted, f_ref)
+    np.testing.assert_allclose(
+        out, occbin_forward(rule, _cycle_state(f_ref)), rtol=1e-13, atol=1e-13
+    )
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_periodic_solution_does_not_rescue_a_wider_loop(
+    table, solved, flip_par, strict
+):
+    # Only a two-cycle is weighed by default. Dropping strictness weighs a loop
+    # as well, but only one where some pass moved the guess no further than the
+    # threshold, and none of this one's did.
+    with pytest.raises(RuntimeError, match="loops over guess regimes"):
+        _flip_run(
+            table,
+            solved,
+            flip_par(3),
+            periodic_solution=True,
+            periodic_strict=strict,
+        )
+
+
+def test_a_reset_drops_a_grown_horizon_only_with_its_companion(table, solved, par, cf):
+    # The first shock grows the horizon to hold its spell. The second clears the
+    # spell outright, so the relaxed guess is the answer: a reset lands it in one
+    # pass, and only the companion flag hands back the dates the guess grew.
+    n_state = solved[3].shape[1]
+    shocks = np.zeros((2, n_state))
+    shocks[0, 0] = SHOCK
+    shocks[1, 0] = 0.005
+    kw = {"T0": SHORT, "T_cap": HORIZON, "n_periods": 2}
+
+    plain_out, _, plain = _run(table, solved, par, cf, shocks, **kw)
+    reset_out, reset_reg, reset = _run(
+        table, solved, par, cf, shocks, reset_regime=True, **kw
+    )
+    both_out, _, both = _run(
+        table,
+        solved,
+        par,
+        cf,
+        shocks,
+        reset_regime=True,
+        reset_check_ahead=True,
+        **kw,
+    )
+
+    assert SHORT < plain["T_used"][0] < HORIZON
+    # A relaxed tail is the reference rule's own fixed point, so the horizon the
+    # period is solved on cannot reach the dates it reports.
+    np.testing.assert_array_equal(reset_out, plain_out)
+    np.testing.assert_array_equal(both_out, plain_out)
+
+    np.testing.assert_array_equal(reset["T_used"], plain["T_used"])
+    np.testing.assert_array_equal(both["T_used"], [plain["T_used"][0], SHORT])
+    assert plain["iters"][1] > reset["iters"][1] == both["iters"][1] == 1
+    np.testing.assert_array_equal(reset_reg[1][SHORT:], 0)
+
+
+def test_the_arena_formula_is_pinned():
+    # The kernel carves nine regions out of two buffers; nothing else states
+    # how big they are.
+    n_var, n_state, n_ctrl, T_cap, max_iter = 7, 3, 4, 11, 5
+    n_rhs = n_state + 1
+    recursion = n_var * n_var + n_var * n_rhs + n_ctrl * n_rhs
+    masks = (max_iter + 3) * T_cap + max_iter
+
+    n_float, n_int = occbin_solve_arena_size(n_var, n_state, n_ctrl, T_cap, max_iter)
+
+    assert n_float == n_state + T_cap * n_var + max_iter + recursion
+    assert n_int == n_var + 2 * max_iter + (masks + 7) // 8

--- a/tests/core/test_constraint_compile.py
+++ b/tests/core/test_constraint_compile.py
@@ -77,7 +77,9 @@ def test_constraint_func_layout(compiled_obc):
     cf = compiled_obc.construct_constraint_func()
 
     assert cf.names == ("lo", "hi")
-    assert (cf.n_constraint, cf.n_flag) == (2, 4)
+    assert (cf.n_constraint, cf.n_cond) == (2, 4)
+    # lo relaxes on >= and hi relaxes on <=; the two bind conditions are strict.
+    assert cf.inclusive == 0b1010
     assert (cf.n_var, cf.n_par) == (
         len(compiled_obc.var_names),
         len(compiled_obc.calib_params),
@@ -97,21 +99,30 @@ def test_constraint_func_is_cached(compiled_obc):
 
 
 def _call(cf, cur, par):
+    """The signed distances the cfunc writes, one per condition slot."""
     fn = ctypes.CFUNCTYPE(
         None,
         ctypes.POINTER(ctypes.c_double),
         ctypes.POINTER(ctypes.c_double),
-        ctypes.POINTER(ctypes.c_int8),
+        ctypes.POINTER(ctypes.c_double),
     )(cf.address)
     cur = np.ascontiguousarray(cur, dtype=np.float64)
     par = np.ascontiguousarray(par, dtype=np.float64)
-    out = np.zeros(cf.n_flag, dtype=np.int8)
+    out = np.zeros(cf.n_cond, dtype=np.float64)
     fn(
         cur.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
         par.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        out.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+        out.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
     )
     return out
+
+
+def _flags(cf, cur, par):
+    """The 0/1 conditions the native latch reads off those distances."""
+    return [
+        int(e > 0.0 or (e == 0.0 and (cf.inclusive >> k) & 1))
+        for k, e in enumerate(_call(cf, cur, par))
+    ]
 
 
 @pytest.mark.parametrize(
@@ -131,10 +142,7 @@ def test_flags_match_the_written_conditions(compiled_obc, g, z, beta, expected):
     par = np.zeros(cf.n_par)
     par[0] = beta
 
-    out = _call(cf, cur, par)
-
-    assert out.dtype == np.int8
-    assert out.tolist() == expected
+    assert _flags(cf, cur, par) == expected
 
 
 def test_flags_match_a_lambdify_oracle(compiled_obc):
@@ -153,7 +161,62 @@ def test_flags_match_a_lambdify_oracle(compiled_obc):
             par[0] = cur[1]
 
         want = [int(bool(f(cur, par))) for f in oracle]
-        assert _call(cf, cur, par).tolist() == want
+        assert _flags(cf, cur, par) == want
+
+
+def test_distances_are_signed_and_fold_over_a_connective(compiled_obc):
+    cf = compiled_obc.construct_constraint_func()
+    cur = np.zeros(cf.n_var)
+    cur[compiled_obc.idx["g"]], cur[compiled_obc.idx["z"]] = 0.75, 2.0
+    par = np.zeros(cf.n_par)
+    par[0] = 0.5
+
+    err = _call(cf, cur, par)
+
+    # lo is g < 0 against g >= 0, so its two slots are exact opposites.
+    assert (err[0], err[1]) == (-0.75, 0.75)
+    # hi binds on z > beta (1.5 clear) and g < 1 (0.25 clear) at once, so the
+    # fold reports the branch nearest to failing.
+    assert (err[2], err[3]) == (0.25, -1.5)
+
+
+def test_a_zero_distance_is_decided_by_inclusive_alone(compiled_obc):
+    # At the origin lo's strict bind and its inclusive relax are both exactly
+    # on the boundary. This is where a simulation starts, not a corner case.
+    cf = compiled_obc.construct_constraint_func()
+    cur, par = np.zeros(cf.n_var), np.zeros(cf.n_par)
+
+    err = _call(cf, cur, par)
+
+    assert (err[0], err[1]) == (0.0, 0.0)
+    assert _flags(cf, cur, par)[:2] == [0, 1]
+
+
+def test_a_connective_mixing_strict_and_inclusive_is_rejected(parsed_post82):
+    # The fold reports one branch's distance and the caller has one bit to read
+    # zero with, so the branches may not disagree about their boundary.
+    model, _ = parsed_post82
+    g, z = (v for v in model.variables.variables[:2])
+    beta = model.parameters[0]
+    compiled = _with_constraints(
+        parsed_post82,
+        {"lo": Constraint(bind=sp.And(z(t) >= beta, g(t) < 1), relax=g(t) > 1)},
+    ).compile()
+
+    with pytest.raises(NotImplementedError, match="mixes strict and inclusive"):
+        compiled.construct_constraint_func()
+
+
+def test_an_equality_condition_has_no_distance(parsed_post82):
+    # A Relational the parser accepts and the distance encoding cannot express.
+    model, _ = parsed_post82
+    g = model.variables.variables[0]
+    compiled = _with_constraints(
+        parsed_post82, {"lo": Constraint(bind=sp.Eq(g(t), 0), relax=g(t) > 0)}
+    ).compile()
+
+    with pytest.raises(NotImplementedError, match="Equality"):
+        compiled.construct_constraint_func()
 
 
 def _params(compiled):

--- a/tests/core/test_occbin_parity.py
+++ b/tests/core/test_occbin_parity.py
@@ -1,0 +1,172 @@
+"""Dynare parity for the two-constraint OccBin RBC: the whole simulated path.
+
+``tests/fixtures/models/rbc_occbin.yaml`` is our twin of Dynare's own
+``rbc_occbin.mod``, and :mod:`_oracles.dynare_rbc_occbin` carries what Dynare 7.1
+produced from it: 169 periods of unforeseen shocks, the piecewise path, the
+unconstrained path, and the realized regime at every date.
+
+This is the only place the OccBin driver meets an answer it did not compute
+itself. The kernel tests check that the accepted guess is a fixed point of the
+latch and that the path is the forward pass of that guess, which any
+self-consistent solver satisfies; only a golden says the fixed point is the same
+one Dynare lands on. It reaches what synthetic fixtures cannot: two constraints
+interacting, a mask that changes 12 times over the run, and shock periods that
+inherit a guess from the period before rather than starting relaxed.
+
+The horizon is Dynare's ``simul_check_ahead_periods=200``, plus the date a
+binding guess appends, so 201. Dynare leaves ``max_check_ahead_periods`` at
+infinity, so its guess may grow; ours is capped, and the run is checked to never
+have needed the room.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from SymbolicDSGE._ckernels.core import klein_solve1
+from SymbolicDSGE._ckernels.occbin import occbin_solve, regime_pencil
+from SymbolicDSGE.core import DSGESolver, ModelParser
+from _oracles import dynare_rbc_occbin as golden
+
+_MODEL = "tests/fixtures/models/rbc_occbin.yaml"
+
+#: Our name for each of the oracle's ``COLUMNS``, in that order.
+_OUR_COLUMNS = ("a", "c", "invest", "k", "lam", "log_k", "log_invest", "log_c")
+
+#: ``simul_check_ahead_periods`` on the golden run, and the appended date.
+_T0 = 201
+
+#: Room for the growth Dynare allows and this run turns out not to need.
+_T_CAP = _T0 + 50
+
+
+@pytest.fixture(scope="module")
+def compiled():
+    model, kalman = ModelParser(_MODEL).get_all()
+    return DSGESolver(model, kalman).compile()
+
+
+@pytest.fixture(scope="module")
+def par(compiled):
+    calib = compiled.config.calibration.parameters
+    return np.array([float(calib[p]) for p in compiled.calib_params])
+
+
+@pytest.fixture(scope="module")
+def solved(compiled, par):
+    """(ss, a_ref, b_ref, f_ref, p_ref) for the all-relaxed reference regime."""
+    seed = DSGESolver._resolve_ss_seed(None, compiled)
+    ss, a_ref, b_ref, f_ref, p_ref, *_ = klein_solve1(
+        compiled.construct_objective_cfunc().address,
+        seed,
+        par,
+        compiled.n_state,
+        compiled.n_exog,
+    )
+    return ss, a_ref, b_ref, f_ref, p_ref
+
+
+@pytest.fixture(scope="module")
+def table(compiled, par, solved):
+    """(a, b, c) stacked by bitmask, IRR at bit 0 and INEG at bit 1."""
+    ss, a_ref, b_ref, _, _ = solved
+    func = compiled.construct_regime_pencil_func()
+    a = [a_ref]
+    b = [b_ref]
+    c = [np.zeros(a_ref.shape[0])]
+    for mask in (1, 2, 3):
+        a_m, b_m, c_m = regime_pencil(
+            func.address(mask), func.rows[mask], ss, par, a_ref, b_ref
+        )
+        a.append(a_m)
+        b.append(b_m)
+        c.append(c_m)
+    return np.stack(a), np.stack(b), np.stack(c)
+
+
+@pytest.fixture(scope="module")
+def shocks(solved):
+    """Dynare's surprise sequence, in the slot the TFP innovation enters."""
+    out = np.zeros((golden.T, solved[3].shape[1]))
+    out[:, 0] = np.ravel(golden.SHOCKS)
+    return out
+
+
+@pytest.fixture(scope="module")
+def piecewise(compiled, table, solved, par, shocks):
+    """(levels, regimes, diag) from the native driver over the golden shocks."""
+    a, b, c = table
+    ss, _, _, f_ref, _ = solved
+    cf = compiled.construct_constraint_func()
+    out, regimes, diag = occbin_solve(
+        a,
+        b,
+        c,
+        f_ref,
+        ss,
+        par,
+        cf.address,
+        cf.n_constraint,
+        cf.inclusive,
+        shocks,
+        np.zeros(f_ref.shape[1]),
+        T0=_T0,
+        T_cap=_T_CAP,
+    )
+    return out + ss, regimes, diag
+
+
+def _columns(levels, compiled):
+    """Our path restricted to the oracle's columns, in the oracle's order."""
+    idx = compiled.layout.idx
+    return np.stack([levels[:, idx[name]] for name in _OUR_COLUMNS], axis=1)
+
+
+def test_the_reference_steady_state_is_dynares(compiled, solved):
+    ss = solved[0]
+    idx = compiled.layout.idx
+    ours = np.array([ss[idx[name]] for name in _OUR_COLUMNS])
+
+    np.testing.assert_allclose(ours, golden.YS, rtol=1e-14, atol=1e-14)
+
+
+def test_the_unconstrained_path_is_dynares_linear_simulation(compiled, solved, shocks):
+    # oo_.occbin.simul.linear: the same surprise sequence with the constraints
+    # ignored, so it settles the reference pencil before any regime logic runs.
+    ss, _, _, f_ref, p_ref = solved
+    x = np.zeros(f_ref.shape[1])
+    rows = []
+    for t in range(golden.LINEAR_HEAD.shape[0]):
+        x = x + shocks[t]
+        rows.append(np.concatenate([x, f_ref @ x]))
+        x = p_ref @ x
+
+    ours = _columns(np.array(rows) + ss, compiled)
+
+    np.testing.assert_allclose(ours, golden.LINEAR_HEAD, rtol=1e-12, atol=1e-12)
+
+
+def test_the_piecewise_path_is_dynares(compiled, piecewise):
+    levels, _, _ = piecewise
+
+    ours = _columns(levels, compiled)
+
+    np.testing.assert_allclose(ours, golden.PIECEWISE, rtol=1e-11, atol=1e-11)
+
+
+def test_the_realized_regime_is_dynares(piecewise):
+    # Date 0 of each period's accepted guess is what that period realizes; the
+    # rest is the expectation the guess was solved under.
+    _, regimes, _ = piecewise
+
+    np.testing.assert_array_equal(regimes[:, 0], golden.REALIZED_MASK)
+
+
+def test_the_run_settles_well_inside_dynares_check_ahead(piecewise):
+    # Dynare would have grown the horizon past 200 rather than clip it, so a
+    # period that reached the cap would make the two runs incomparable.
+    _, _, diag = piecewise
+
+    np.testing.assert_array_equal(diag["T_used"], _T0)
+    assert 1 < diag["iters"].max() < 30


### PR DESCRIPTION
This pull request introduces a major refactor of how regime constraints are represented and evaluated in the native OccBin solver and its Python interface. The core change is that constraints are now evaluated as signed distances to their boundaries (using `float64`), rather than as binary flags (`int8`). This enables more precise and informative diagnostics and aligns the Python and native implementations. Several new native OccBin solver APIs are also exposed and documented in the Python interface.

The most important changes are:

### Constraint Representation and Evaluation

* Constraints are now evaluated as signed distances to their boundaries (positive where the condition holds), not as 0/1 flags. This is reflected throughout the codebase, including the constraint printers, compiled model interface, and native function signatures. The only remaining ambiguity—whether a distance of exactly zero counts as satisfied—is tracked by a new `inclusive` bitmask. ( [[1]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL1-R11), [[2]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL17-R57), [[3]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL85-R77), [[4]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL116-R103), [[5]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aR114-R126), [[6]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aR136-R180), [[7]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL168-R200), [[8]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fL69-R78), [[9]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fR87-R100), [[10]](diffhunk://#diff-02759a64e8c193a4489771c451de417d79cff2131ce7030132227133635eec8fR275-R281) )

* The constraint printer now emits code that computes distances, using `min`/`max` for logical connectives, and a new mechanism to determine which constraints are inclusive at zero. ( [[1]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aL17-R57), [[2]](diffhunk://#diff-bc9db85cf84f42065e6cd49b4830c6a6dcf96e4de4b31741f962ecc853803f2aR136-R180) )

### OccBin Native Solver API and Interface

* The native OccBin solver interface (`occbin.h`) is extended with new context and diagnostic structs, new functions for recursion, forward solution, and full solve, and new arena size queries. These are exposed in the Python interface and type stubs. ( [[1]](diffhunk://#diff-b22799833f42c125f94bc34f0b27735d3479dc4a82fa818fc1b271a5eb5198f5R5-R110), [[2]](diffhunk://#diff-e9c9730fdaa5b229334818a4f6fa7e9344442cab1fb822c252ea23d80ffe96b7L1-R25), [[3]](diffhunk://#diff-19e5a886ce33402730a9e8774aa493a7a4623d5b8d3091fdc8413b025f7564dbR49-R124) )

* The Python stub for `constraint_path` is updated to return the `inclusive` bitmask and the maximum error per path, reflecting the new regime evaluation semantics. ( [`SymbolicDSGE/_ckernels/occbin/_occbin.pyiR25-R33`](diffhunk://#diff-19e5a886ce33402730a9e8774aa493a7a4623d5b8d3091fdc8413b025f7564dbR25-R33) )

### Utility and Internal Improvements

* Added inline utility functions for checking if any element of a buffer is zero or nonzero, for use in native kernels. ([`SymbolicDSGE/_ckernels/_common/sdsge_common.hR49-R67`](diffhunk://#diff-f3f797a9a16b8ebf3c36a8fd8e97ef2db34fd1fe724dd8c3da1e3b7e80f3dc26R49-R67))

This refactor improves the expressiveness, correctness, and diagnostics of the OccBin constraint handling, and lays groundwork for more advanced solution features.

Partly closes #405 (native side implemented, no python representation)